### PR TITLE
fix(android): persist Mac device name from HELLO handshake

### DIFF
--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -410,6 +410,15 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         // advertising without risking the active L2CAP connection.
         advertiser?.restart()
 
+        // The HELLO/WELCOME handshake carries the remote device name. Persist
+        // it so the UI always shows the real hostname (e.g. "Christian's Mac")
+        // instead of null — during pairing, KEY_CONFIRM doesn't include a name
+        // so this is the first point where the Mac's name is available.
+        activeSession?.remoteName?.let {
+            saveConnectedDeviceName(it)
+            publishDirectShareShortcut(it)
+        }
+
         val name = loadConnectedDeviceName()
         sendConnectionBroadcast(true, name)
         DebugSmokeProbe.onConnectionChanged(this, true)


### PR DESCRIPTION
## Summary
- During ECDH pairing, the Mac's `KEY_CONFIRM` message doesn't carry a device name, so `onPairingComplete()` receives `remoteName=null` and the UI falls back to "Mac"
- The real hostname (e.g. "Christian's Mac") only arrives in the subsequent `HELLO` message, but `onSessionReady()` never persisted it
- Now `onSessionReady()` saves `activeSession.remoteName` to prefs and updates the Direct Share shortcut with the correct name

## Root cause
The ECDH handshake was added without updating the name propagation path. Android sends its name in `KEY_EXCHANGE`, but Mac only sends its name in `HELLO` (after pairing). The `onPairingComplete` → `saveConnectedDeviceName` path ran before `HELLO` arrived, storing null.

## Test plan
- [x] All 81 unit tests pass (macOS + Android)
- [x] Build succeeds for both platforms
- [ ] Re-pair devices and verify Mac's real hostname appears on Android
- [ ] Verify Direct Share shortcut shows correct name after pairing