### PR TITLE
chore(android): upgrade Gradle 9.4, AGP 9.1, Kotlin 2.3.10

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,7 +3,6 @@ import java.util.Properties
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.github.triplet.play")
 }
@@ -58,12 +57,12 @@ val playTrack = playValue("track", "PLAY_TRACK") ?: "internal"
 
 android {
     namespace = "org.cliprelay"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "org.cliprelay"
         minSdk = 31
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1  // Auto-incremented by Play plugin's resolutionStrategy
         versionName = file("../VERSION").readText().trim()
 
@@ -101,10 +100,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
-    id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
-    id("com.github.triplet.play") version "3.12.1" apply false
+    id("com.android.application") version "9.1.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.3.10" apply false
+    id("com.github.triplet.play") version "4.0.0" apply false
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/gradlew
+++ b/android/gradlew
@@ -203,7 +203,7 @@ fi
 
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='-Dfile.encoding=UTF-8 "-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -36,7 +36,7 @@ set APP_HOME=%DIRNAME%
 for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=-Dfile.encoding=UTF-8 "-Xmx64m" "-Xms64m"
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome


### PR DESCRIPTION
## Summary
- Gradle: 8.10.2 → 9.4.0
- Android Gradle Plugin: 8.7.3 → 9.1.0
- Kotlin (Compose compiler): 2.0.21 → 2.3.10
- gradle-play-publisher: 3.12.1 → 4.0.0
- compileSdk/targetSdk: 35 → 36

AGP 9 includes built-in Kotlin compilation, so `org.jetbrains.kotlin.android` is removed. The Compose compiler plugin is still required separately. The `kotlinOptions` block is removed as JVM target is inferred from `compileOptions`.

This eliminates the `java.lang.System::load` restricted method warning during builds.

## Test plan
- [x] All 81 unit tests pass (macOS + Android)
- [x] Build succeeds for both platforms
- [x] APK installs and launches on device