### PR TITLE
fix(android): crash on Android 16 during pairing (receiver export flag)

### DIFF
--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -13,6 +13,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
@@ -136,7 +137,12 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         DebugSmokeProbe.reset(this)
 
         startForeground(1001, buildNotification())
-        registerReceiver(bluetoothStateReceiver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
+        ContextCompat.registerReceiver(
+            this,
+            bluetoothStateReceiver,
+            IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
         ensureBleComponentsState()
 
         // Publish direct share shortcut if already paired


### PR DESCRIPTION
## Summary
- Fixes app crash on Android 16 devices with OEM skins (e.g. Realme GT6) when starting the pairing flow
- `ClipRelayService.registerReceiver()` was missing the `RECEIVER_NOT_EXPORTED` flag required by Android 14+ — stock AOSP was lenient for protected system broadcasts, but Realme UI enforces it strictly
- `MainActivity` already used `ContextCompat.registerReceiver` correctly; this aligns `ClipRelayService` to the same pattern

## Test plan
- [x] All unit tests pass (`scripts/test-all.sh`)
- [x] Debug APK builds and installs successfully
- [ ] Verify pairing flow works on stock Android 16 (Pixel)
- [ ] Verify pairing flow no longer crashes on Realme GT6 / Android 16