### PR TITLE
fix(android): add R8 keep rules for GMS code scanner

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,5 @@
+# Google ML Kit / GMS Code Scanner
+# R8 in AGP 9.x strips internal classes that the GMS barcode scanner
+# resolves via reflection, causing a NullPointerException in zzny.<init>.
+-keep class com.google.mlkit.** { *; }
+-keep class com.google.android.gms.internal.mlkit_code_scanner.** { *; }


### PR DESCRIPTION
## Summary
- Fixes QR scanner crash during pairing on release builds since AGP 9.1 upgrade
- AGP 9.1's R8 strips internal ML Kit classes that `GmsBarcodeScanning.getClient()` resolves via reflection, causing `NullPointerException` in `zzny.<init>`
- Adds ProGuard keep rules for `com.google.mlkit.**` and `com.google.android.gms.internal.mlkit_code_scanner.**`
- Verified: debug builds (no R8) work, release builds without rules crash, release builds with rules work

## Root cause
The AGP 8.7 → 9.1 upgrade (PR #7) shipped a newer R8 compiler that is more aggressive about stripping classes it considers unused. The GMS code scanner library uses reflection internally, and R8 removed classes it couldn't trace statically.

## Test plan
- [x] All unit tests pass
- [x] Reproduced crash on release build without fix
- [x] Verified release build with fix works (QR scanner opens, pairing succeeds)
- [x] Verified debug build unaffected