### PR TITLE
PoC: Rich media transfer via TCP sideband

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application
@@ -24,6 +25,11 @@
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
             </intent-filter>
         </activity>
 
@@ -56,6 +62,16 @@
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
         <service
             android:name=".service.ClipRelayService"

--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -2,7 +2,9 @@ package org.cliprelay.protocol
 
 // Manages a single L2CAP protocol session: handshake, clipboard offer/accept, and payload transfer.
 
+import android.util.Log
 import org.cliprelay.crypto.E2ECrypto
+import org.cliprelay.tcp.TcpRelay
 import org.json.JSONObject
 import java.io.InputStream
 import java.io.OutputStream
@@ -68,8 +70,8 @@ class Session(
     /** Ephemeral key pair, generated at handshake start and dropped after session key derivation. */
     private var ephemeralKeyPair: KeyPair? = null
 
-    /** Queue of outbound clipboard transfers (plaintext). */
-    private val outboundQueue = LinkedBlockingQueue<ByteArray>()
+    /** Queue of outbound clipboard transfers (plaintext + contentType). */
+    private val outboundQueue = LinkedBlockingQueue<Pair<ByteArray, String>>()
 
     /**
      * Queue of inbound messages, populated by the reader thread.
@@ -234,7 +236,7 @@ class Session(
                 // Check for queued outbound transfers (short poll)
                 val outbound = outboundQueue.poll(50, TimeUnit.MILLISECONDS)
                 if (outbound != null) {
-                    doSendClipboard(outbound)
+                    doSendClipboard(outbound.first, outbound.second)
                     continue
                 }
 
@@ -290,44 +292,88 @@ class Session(
      * The actual transfer happens in the listen loop.
      * Session encrypts the data internally using the session key.
      */
-    fun sendClipboard(plaintext: ByteArray) {
+    fun sendClipboard(plaintext: ByteArray, contentType: String = "text/plain") {
         if (closed.get()) return
-        outboundQueue.put(plaintext)
+        outboundQueue.put(Pair(plaintext, contentType))
     }
 
-    private fun doSendClipboard(plaintext: ByteArray) {
+    private fun doSendClipboard(plaintext: ByteArray, contentType: String) {
         // Hash is computed over plaintext (for dedup across sessions)
         val key = sessionKey ?: throw ProtocolException("No session key available")
         val hash = sha256Hex(plaintext)
         val encryptedBlob = E2ECrypto.seal(plaintext, key)
-        val offerJson = JSONObject().apply {
-            put("hash", hash)
-            put("size", encryptedBlob.size)
-            put("type", "text/plain")
-        }
-        val offer = Message(MessageType.OFFER, offerJson.toString().toByteArray())
-        MessageCodec.write(output, offer)
 
-        // Wait for ACCEPT or DONE
-        val response = readWithTimeout(transferTimeoutMs)
-        when (response.type) {
-            MessageType.ACCEPT -> {
-                // Send PAYLOAD
-                val payload = Message(MessageType.PAYLOAD, encryptedBlob)
-                MessageCodec.write(output, payload)
+        if (contentType == "text/plain") {
+            // Existing BLE-based text transfer
+            val offerJson = JSONObject().apply {
+                put("hash", hash)
+                put("size", encryptedBlob.size)
+                put("type", "text/plain")
+            }
+            val offer = Message(MessageType.OFFER, offerJson.toString().toByteArray())
+            MessageCodec.write(output, offer)
 
-                // Wait for DONE
-                val done = readWithTimeout(transferTimeoutMs)
-                if (done.type != MessageType.DONE) {
-                    throw ProtocolException("Expected DONE, got ${done.type}")
+            // Wait for ACCEPT or DONE
+            val response = readWithTimeout(transferTimeoutMs)
+            when (response.type) {
+                MessageType.ACCEPT -> {
+                    // Send PAYLOAD
+                    val payload = Message(MessageType.PAYLOAD, encryptedBlob)
+                    MessageCodec.write(output, payload)
+
+                    // Wait for DONE
+                    val done = readWithTimeout(transferTimeoutMs)
+                    if (done.type != MessageType.DONE) {
+                        throw ProtocolException("Expected DONE, got ${done.type}")
+                    }
+                    callback.onTransferComplete(hash)
                 }
-                callback.onTransferComplete(hash)
+                MessageType.DONE -> {
+                    // Receiver already had this hash — transfer complete (dedup)
+                    callback.onTransferComplete(hash)
+                }
+                else -> throw ProtocolException("Expected ACCEPT or DONE, got ${response.type}")
             }
-            MessageType.DONE -> {
-                // Receiver already had this hash — transfer complete (dedup)
-                callback.onTransferComplete(hash)
+        } else {
+            // Rich media transfer via TCP sideband
+            val tcpTimeoutMs = TCP_TRANSFER_TIMEOUT_MS
+            val localIp = TcpRelay.getLocalIpAddress()
+                ?: throw ProtocolException("Cannot determine local IP address for TCP transfer")
+            val tcpServer = TcpRelay.serve(tcpTimeoutMs)
+            try {
+                val offerJson = JSONObject().apply {
+                    put("hash", hash)
+                    put("size", encryptedBlob.size)
+                    put("type", contentType)
+                    put("tcp_port", tcpServer.port)
+                    put("tcp_host", localIp)
+                }
+                Log.d(TAG, "Sending rich media OFFER: type=$contentType, size=${encryptedBlob.size}, tcp=$localIp:${tcpServer.port}")
+                val offer = Message(MessageType.OFFER, offerJson.toString().toByteArray())
+                MessageCodec.write(output, offer)
+
+                // Wait for ACCEPT or DONE
+                val response = readWithTimeout(tcpTimeoutMs)
+                when (response.type) {
+                    MessageType.ACCEPT -> {
+                        // Send encrypted blob over TCP
+                        tcpServer.sendAndClose(encryptedBlob)
+
+                        // Wait for DONE over BLE
+                        val done = readWithTimeout(tcpTimeoutMs)
+                        if (done.type != MessageType.DONE) {
+                            throw ProtocolException("Expected DONE, got ${done.type}")
+                        }
+                        callback.onTransferComplete(hash)
+                    }
+                    MessageType.DONE -> {
+                        callback.onTransferComplete(hash)
+                    }
+                    else -> throw ProtocolException("Expected ACCEPT or DONE, got ${response.type}")
+                }
+            } finally {
+                tcpServer.close()
             }
-            else -> throw ProtocolException("Expected ACCEPT or DONE, got ${response.type}")
         }
     }
 
@@ -336,6 +382,10 @@ class Session(
     private fun handleInboundOffer(msg: Message) {
         val json = JSONObject(String(msg.payload))
         val hash = json.getString("hash")
+        val size = json.getInt("size")
+        val contentType = json.optString("type", "text/plain")
+        val tcpPort = if (json.has("tcp_port")) json.getInt("tcp_port") else null
+        val tcpHost = if (json.has("tcp_host")) json.getString("tcp_host") else null
 
         if (callback.hasHash(hash)) {
             // Already have this — skip PAYLOAD, send DONE immediately
@@ -352,15 +402,24 @@ class Session(
         val accept = Message(MessageType.ACCEPT, ByteArray(0))
         MessageCodec.write(output, accept)
 
-        // Wait for PAYLOAD
-        val payload = readWithTimeout(transferTimeoutMs)
-        if (payload.type != MessageType.PAYLOAD) {
-            throw ProtocolException("Expected PAYLOAD, got ${payload.type}")
+        val key = sessionKey ?: throw ProtocolException("No session key available")
+
+        val encryptedPayload: ByteArray
+        if (tcpPort != null && tcpHost != null) {
+            // Rich media: fetch encrypted blob via TCP
+            Log.d(TAG, "Fetching rich media via TCP: $tcpHost:$tcpPort, size=$size, type=$contentType")
+            encryptedPayload = TcpRelay.fetch(tcpHost, tcpPort, size, TCP_TRANSFER_TIMEOUT_MS)
+        } else {
+            // Text: receive PAYLOAD over BLE
+            val payload = readWithTimeout(transferTimeoutMs)
+            if (payload.type != MessageType.PAYLOAD) {
+                throw ProtocolException("Expected PAYLOAD, got ${payload.type}")
+            }
+            encryptedPayload = payload.payload
         }
 
         // Decrypt payload
-        val key = sessionKey ?: throw ProtocolException("No session key available")
-        val plaintext = E2ECrypto.open(payload.payload, key)
+        val plaintext = E2ECrypto.open(encryptedPayload, key)
 
         // Verify hash against plaintext
         val actualHash = sha256Hex(plaintext)
@@ -368,8 +427,8 @@ class Session(
             throw ProtocolException("Hash mismatch: expected $hash, got $actualHash")
         }
 
-        // Notify callback with plaintext
-        callback.onClipboardReceived(plaintext, hash)
+        // Notify callback with plaintext and content type
+        callback.onClipboardReceived(plaintext, hash, contentType)
 
         // Send DONE
         val doneJson = JSONObject().apply {
@@ -500,6 +559,12 @@ class Session(
     }
 
     companion object {
+        private const val TAG = "Session"
+        /** TCP transfer timeout: 120 seconds (images are bigger than text). */
+        private const val TCP_TRANSFER_TIMEOUT_MS = 120_000L
+        /** Maximum rich media payload size: 10 MB. */
+        internal const val MAX_RICH_MEDIA_BYTES = 10 * 1024 * 1024
+
         internal fun sha256Hex(data: ByteArray): String {
             val digest = java.security.MessageDigest.getInstance("SHA-256")
             return digest.digest(data).joinToString("") { "%02x".format(it) }
@@ -509,7 +574,7 @@ class Session(
 
 interface SessionCallback {
     fun onSessionReady()
-    fun onClipboardReceived(plaintext: ByteArray, hash: String)
+    fun onClipboardReceived(plaintext: ByteArray, hash: String, contentType: String = "text/plain")
     fun onTransferComplete(hash: String)
     fun onSessionError(error: Exception)
     fun hasHash(hash: String): Boolean

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -43,6 +43,9 @@ import java.util.concurrent.Executors
 
 class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     companion object {
+        const val ACTION_PUSH_IMAGE = "org.cliprelay.action.PUSH_IMAGE"
+        const val EXTRA_IMAGE_PATH = "extra_image_path"
+        const val EXTRA_IMAGE_MIME = "extra_image_mime"
         const val ACTION_PUSH_TEXT = "org.cliprelay.action.PUSH_TEXT"
         const val ACTION_RELOAD_PAIRING = "org.cliprelay.action.RELOAD_PAIRING"
         const val ACTION_UNPAIR = "org.cliprelay.action.UNPAIR"
@@ -205,6 +208,19 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                 if (!text.isNullOrBlank()) {
                     executor.execute {
                         pushPlainTextToMac(text)
+                    }
+                }
+            }
+            ACTION_PUSH_IMAGE -> {
+                val path = intent.getStringExtra(EXTRA_IMAGE_PATH)
+                val mime = intent.getStringExtra(EXTRA_IMAGE_MIME) ?: "image/png"
+                if (!path.isNullOrEmpty()) {
+                    executor.execute {
+                        val file = java.io.File(path)
+                        val data = runCatching { file.readBytes() }.getOrNull()
+                        if (data != null && data.isNotEmpty()) {
+                            pushImageToMac(data, mime)
+                        }
                     }
                 }
             }
@@ -432,15 +448,21 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         DebugSmokeProbe.onConnectionChanged(this, true)
     }
 
-    override fun onClipboardReceived(plaintext: ByteArray, hash: String) {
-        val decodedText = plaintext.toString(Charsets.UTF_8)
-        if (decodedText.isEmpty()) return
-
+    override fun onClipboardReceived(plaintext: ByteArray, hash: String, contentType: String) {
         lastInboundHash = hash
-        clipboardWriter.writeText(decodedText)
-        scheduleClipboardAutoClear(decodedText)
-        sendClipboardTransferBroadcast(fromMac = true)
-        DebugSmokeProbe.onInboundClipboardApplied(this, decodedText)
+
+        if (contentType.startsWith("image/")) {
+            clipboardWriter.writeImage(plaintext, contentType)
+            sendClipboardTransferBroadcast(fromMac = true)
+        } else {
+            val decodedText = plaintext.toString(Charsets.UTF_8)
+            if (decodedText.isEmpty()) return
+
+            clipboardWriter.writeText(decodedText)
+            scheduleClipboardAutoClear(decodedText)
+            sendClipboardTransferBroadcast(fromMac = true)
+            DebugSmokeProbe.onInboundClipboardApplied(this, decodedText)
+        }
     }
 
     override fun onTransferComplete(hash: String) {
@@ -535,6 +557,22 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
         session.sendClipboard(plaintext)
         DebugSmokeProbe.onOutboundClipboardPublished(this, text)
+    }
+
+    private fun pushImageToMac(data: ByteArray, mimeType: String) {
+        if (isDestroyed) return
+        if (data.isEmpty() || data.size > org.cliprelay.protocol.Session.MAX_RICH_MEDIA_BYTES) {
+            Log.w(TAG, "Image too large or empty: ${data.size} bytes")
+            return
+        }
+
+        val session = activeSession
+        if (session == null) {
+            Log.d(TAG, "No active L2CAP session; skipping image push")
+            return
+        }
+
+        session.sendClipboard(data, mimeType)
     }
 
     // ── Pairing ────────────────────────────────────────────────────────

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardWriter.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardWriter.kt
@@ -1,14 +1,16 @@
 package org.cliprelay.service
 
-// Writes received text to the Android system clipboard on the main thread.
+// Writes received text or images to the Android system clipboard on the main thread.
 
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import androidx.core.content.FileProvider
+import java.io.File
 
-class ClipboardWriter(context: Context) {
+class ClipboardWriter(private val context: Context) {
     companion object {
         private const val CLIP_LABEL = "cliprelay"
     }
@@ -37,6 +39,27 @@ class ClipboardWriter(context: Context) {
                 }
             }
         }
+    }
+
+    fun writeImage(data: ByteArray, mimeType: String) {
+        val ext = when {
+            mimeType.contains("png") -> "png"
+            mimeType.contains("jpeg") || mimeType.contains("jpg") -> "jpg"
+            mimeType.contains("gif") -> "gif"
+            mimeType.contains("webp") -> "webp"
+            else -> "png"
+        }
+        val file = File(context.cacheDir, "cliprelay_image.$ext")
+        file.writeBytes(data)
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        // Grant read permission broadly so any app can paste the image
+        context.grantUriPermission("*", uri, android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        val applyWrite = {
+            val clip = ClipData.newUri(context.contentResolver, CLIP_LABEL, uri)
+            runCatching { clipboard.setPrimaryClip(clip) }
+            Unit
+        }
+        if (Looper.myLooper() == Looper.getMainLooper()) applyWrite() else mainHandler.post(applyWrite)
     }
 
     private fun clipMatches(expectedText: String): Boolean {

--- a/android/app/src/main/java/org/cliprelay/tcp/TcpRelay.kt
+++ b/android/app/src/main/java/org/cliprelay/tcp/TcpRelay.kt
@@ -1,0 +1,61 @@
+package org.cliprelay.tcp
+
+import java.io.InputStream
+import java.net.Inet4Address
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.net.ServerSocket
+import java.net.Socket
+
+object TcpRelay {
+    class TcpServer(private val serverSocket: ServerSocket) {
+        val port: Int = serverSocket.localPort
+
+        fun sendAndClose(data: ByteArray) {
+            serverSocket.use { server ->
+                val client = server.accept()
+                client.use { socket ->
+                    socket.getOutputStream().write(data)
+                    socket.getOutputStream().flush()
+                }
+            }
+        }
+
+        fun close() {
+            runCatching { serverSocket.close() }
+        }
+    }
+
+    fun serve(timeoutMs: Long = 30_000): TcpServer {
+        val server = ServerSocket(0)
+        server.soTimeout = timeoutMs.toInt()
+        return TcpServer(server)
+    }
+
+    fun fetch(host: String, port: Int, size: Int, timeoutMs: Long = 30_000): ByteArray {
+        val socket = Socket()
+        socket.connect(InetSocketAddress(host, port), timeoutMs.toInt())
+        socket.soTimeout = timeoutMs.toInt()
+        socket.use {
+            return readExactly(it.getInputStream(), size)
+        }
+    }
+
+    fun getLocalIpAddress(): String? {
+        return NetworkInterface.getNetworkInterfaces()?.toList()
+            ?.flatMap { it.inetAddresses.toList() }
+            ?.firstOrNull { !it.isLoopbackAddress && it is Inet4Address }
+            ?.hostAddress
+    }
+
+    private fun readExactly(input: InputStream, count: Int): ByteArray {
+        val buffer = ByteArray(count)
+        var offset = 0
+        while (offset < count) {
+            val read = input.read(buffer, offset, count - offset)
+            if (read == -1) throw java.io.IOException("Stream closed after $offset/$count bytes")
+            offset += read
+        }
+        return buffer
+    }
+}

--- a/android/app/src/main/java/org/cliprelay/ui/ShareReceiverActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ShareReceiverActivity.kt
@@ -1,8 +1,9 @@
 package org.cliprelay.ui
 
-// Handles Android share-sheet intents to send shared text to the connected Mac.
+// Handles Android share-sheet intents to send shared text or images to the connected Mac.
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -14,31 +15,74 @@ class ShareReceiverActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (intent?.action == Intent.ACTION_SEND && intent.type?.startsWith("text/") == true) {
-            val text = intent.getStringExtra(Intent.EXTRA_TEXT)
-            if (!text.isNullOrBlank()) {
-                val serviceIntent = Intent(this, ClipRelayService::class.java).apply {
-                    action = ClipRelayService.ACTION_PUSH_TEXT
-                    putExtra(ClipRelayService.EXTRA_TEXT, text)
-                }
-                runCatching {
-                    ContextCompat.startForegroundService(this, serviceIntent)
-                }.onFailure {
-                    Toast.makeText(this, "Could not start ClipRelay service", Toast.LENGTH_SHORT).show()
-                    finish()
-                    return
-                }
-
-                val deviceName = getSharedPreferences(ClipRelayService.PREFS_NAME, MODE_PRIVATE)
-                    .getString(ClipRelayService.KEY_CONNECTED_DEVICE, null)
-                val message = if (deviceName != null)
-                    getString(R.string.toast_sent_to, deviceName)
-                else
-                    getString(R.string.toast_sent)
-                Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+        if (intent?.action == Intent.ACTION_SEND) {
+            when {
+                intent.type?.startsWith("image/") == true -> handleImageShare()
+                intent.type?.startsWith("text/") == true -> handleTextShare()
             }
         }
 
         finish()
+    }
+
+    private fun handleTextShare() {
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+        if (!text.isNullOrBlank()) {
+            val serviceIntent = Intent(this, ClipRelayService::class.java).apply {
+                action = ClipRelayService.ACTION_PUSH_TEXT
+                putExtra(ClipRelayService.EXTRA_TEXT, text)
+            }
+            if (!startServiceSafely(serviceIntent)) return
+            showSentToast()
+        }
+    }
+
+    private fun handleImageShare() {
+        @Suppress("DEPRECATION")
+        val imageUri: Uri? = intent.getParcelableExtra(Intent.EXTRA_STREAM)
+        if (imageUri == null) return
+
+        val mimeType = intent.type ?: "image/png"
+
+        // Copy image to a temp file to avoid Binder transaction size limits
+        val tempFile = java.io.File(cacheDir, "share_image_tmp")
+        try {
+            contentResolver.openInputStream(imageUri)?.use { input ->
+                tempFile.outputStream().use { output -> input.copyTo(output) }
+            } ?: return
+        } catch (e: Exception) {
+            Toast.makeText(this, "Could not read image", Toast.LENGTH_SHORT).show()
+            return
+        }
+        if (!tempFile.exists() || tempFile.length() == 0L) return
+
+        val serviceIntent = Intent(this, ClipRelayService::class.java).apply {
+            action = ClipRelayService.ACTION_PUSH_IMAGE
+            putExtra(ClipRelayService.EXTRA_IMAGE_PATH, tempFile.absolutePath)
+            putExtra(ClipRelayService.EXTRA_IMAGE_MIME, mimeType)
+        }
+        if (!startServiceSafely(serviceIntent)) return
+        showSentToast()
+    }
+
+    private fun startServiceSafely(serviceIntent: Intent): Boolean {
+        return runCatching {
+            ContextCompat.startForegroundService(this, serviceIntent)
+            true
+        }.getOrElse {
+            Toast.makeText(this, "Could not start ClipRelay service", Toast.LENGTH_SHORT).show()
+            finish()
+            false
+        }
+    }
+
+    private fun showSentToast() {
+        val deviceName = getSharedPreferences(ClipRelayService.PREFS_NAME, MODE_PRIVATE)
+            .getString(ClipRelayService.KEY_CONNECTED_DEVICE, null)
+        val message = if (deviceName != null)
+            getString(R.string.toast_sent_to, deviceName)
+        else
+            getString(R.string.toast_sent)
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 }

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="images" path="." />
+</paths>

--- a/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
+++ b/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
@@ -175,7 +175,7 @@ class SessionTest {
             assertEquals(expectedHash, hash)
             transferLatch.countDown()
         }
-        env.androidCallback.onReceived = { blob, hash ->
+        env.androidCallback.onReceived = { blob, hash, _ ->
             assertArrayEquals(testData, blob)
             assertEquals(expectedHash, hash)
             receivedLatch.countDown()
@@ -203,7 +203,7 @@ class SessionTest {
 
         env.macCallback.onReady = { readyLatch.countDown() }
         env.androidCallback.onReady = { readyLatch.countDown() }
-        env.macCallback.onReceived = { blob, hash ->
+        env.macCallback.onReceived = { blob, hash, _ ->
             receivedBlob = blob
             receivedHash = hash
             receivedLatch.countDown()
@@ -244,7 +244,7 @@ class SessionTest {
         }
 
         // Android should NOT receive onClipboardReceived for a dedup
-        env.androidCallback.onReceived = { _, _ ->
+        env.androidCallback.onReceived = { _, _, _ ->
             fail("Should not receive clipboard for duplicate")
         }
 
@@ -602,7 +602,7 @@ class SessionTest {
             assertEquals(expectedHash, hash)
             transferLatch.countDown()
         }
-        env.androidCallback.onReceived = { received, hash ->
+        env.androidCallback.onReceived = { received, hash, _ ->
             assertArrayEquals("Plaintext should match", plaintext, received)
             assertEquals("Hash should match", expectedHash, hash)
             receivedLatch.countDown()
@@ -852,15 +852,15 @@ class SessionTest {
 
     class TestCallback : SessionCallback {
         var onReady: () -> Unit = {}
-        var onReceived: (ByteArray, String) -> Unit = { _, _ -> }
+        var onReceived: (ByteArray, String, String) -> Unit = { _, _, _ -> }
         var onTransfer: (String) -> Unit = {}
         var onError: (Exception) -> Unit = {}
         var onPairing: (ByteArray, String?) -> Unit = { _, _ -> }
         val knownHashes = CopyOnWriteArrayList<String>()
 
         override fun onSessionReady() = onReady()
-        override fun onClipboardReceived(plaintext: ByteArray, hash: String) =
-            onReceived(plaintext, hash)
+        override fun onClipboardReceived(plaintext: ByteArray, hash: String, contentType: String) =
+            onReceived(plaintext, hash, contentType)
         override fun onTransferComplete(hash: String) = onTransfer(hash)
         override fun onSessionError(error: Exception) = onError(error)
         override fun hasHash(hash: String): Boolean = hash in knownHashes

--- a/macos/ClipRelayMac/Resources/ClipRelay.entitlements
+++ b/macos/ClipRelayMac/Resources/ClipRelay.entitlements
@@ -2,5 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -80,8 +80,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Clipboard monitor triggers outbound sends via Session
-        clipboardMonitor = ClipboardMonitor { [weak self] text in
-            self?.onClipboardChange(text)
+        clipboardMonitor = ClipboardMonitor { [weak self] content in
+            self?.onClipboardChange(content)
         }
 
         // Start scanning and monitoring
@@ -115,15 +115,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Clipboard Change → Session
 
-    private func onClipboardChange(_ text: String) {
+    private func onClipboardChange(_ content: ClipboardContent) {
         guard connectedSecret != nil else {
             appLogger.debug("[App] Clipboard changed but no connected device")
             return
         }
-        guard let plainData = text.data(using: .utf8) else { return }
 
-        // Dedup: skip if we just received this exact text from the remote side
-        let hash = SHA256.hash(data: Data(text.utf8))
+        let plainData: Data
+        let contentType: String
+
+        switch content {
+        case .text(let text):
+            guard let data = text.data(using: .utf8) else { return }
+            plainData = data
+            contentType = "text/plain"
+        case .image(let data, let mimeType):
+            plainData = data
+            contentType = mimeType
+        }
+
+        // Dedup: skip if we just received this exact content from the remote side
+        let hash = SHA256.hash(data: plainData)
             .map { String(format: "%02x", $0) }
             .joined()
         if hash == lastReceivedHash {
@@ -136,8 +148,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Try to send immediately
         if let session = activeSession {
-            session.sendClipboard(plainData)
-            appLogger.info("[App] Queued clipboard for send (\(plainData.count) bytes)")
+            session.sendClipboard(plainData, contentType: contentType)
+            appLogger.info("[App] Queued clipboard for send (\(plainData.count) bytes, type: \(contentType))")
         } else {
             appLogger.info("[App] Clipboard cached for send on reconnect (\(plainData.count) bytes)")
         }
@@ -482,28 +494,53 @@ extension AppDelegate: SessionDelegate {
         }
     }
 
-    func session(_ session: Session, didReceivePlaintext plaintext: Data, hash: String) {
+    func session(_ session: Session, didReceivePlaintext plaintext: Data, hash: String, contentType: String) {
         guard connectedSecret != nil else {
             appLogger.error("[App] Received clipboard but no connected token")
             return
         }
-        guard let text = String(data: plaintext, encoding: .utf8) else {
-            appLogger.error("[App] Received data is not valid UTF-8")
-            return
-        }
 
         // Track hash for dedup (prevent echo back)
-        let textHash = SHA256.hash(data: Data(text.utf8))
+        let contentHash = SHA256.hash(data: plaintext)
             .map { String(format: "%02x", $0) }
             .joined()
-        lastReceivedHash = textHash
+        lastReceivedHash = contentHash
 
-        appLogger.info("[App] Received clipboard from Android (\(text.count) chars)")
+        if contentType == "text/plain" {
+            guard let text = String(data: plaintext, encoding: .utf8) else {
+                appLogger.error("[App] Received data is not valid UTF-8")
+                return
+            }
 
-        DispatchQueue.main.async { [weak self] in
-            self?.clipboardWriter.writeText(text)
-            self?.notificationManager.postClipboardReceived(text: text)
-            self?.statusBarController.flashSyncIndicator()
+            appLogger.info("[App] Received clipboard from Android (\(text.count) chars)")
+
+            DispatchQueue.main.async { [weak self] in
+                self?.clipboardWriter.writeText(text)
+                self?.notificationManager.postClipboardReceived(text: text)
+                self?.statusBarController.flashSyncIndicator()
+            }
+        } else {
+            // Rich content (image)
+            let pasteboardType: NSPasteboard.PasteboardType
+            switch contentType {
+            case "image/png":
+                pasteboardType = .png
+            case "image/tiff":
+                pasteboardType = .tiff
+            case "image/jpeg":
+                // Write JPEG as PNG to pasteboard for broader compatibility
+                pasteboardType = .png
+            default:
+                pasteboardType = .png
+            }
+
+            appLogger.info("[App] Received image from Android (\(plaintext.count) bytes, type: \(contentType))")
+
+            DispatchQueue.main.async { [weak self] in
+                self?.clipboardWriter.writeImage(plaintext, type: pasteboardType)
+                self?.notificationManager.postClipboardReceived(text: "[Image copied]")
+                self?.statusBarController.flashSyncIndicator()
+            }
         }
     }
 

--- a/macos/ClipRelayMac/Sources/Clipboard/ClipboardMonitor.swift
+++ b/macos/ClipRelayMac/Sources/Clipboard/ClipboardMonitor.swift
@@ -1,7 +1,12 @@
-// Polls the macOS pasteboard for changes and fires a callback when new text is detected.
+// Polls the macOS pasteboard for changes and fires a callback when new content is detected.
 
 import AppKit
 import CryptoKit
+
+enum ClipboardContent {
+    case text(String)
+    case image(Data, String)  // (data, mimeType e.g. "image/png")
+}
 
 final class ClipboardMonitor {
     static let defaultPollInterval: TimeInterval = {
@@ -15,14 +20,17 @@ final class ClipboardMonitor {
         return milliseconds / 1000
     }()
 
+    /// Maximum image size: 10 MB
+    private static let maxImageSize = 10_485_760
+
     private let pasteboard = NSPasteboard.general
-    private let onChange: (String) -> Void
+    private let onChange: (ClipboardContent) -> Void
     private let pollInterval: TimeInterval
     private var timer: Timer?
     private var lastChangeCount: Int
     private var lastHash: String?
 
-    init(pollInterval: TimeInterval = ClipboardMonitor.defaultPollInterval, onChange: @escaping (String) -> Void) {
+    init(pollInterval: TimeInterval = ClipboardMonitor.defaultPollInterval, onChange: @escaping (ClipboardContent) -> Void) {
         self.pollInterval = pollInterval
         self.onChange = onChange
         self.lastChangeCount = pasteboard.changeCount
@@ -43,6 +51,29 @@ final class ClipboardMonitor {
     private func poll() {
         guard pasteboard.changeCount != lastChangeCount else { return }
         lastChangeCount = pasteboard.changeCount
+
+        // Check for image first (PNG, then TIFF)
+        if let imageData = pasteboard.data(forType: .png), !imageData.isEmpty {
+            guard imageData.count <= Self.maxImageSize else { return }
+            let digest = SHA256.hash(data: imageData)
+            let hash = digest.map { String(format: "%02x", $0) }.joined()
+            guard hash != lastHash else { return }
+            lastHash = hash
+            onChange(.image(imageData, "image/png"))
+            return
+        }
+
+        if let imageData = pasteboard.data(forType: .tiff), !imageData.isEmpty {
+            guard imageData.count <= Self.maxImageSize else { return }
+            let digest = SHA256.hash(data: imageData)
+            let hash = digest.map { String(format: "%02x", $0) }.joined()
+            guard hash != lastHash else { return }
+            lastHash = hash
+            onChange(.image(imageData, "image/tiff"))
+            return
+        }
+
+        // Fall back to text
         guard let text = pasteboard.string(forType: .string), !text.isEmpty else { return }
         guard text.utf8.count <= 102_400 else { return }
 
@@ -50,6 +81,6 @@ final class ClipboardMonitor {
         let hash = digest.map { String(format: "%02x", $0) }.joined()
         guard hash != lastHash else { return }
         lastHash = hash
-        onChange(text)
+        onChange(.text(text))
     }
 }

--- a/macos/ClipRelayMac/Sources/Clipboard/ClipboardWriter.swift
+++ b/macos/ClipRelayMac/Sources/Clipboard/ClipboardWriter.swift
@@ -1,4 +1,4 @@
-// Writes received text to the macOS system pasteboard.
+// Writes received text or images to the macOS system pasteboard.
 
 import AppKit
 
@@ -7,5 +7,11 @@ final class ClipboardWriter {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
+    }
+
+    func writeImage(_ data: Data, type: NSPasteboard.PasteboardType) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setData(data, forType: type)
     }
 }

--- a/macos/ClipRelayMac/Sources/Protocol/Session.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/Session.swift
@@ -3,12 +3,15 @@
 import Foundation
 import CommonCrypto
 import CryptoKit
+import os
+
+private let sessionLogger = Logger(subsystem: "org.cliprelay", category: "Session")
 
 // MARK: - Session Delegate
 
 protocol SessionDelegate: AnyObject {
     func sessionDidBecomeReady(_ session: Session)
-    func session(_ session: Session, didReceivePlaintext plaintext: Data, hash: String)
+    func session(_ session: Session, didReceivePlaintext plaintext: Data, hash: String, contentType: String)
     func session(_ session: Session, didCompleteTransfer hash: String)
     func session(_ session: Session, didFailWithError error: Error)
     func session(_ session: Session, alreadyHasHash hash: String) -> Bool
@@ -69,8 +72,8 @@ final class Session {
         set { lock.lock(); _closed = newValue; lock.unlock() }
     }
 
-    /// Queue of outbound clipboard transfers (plaintext).
-    private var outboundQueue: [Data] = []
+    /// Queue of outbound clipboard transfers (plaintext, contentType).
+    private var outboundQueue: [(Data, String)] = []
     private let queueLock = NSLock()
 
     /// Shared secret hex string for deriving auth and session keys.
@@ -251,8 +254,8 @@ final class Session {
         do {
             while !closed {
                 // Check for queued outbound transfers
-                if let outbound = dequeueOutbound() {
-                    try doSendClipboard(outbound)
+                if let (outbound, contentType) = dequeueOutbound() {
+                    try doSendClipboard(outbound, contentType: contentType)
                     continue
                 }
 
@@ -266,6 +269,7 @@ final class Session {
                 }
             }
         } catch {
+            sessionLogger.error("[Session] listenForMessages error: \(error.localizedDescription)")
             lock.lock()
             guard !_closed else { lock.unlock(); return }
             _closed = true
@@ -290,57 +294,106 @@ final class Session {
     /// Queue plaintext clipboard data for sending. Thread-safe.
     /// The actual transfer happens in the listen loop.
     /// Session encrypts the data internally using the session key.
-    func sendClipboard(_ plaintext: Data) {
+    func sendClipboard(_ plaintext: Data, contentType: String = "text/plain") {
         guard !closed else { return }
         queueLock.lock()
-        outboundQueue.append(plaintext)
+        outboundQueue.append((plaintext, contentType))
         queueLock.unlock()
     }
 
-    private func dequeueOutbound() -> Data? {
+    private func dequeueOutbound() -> (Data, String)? {
         queueLock.lock()
         defer { queueLock.unlock() }
         if outboundQueue.isEmpty { return nil }
         return outboundQueue.removeFirst()
     }
 
-    private func doSendClipboard(_ plaintext: Data) throws {
+    private func doSendClipboard(_ plaintext: Data, contentType: String = "text/plain") throws {
         // Hash is computed over plaintext (for dedup across sessions)
         guard let key = sessionKey else {
             throw SessionError.protocolError("No session key available")
         }
         let hash = Session.sha256Hex(plaintext)
         let encryptedBlob = try E2ECrypto.seal(plaintext, key: key)
-        let offerJSON: [String: Any] = [
-            "hash": hash,
-            "size": encryptedBlob.count,
-            "type": "text/plain"
-        ]
-        let offerData = try JSONSerialization.data(withJSONObject: offerJSON)
-        let offer = Message(type: .offer, payload: offerData)
-        try writeMessage(offer)
 
-        // Wait for ACCEPT or DONE
-        let response = try readWithTimeout(transferTimeoutSeconds)
-        switch response.type {
-        case .accept:
-            // Send PAYLOAD
-            let payload = Message(type: .payload, payload: encryptedBlob)
-            try writeMessage(payload)
+        let isRichContent = contentType != "text/plain"
 
-            // Wait for DONE
-            let done = try readWithTimeout(transferTimeoutSeconds)
-            guard done.type == .done else {
-                throw SessionError.unexpectedMessage("Expected DONE, got \(done.type)")
+        if isRichContent {
+            // Rich content: use TCP sideband
+            guard let localIP = TcpRelay.getLocalIPAddress() else {
+                // No WiFi IP — skip rich content (can't send over BLE)
+                return
             }
-            delegate?.session(self, didCompleteTransfer: hash)
 
-        case .done:
-            // Receiver already had this hash — dedup
-            delegate?.session(self, didCompleteTransfer: hash)
+            let server = try TcpRelay.TcpServer(timeoutSeconds: 120)
 
-        default:
-            throw SessionError.unexpectedMessage("Expected ACCEPT or DONE, got \(response.type)")
+            let offerJSON: [String: Any] = [
+                "hash": hash,
+                "size": encryptedBlob.count,
+                "type": contentType,
+                "tcp_port": Int(server.port),
+                "tcp_host": localIP
+            ]
+            let offerData = try JSONSerialization.data(withJSONObject: offerJSON)
+            let offer = Message(type: .offer, payload: offerData)
+            try writeMessage(offer)
+
+            // Wait for ACCEPT or DONE
+            let response = try readWithTimeout(120)
+            switch response.type {
+            case .accept:
+                // Send encrypted blob over TCP
+                try server.sendAndClose(encryptedBlob)
+
+                // Wait for DONE over BLE
+                let done = try readWithTimeout(120)
+                guard done.type == .done else {
+                    throw SessionError.unexpectedMessage("Expected DONE, got \(done.type)")
+                }
+                delegate?.session(self, didCompleteTransfer: hash)
+
+            case .done:
+                // Receiver already had this hash — dedup
+                server.close()
+                delegate?.session(self, didCompleteTransfer: hash)
+
+            default:
+                server.close()
+                throw SessionError.unexpectedMessage("Expected ACCEPT or DONE, got \(response.type)")
+            }
+        } else {
+            // Text content: existing BLE PAYLOAD flow
+            let offerJSON: [String: Any] = [
+                "hash": hash,
+                "size": encryptedBlob.count,
+                "type": "text/plain"
+            ]
+            let offerData = try JSONSerialization.data(withJSONObject: offerJSON)
+            let offer = Message(type: .offer, payload: offerData)
+            try writeMessage(offer)
+
+            // Wait for ACCEPT or DONE
+            let response = try readWithTimeout(transferTimeoutSeconds)
+            switch response.type {
+            case .accept:
+                // Send PAYLOAD
+                let payload = Message(type: .payload, payload: encryptedBlob)
+                try writeMessage(payload)
+
+                // Wait for DONE
+                let done = try readWithTimeout(transferTimeoutSeconds)
+                guard done.type == .done else {
+                    throw SessionError.unexpectedMessage("Expected DONE, got \(done.type)")
+                }
+                delegate?.session(self, didCompleteTransfer: hash)
+
+            case .done:
+                // Receiver already had this hash — dedup
+                delegate?.session(self, didCompleteTransfer: hash)
+
+            default:
+                throw SessionError.unexpectedMessage("Expected ACCEPT or DONE, got \(response.type)")
+            }
         }
     }
 
@@ -351,6 +404,12 @@ final class Session {
               let hash = json["hash"] as? String else {
             throw SessionError.protocolError("Invalid OFFER payload")
         }
+
+        let contentType = json["type"] as? String ?? "text/plain"
+        let tcpPort = json["tcp_port"] as? Int
+        let tcpHost = json["tcp_host"] as? String
+
+        sessionLogger.info("[Session] Inbound OFFER: type=\(contentType), tcpPort=\(tcpPort.map { String($0) } ?? "nil"), tcpHost=\(tcpHost ?? "nil"), hash=\(hash.prefix(8))...")
 
         if delegate?.session(self, alreadyHasHash: hash) == true {
             // Dedup — send DONE immediately
@@ -365,17 +424,36 @@ final class Session {
         let accept = Message(type: .accept, payload: Data())
         try writeMessage(accept)
 
-        // Wait for PAYLOAD
-        let payload = try readWithTimeout(transferTimeoutSeconds)
-        guard payload.type == .payload else {
-            throw SessionError.unexpectedMessage("Expected PAYLOAD, got \(payload.type)")
-        }
+        let plaintext: Data
 
-        // Decrypt payload
-        guard let key = sessionKey else {
-            throw SessionError.protocolError("No session key available")
+        if let tcpPort = tcpPort, let tcpHost = tcpHost {
+            // Rich content: fetch encrypted data over TCP
+            guard let size = json["size"] as? Int else {
+                throw SessionError.protocolError("OFFER missing size")
+            }
+
+            sessionLogger.info("[Session] TCP fetch: \(tcpHost):\(tcpPort), size=\(size)")
+            let encryptedData = try TcpRelay.fetch(host: tcpHost, port: UInt16(tcpPort), size: size, timeoutSeconds: 120)
+            sessionLogger.info("[Session] TCP fetch complete: \(encryptedData.count) bytes")
+
+            // Decrypt
+            guard let key = sessionKey else {
+                throw SessionError.protocolError("No session key available")
+            }
+            plaintext = try E2ECrypto.open(encryptedData, key: key)
+        } else {
+            // Text content: receive PAYLOAD over BLE
+            let payload = try readWithTimeout(transferTimeoutSeconds)
+            guard payload.type == .payload else {
+                throw SessionError.unexpectedMessage("Expected PAYLOAD, got \(payload.type)")
+            }
+
+            // Decrypt payload
+            guard let key = sessionKey else {
+                throw SessionError.protocolError("No session key available")
+            }
+            plaintext = try E2ECrypto.open(payload.payload, key: key)
         }
-        let plaintext = try E2ECrypto.open(payload.payload, key: key)
 
         // Verify hash against plaintext
         let actualHash = Session.sha256Hex(plaintext)
@@ -383,8 +461,8 @@ final class Session {
             throw SessionError.hashMismatch(expected: hash, actual: actualHash)
         }
 
-        // Notify delegate with plaintext
-        delegate?.session(self, didReceivePlaintext: plaintext, hash: hash)
+        // Notify delegate with plaintext and content type
+        delegate?.session(self, didReceivePlaintext: plaintext, hash: hash, contentType: contentType)
 
         // Send DONE
         let doneJSON: [String: Any] = ["hash": hash, "ok": true]

--- a/macos/ClipRelayMac/Sources/TCP/TcpRelay.swift
+++ b/macos/ClipRelayMac/Sources/TCP/TcpRelay.swift
@@ -1,0 +1,119 @@
+// TCP helper for rich media transfer: server (send) and client (fetch) operations.
+
+import Foundation
+
+enum TcpRelay {
+    class TcpServer {
+        let port: UInt16
+        private let socketFD: Int32
+
+        init(timeoutSeconds: TimeInterval = 30) throws {
+            let fd = socket(AF_INET, SOCK_STREAM, 0)
+            guard fd >= 0 else { throw TcpError.socketCreationFailed }
+
+            var yes: Int32 = 1
+            setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+
+            var addr = sockaddr_in()
+            addr.sin_family = sa_family_t(AF_INET)
+            addr.sin_port = 0  // random port
+            addr.sin_addr.s_addr = INADDR_ANY
+
+            var bindResult: Int32 = -1
+            withUnsafePointer(to: &addr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { bindResult = bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) }
+            }
+            guard bindResult == 0 else { Darwin.close(fd); throw TcpError.bindFailed }
+
+            listen(fd, 1)
+
+            // Get assigned port
+            var boundAddr = sockaddr_in()
+            var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+            withUnsafeMutablePointer(to: &boundAddr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { _ = getsockname(fd, $0, &len) }
+            }
+
+            // Set timeout
+            var tv = timeval(tv_sec: Int(timeoutSeconds), tv_usec: 0)
+            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+
+            // Assign stored properties last (after all failable operations)
+            self.socketFD = fd
+            self.port = UInt16(bigEndian: boundAddr.sin_port)
+        }
+
+        func sendAndClose(_ data: Data) throws {
+            let clientFD = accept(socketFD, nil, nil)
+            guard clientFD >= 0 else { Darwin.close(socketFD); throw TcpError.acceptFailed }
+            defer { Darwin.close(clientFD); Darwin.close(socketFD) }
+
+            try data.withUnsafeBytes { rawBuffer in
+                guard let base = rawBuffer.baseAddress else { return }
+                var sent = 0
+                while sent < data.count {
+                    let n = send(clientFD, base + sent, data.count - sent, 0)
+                    guard n > 0 else { throw TcpError.sendFailed }
+                    sent += n
+                }
+            }
+        }
+
+        func close() {
+            Darwin.close(socketFD)
+        }
+    }
+
+    static func fetch(host: String, port: UInt16, size: Int, timeoutSeconds: TimeInterval = 30) throws -> Data {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw TcpError.socketCreationFailed }
+        defer { Darwin.close(fd) }
+
+        var tv = timeval(tv_sec: Int(timeoutSeconds), tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        inet_pton(AF_INET, host, &addr.sin_addr)
+
+        let connectResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) }
+        }
+        guard connectResult == 0 else { throw TcpError.connectFailed }
+
+        var buffer = Data(count: size)
+        var received = 0
+        while received < size {
+            let n = buffer.withUnsafeMutableBytes { rawBuffer in
+                recv(fd, rawBuffer.baseAddress! + received, size - received, 0)
+            }
+            guard n > 0 else { throw TcpError.receiveFailed }
+            received += n
+        }
+        return buffer
+    }
+
+    static func getLocalIPAddress() -> String? {
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddr) == 0, let first = ifaddr else { return nil }
+        defer { freeifaddrs(ifaddr) }
+        for ptr in sequence(first: first, next: { $0.pointee.ifa_next }) {
+            let addr = ptr.pointee
+            guard addr.ifa_addr.pointee.sa_family == UInt8(AF_INET) else { continue }
+            let name = String(cString: addr.ifa_name)
+            guard name == "en0" || name == "en1" else { continue }
+            var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            getnameinfo(addr.ifa_addr, socklen_t(addr.ifa_addr.pointee.sa_len),
+                        &hostname, socklen_t(hostname.count), nil, 0, NI_NUMERICHOST)
+            return String(cString: hostname)
+        }
+        return nil
+    }
+
+    enum TcpError: Error {
+        case socketCreationFailed, bindFailed, acceptFailed, sendFailed
+        case connectFailed, receiveFailed
+    }
+}

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/SessionTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/SessionTests.swift
@@ -642,7 +642,7 @@ final class TestSessionDelegate: SessionDelegate {
     var knownHashes = Set<String>()
 
     func sessionDidBecomeReady(_ session: Session) { onReady(session) }
-    func session(_ session: Session, didReceivePlaintext plaintext: Data, hash: String) {
+    func session(_ session: Session, didReceivePlaintext plaintext: Data, hash: String, contentType: String) {
         onReceived(session, plaintext, hash)
     }
     func session(_ session: Session, didCompleteTransfer hash: String) {


### PR DESCRIPTION
## Summary

**This is a quick & dirty proof-of-concept — not production-ready.**

Adds image transfer between Android and macOS using TCP sockets as a sideband channel. BLE L2CAP remains the signaling layer (OFFER/ACCEPT/DONE), while the actual image payload transfers over a local-network TCP socket for dramatically better throughput (~100x faster than BLE).

### How it works
1. Sender detects image on clipboard / share sheet
2. Sender encrypts image, starts a TCP server on a random port
3. Sender sends OFFER over BLE with `tcp_port` + `tcp_host` fields
4. Receiver sends ACCEPT over BLE, connects to TCP server, downloads encrypted blob
5. Receiver decrypts, verifies hash, writes to clipboard
6. Receiver sends DONE over BLE

### What's included
- `TcpRelay` helper (server/client) on both platforms
- Protocol OFFER extended with optional `tcp_port`/`tcp_host` for rich content
- Mac: ClipboardMonitor detects PNG/TIFF images on pasteboard
- Android: ShareReceiverActivity accepts `image/*` shares
- ClipboardWriter on both platforms writes images
- INTERNET permission (Android) + network entitlements (macOS)

### Known limitations / not addressed
- No progress indicator during transfer
- No fallback if TCP connection fails (e.g. different subnets)
- No auto-copy for images on Android (only share sheet)
- Image size capped at 10MB (arbitrary MVP limit)
- No cleanup of temp files
- Debug logging left in
- Minimal error handling on TCP path

## Test plan
- [x] Mac→Android: copy image on Mac, verify it arrives on Android clipboard
- [x] Android→Mac: share image via share sheet, verify it arrives on Mac clipboard
- [x] Text transfers still work unchanged over BLE
- [x] Both apps build clean