### PR TITLE
fix: advertise all local IPs in image sync OFFER for VPN/Tailscale compat

### DIFF
--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -395,15 +395,18 @@ class Session(
     private fun doSendImage(imageData: ByteArray, contentType: String) {
         val key = sessionKey ?: throw ProtocolException("No session key available")
         val hash = sha256Hex(imageData)
-        val senderIp = NetworkUtil.getLocalIpAddress()
-            ?: throw ProtocolException("No local IP address available")
+        val senderIps = NetworkUtil.getAllLocalIpAddresses()
+        if (senderIps.isEmpty()) {
+            throw ProtocolException("No local IP address available")
+        }
 
         // Send OFFER over BLE
         val offerJson = JSONObject().apply {
             put("hash", hash)
             put("size", imageData.size)
             put("type", contentType)
-            put("senderIp", senderIp)
+            put("senderIp", senderIps.first()) // backward compat
+            put("senderIps", org.json.JSONArray(senderIps))
         }
         val offer = Message(MessageType.OFFER, offerJson.toString().toByteArray())
         MessageCodec.write(output, offer)
@@ -483,7 +486,12 @@ class Session(
         val contentType = json.getString("type")
         val size = json.getInt("size")
         val hash = json.getString("hash")
-        val senderIp = json.getString("senderIp")
+        val senderIps = if (json.has("senderIps")) {
+            val arr = json.getJSONArray("senderIps")
+            (0 until arr.length()).map { arr.getString(it) }.toSet()
+        } else {
+            setOf(json.getString("senderIp"))
+        }
 
         // Check richMediaEnabled
         val sp = settingsProvider
@@ -521,7 +529,7 @@ class Session(
         val expectedSize = size + 28
         val receiver = TcpImageReceiver(
             expectedSize = expectedSize,
-            allowedSenderIp = senderIp
+            allowedSenderIps = senderIps
         )
         activeReceiver = receiver
 

--- a/android/app/src/main/java/org/cliprelay/tcp/NetworkUtil.kt
+++ b/android/app/src/main/java/org/cliprelay/tcp/NetworkUtil.kt
@@ -4,26 +4,29 @@ import java.net.Inet4Address
 import java.net.NetworkInterface
 
 object NetworkUtil {
-    fun getLocalIpAddress(): String? {
+    fun getLocalIpAddress(): String? = getAllLocalIpAddresses().firstOrNull()
+
+    /**
+     * Returns all non-loopback IPv4 addresses, with wlan/eth interfaces listed first.
+     */
+    fun getAllLocalIpAddresses(): List<String> {
         val interfaces = NetworkInterface.getNetworkInterfaces()?.asSequence()
             ?.filter { it.isUp && !it.isLoopback }
-            ?.toList() ?: return null
+            ?.toList() ?: return emptyList()
 
         // Prefer wlan/eth interfaces (typical Android Wi-Fi/Ethernet)
         val preferred = interfaces
             .filter { it.name.startsWith("wlan") || it.name.startsWith("eth") }
             .flatMap { it.inetAddresses.asSequence() }
             .filterIsInstance<Inet4Address>()
-            .firstOrNull()
-            ?.hostAddress
+            .mapNotNull { it.hostAddress }
 
-        if (preferred != null) return preferred
-
-        // Fallback: any non-loopback IPv4 address (e.g. en0 on macOS/desktop)
-        return interfaces
+        val others = interfaces
+            .filter { !it.name.startsWith("wlan") && !it.name.startsWith("eth") }
             .flatMap { it.inetAddresses.asSequence() }
             .filterIsInstance<Inet4Address>()
-            .firstOrNull()
-            ?.hostAddress
+            .mapNotNull { it.hostAddress }
+
+        return (preferred + others).distinct()
     }
 }

--- a/android/app/src/main/java/org/cliprelay/tcp/TcpImageReceiver.kt
+++ b/android/app/src/main/java/org/cliprelay/tcp/TcpImageReceiver.kt
@@ -11,7 +11,7 @@ data class ServerInfo(val host: String, val port: Int)
 
 class TcpImageReceiver(
     private val expectedSize: Int,
-    private val allowedSenderIp: String?,
+    private val allowedSenderIps: Set<String> = emptySet(),
     private val noConnectionTimeoutMs: Int = 30_000,
     private val transferTimeoutMs: Int = 120_000,
     private val maxConnections: Int = 2,
@@ -54,7 +54,7 @@ class TcpImageReceiver(
                     val remoteIp = (client.remoteSocketAddress as? InetSocketAddress)
                         ?.address?.hostAddress
 
-                    if (allowedSenderIp != null && remoteIp != allowedSenderIp) {
+                    if (allowedSenderIps.isNotEmpty() && remoteIp !in allowedSenderIps) {
                         client.close()
                         continue
                     }

--- a/android/app/src/test/java/org/cliprelay/tcp/TcpImageReceiverTest.kt
+++ b/android/app/src/test/java/org/cliprelay/tcp/TcpImageReceiverTest.kt
@@ -14,7 +14,7 @@ class TcpImageReceiverTest {
         val payload = ByteArray(1024) { it.toByte() }
         val receiver = TcpImageReceiver(
             expectedSize = payload.size,
-            allowedSenderIp = null, // accept any
+            allowedSenderIps = emptySet(), // accept any
         )
 
         val info = receiver.start()
@@ -42,7 +42,7 @@ class TcpImageReceiverTest {
         val payload = ByteArray(64) { 0x42 }
         val receiver = TcpImageReceiver(
             expectedSize = payload.size,
-            allowedSenderIp = "10.0.0.99", // won't match 127.0.0.1
+            allowedSenderIps = setOf("10.0.0.99"), // won't match 127.0.0.1
             maxConnections = 1,
             noConnectionTimeoutMs = 2000,
         )
@@ -77,7 +77,7 @@ class TcpImageReceiverTest {
     fun timesOutWhenNoConnection() {
         val receiver = TcpImageReceiver(
             expectedSize = 100,
-            allowedSenderIp = null,
+            allowedSenderIps = emptySet(),
             noConnectionTimeoutMs = 300,
         )
 

--- a/macos/ClipRelayMac/Sources/Protocol/Session.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/Session.swift
@@ -457,7 +457,8 @@ final class Session {
             throw SessionError.protocolError("No session key available")
         }
         let hash = Session.sha256Hex(imageData)
-        guard let senderIp = LocalNetworkAddress.getLocalIPv4Address() else {
+        let senderIps = LocalNetworkAddress.getAllLocalIPv4Addresses()
+        guard let primaryIp = senderIps.first else {
             throw SessionError.protocolError("No local IP address available")
         }
 
@@ -466,7 +467,8 @@ final class Session {
             "hash": hash,
             "size": imageData.count,
             "type": contentType,
-            "senderIp": senderIp
+            "senderIp": primaryIp, // backward compat
+            "senderIps": senderIps
         ]
         let offerData = try JSONSerialization.data(withJSONObject: offerJSON)
         let offer = Message(type: .offer, payload: offerData)
@@ -548,6 +550,12 @@ final class Session {
               let senderIp = json["senderIp"] as? String else {
             throw SessionError.protocolError("Invalid image OFFER payload")
         }
+        let senderIps: Set<String>
+        if let ipsArray = json["senderIps"] as? [String], !ipsArray.isEmpty {
+            senderIps = Set(ipsArray)
+        } else {
+            senderIps = Set([senderIp])
+        }
 
         // Check richMediaEnabled
         guard let sp = settingsProvider, sp.isRichMediaEnabled() else {
@@ -573,7 +581,7 @@ final class Session {
         let expectedSize = size + 28
         let receiver = TcpImageReceiver(
             expectedSize: expectedSize,
-            allowedSenderIp: senderIp
+            allowedSenderIps: senderIps
         )
         activeReceiver = receiver
 

--- a/macos/ClipRelayMac/Sources/TCP/LocalNetworkAddress.swift
+++ b/macos/ClipRelayMac/Sources/TCP/LocalNetworkAddress.swift
@@ -3,16 +3,21 @@ import Foundation
 enum LocalNetworkAddress {
     /// Returns the local IPv4 address on Wi-Fi (en0/en1) or nil if unavailable.
     static func getLocalIPv4Address() -> String? {
+        getAllLocalIPv4Addresses().first
+    }
+
+    /// Returns all non-loopback IPv4 addresses, with en0/en1 interfaces listed first.
+    static func getAllLocalIPv4Addresses() -> [String] {
         var ifaddr: UnsafeMutablePointer<ifaddrs>?
-        guard getifaddrs(&ifaddr) == 0 else { return nil }
+        guard getifaddrs(&ifaddr) == 0 else { return [] }
         defer { freeifaddrs(ifaddr) }
+
+        var preferred: [String] = []
+        var others: [String] = []
 
         var current = ifaddr
         while let ifa = current {
             defer { current = ifa.pointee.ifa_next }
-
-            let name = String(cString: ifa.pointee.ifa_name)
-            guard name.hasPrefix("en0") || name.hasPrefix("en1") else { continue }
 
             let family = ifa.pointee.ifa_addr.pointee.sa_family
             guard family == UInt8(AF_INET) else { continue }
@@ -28,10 +33,18 @@ enum LocalNetworkAddress {
             guard result == 0 else { continue }
 
             let address = String(cString: hostname)
-            // Skip loopback
             if address.hasPrefix("127.") { continue }
-            return address
+
+            let name = String(cString: ifa.pointee.ifa_name)
+            if name.hasPrefix("en0") || name.hasPrefix("en1") {
+                preferred.append(address)
+            } else {
+                others.append(address)
+            }
         }
-        return nil
+
+        // Deduplicate while preserving order (preferred first)
+        var seen = Set<String>()
+        return (preferred + others).filter { seen.insert($0).inserted }
     }
 }

--- a/macos/ClipRelayMac/Sources/TCP/TcpImageReceiver.swift
+++ b/macos/ClipRelayMac/Sources/TCP/TcpImageReceiver.swift
@@ -7,7 +7,7 @@ struct TcpServerInfo {
 
 final class TcpImageReceiver {
     private let expectedSize: Int
-    private let allowedSenderIp: String?
+    private let allowedSenderIps: Set<String>
     private let noConnectionTimeoutMs: Int
     private let transferTimeoutMs: Int
     private let maxConnections: Int
@@ -18,13 +18,13 @@ final class TcpImageReceiver {
 
     init(
         expectedSize: Int,
-        allowedSenderIp: String?,
+        allowedSenderIps: Set<String> = [],
         noConnectionTimeoutMs: Int = 30_000,
         transferTimeoutMs: Int = 120_000,
         maxConnections: Int = 2
     ) {
         self.expectedSize = expectedSize
-        self.allowedSenderIp = allowedSenderIp
+        self.allowedSenderIps = allowedSenderIps
         self.noConnectionTimeoutMs = noConnectionTimeoutMs
         self.transferTimeoutMs = transferTimeoutMs
         self.maxConnections = maxConnections
@@ -119,7 +119,7 @@ final class TcpImageReceiver {
             }
 
             // Validate sender IP
-            if let allowed = allowedSenderIp {
+            if !allowedSenderIps.isEmpty {
                 var remoteHostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
                 withUnsafePointer(to: &clientAddr) { ptr in
                     ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
@@ -128,7 +128,7 @@ final class TcpImageReceiver {
                     }
                 }
                 let remoteIp = String(cString: remoteHostname)
-                if remoteIp != allowed {
+                if !allowedSenderIps.contains(remoteIp) {
                     close(clientFd)
                     continue
                 }

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/TcpImageReceiverTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/TcpImageReceiverTests.swift
@@ -7,7 +7,7 @@ final class TcpImageReceiverTests: XCTestCase {
         let payload = Data((0..<1024).map { UInt8($0 % 256) })
         let receiver = TcpImageReceiver(
             expectedSize: payload.count,
-            allowedSenderIp: nil
+            allowedSenderIps: []
         )
 
         let info = try receiver.start()
@@ -41,7 +41,7 @@ final class TcpImageReceiverTests: XCTestCase {
         let payload = Data(repeating: 0x42, count: 64)
         let receiver = TcpImageReceiver(
             expectedSize: payload.count,
-            allowedSenderIp: "10.0.0.99", // won't match 127.0.0.1
+            allowedSenderIps: ["10.0.0.99"], // won't match 127.0.0.1
             noConnectionTimeoutMs: 2000,
             maxConnections: 1
         )
@@ -75,7 +75,7 @@ final class TcpImageReceiverTests: XCTestCase {
     func testTimesOutWhenNoConnection() throws {
         let receiver = TcpImageReceiver(
             expectedSize: 100,
-            allowedSenderIp: nil,
+            allowedSenderIps: [],
             noConnectionTimeoutMs: 300
         )
 


### PR DESCRIPTION
## Summary

- Send all non-loopback IPv4 addresses in a new `senderIps` array in the OFFER message (keeps `senderIp` for backward compat)
- Receiver accepts TCP connections from any of the advertised IPs instead of just one

## Motivation

A user reported that image sync fails when both devices are on the same Tailscale tailnet. The root cause: when Tailscale (or other VPNs) is active, a device has multiple IPs (e.g., `192.168.x.x` on WiFi + `100.x.x.x` on Tailscale). The sender would advertise one IP in the OFFER, but the OS could route the TCP connection through a different interface, causing the receiver's IP validation to reject the connection as a source IP mismatch.

## Changes

- `NetworkUtil.kt` / `LocalNetworkAddress.swift`: Added `getAllLocal*` methods that return all non-loopback IPv4 addresses (preferred interfaces listed first)
- `Session.kt` / `Session.swift`: OFFER now includes `senderIps` array; receiver reads it with fallback to single `senderIp`
- `TcpImageReceiver` (both platforms): Changed from `allowedSenderIp: String?` to `allowedSenderIps: Set<String>`, checks set membership

## Backward compatibility

- **New sender → old receiver**: Old receiver reads `senderIp` (still present), ignores `senderIps`. Works.
- **Old sender → new receiver**: New receiver falls back to `[senderIp]` when `senderIps` is absent. Works.

## Test plan

- [x] All existing unit tests pass (132 tests, 0 failures)
- [ ] Test image sync with Tailscale active on both devices
- [ ] Test image sync with Tailscale on only one device
- [ ] Test image sync with no VPN (regression check)