### PR TITLE
fix(mac): recover from stale BLE scans that prevent reconnection

### DIFF
--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -602,6 +602,8 @@ extension AppDelegate: SessionDelegate {
 
         if case SessionError.versionMismatch = error {
             activeSession = nil
+            activeSettingsProvider = nil
+            connectedSecret = nil
             sessionThread = nil
             DispatchQueue.main.async { [weak self] in
                 self?.statusBarController.setConnectedPeers([])
@@ -614,13 +616,18 @@ extension AppDelegate: SessionDelegate {
         }
 
         activeSession = nil
+        activeSettingsProvider = nil
+        connectedSecret = nil
         sessionThread = nil
 
         DispatchQueue.main.async { [weak self] in
             self?.statusBarController.setConnectedPeers([])
         }
 
-        // ConnectionManager handles reconnect automatically
+        // The BLE link may still be alive even though the session failed.
+        // Explicitly tear down the peripheral connection so that
+        // didDisconnectPeripheral fires and triggers the reconnection cycle.
+        connectionManager?.triggerReconnect()
     }
 
     func session(_ session: Session, alreadyHasHash hash: String) -> Bool {

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionManager.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionManager.swift
@@ -121,6 +121,25 @@ class ConnectionManager: NSObject {
         state = .idle
     }
 
+    /// Tear down the current connection and start the reconnection cycle.
+    /// Use when the session layer detects a failure but the BLE link may still be alive.
+    func triggerReconnect() {
+        switch state {
+        case .connecting(let peripheral, _),
+             .openingL2CAP(let peripheral),
+             .connected(let peripheral):
+            l2capChannel = nil
+            matchedToken = nil
+            centralManager?.cancelPeripheralConnection(peripheral)
+            // didDisconnectPeripheral will set state to .idle and call scheduleReconnect()
+        case .scanning:
+            break  // already scanning for devices
+        case .idle:
+            resetReconnectDelay()
+            startScanning()
+        }
+    }
+
     // MARK: - Health Check
 
     private func startHealthCheck() {
@@ -132,6 +151,20 @@ class ConnectionManager: NSObject {
 
     private func performHealthCheck() {
         guard centralManager?.state == .poweredOn else { return }
+
+        // If we've been scanning without finding a device, cycle the scan.
+        // CoreBluetooth's allowDuplicates=false caches discovered peripherals;
+        // stopping and restarting clears the cache so peripherals whose
+        // advertisements were previously incomplete (missing scan response)
+        // will be reported again.
+        if case .scanning = state {
+            connLogger.info("Health check: cycling stale scan")
+            centralManager?.stopScan()
+            state = .idle
+            startScanning()
+            return
+        }
+
         guard case .idle = state else { return }
         guard reconnectTimer == nil else { return }
         connLogger.info("Health check: idle with no reconnect scheduled, restarting scan")


### PR DESCRIPTION
## Summary

- **Cycle stale BLE scans in health check**: CoreBluetooth's `allowDuplicates=false` caches discovered peripherals and stops reporting them. When in `.scanning` state, the health check now stops and restarts the scan every 60s to clear the cache.
- **Add `triggerReconnect()` to ConnectionManager**: Explicitly tears down the BLE connection when the session layer fails, ensuring `didDisconnectPeripheral` fires and the reconnection cycle starts — even if the BLE link is still alive.
- **Clean up state in `didFailWithError`**: Previously left `connectedSecret` and `activeSettingsProvider` set after session errors, causing inconsistent state between the UI (disconnected) and internal tracking.

## Root Cause

After a BLE disconnect, the Mac starts scanning. CoreBluetooth discovers the Android peripheral and reports it via `didDiscover`. If the scan response data is incomplete at that moment (e.g., during an Android advertisement cycle), the peripheral is silently rejected. With `allowDuplicates=false`, CoreBluetooth never reports it again. The health check couldn't recover because it only restarted scanning when `state == .idle`, but the stale scan keeps state at `.scanning` — permanent deadlock.

## Test plan

- [x] All 132 unit tests pass
- [x] Verified live connection establishes within 1 second after Mac app restart
- [x] Confirmed Android advertising state and Mac scanning state via `dumpsys bluetooth_manager` and macOS unified logging