### PR TITLE
chore(mac): reduce Sparkle update check interval from 24h to 2h

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -147,6 +147,8 @@ build_mac() {
   <true/>
   <key>SUFeedURL</key>
   <string>https://raw.githubusercontent.com/geekflyer/cliprelay/sparkle/appcast.xml</string>
+  <key>SUScheduledCheckInterval</key>
+  <integer>7200</integer>
   ${SPARKLE_PLIST_KEYS}
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Set `SUScheduledCheckInterval` to 7200 seconds (2 hours) in the generated Info.plist
- Sparkle's default is 86400 seconds (24 hours) when this key is absent

## Test plan

- [x] Verified no `SUScheduledCheckInterval` was previously set (Sparkle used its 24h default)
- [ ] Rebuild and confirm the key appears in the app bundle's Info.plist