### PR TITLE
Delay Android image acceptance after wake

### DIFF
--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -808,14 +808,21 @@ class Session(
     }
 
     private fun waitForDeviceAwake(): Boolean {
+        if (closed.get()) return false
         if (callback.isDeviceAwake()) return true
 
         val deadline = System.currentTimeMillis() + inboundImageAcceptWindowMs
         while (!closed.get() && System.currentTimeMillis() < deadline) {
-            Thread.sleep(100)
+            try {
+                Thread.sleep(100)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                return false
+            }
             if (callback.isDeviceAwake()) return true
         }
 
+        if (closed.get()) return false
         return callback.isDeviceAwake()
     }
 

--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -61,6 +61,7 @@ class Session(
     internal var handshakeTimeoutMs: Long = 5_000L,
     internal var transferTimeoutMs: Long = 30_000L,
     internal var pairingTimeoutMs: Long = 60_000L,
+    internal var inboundImageAcceptWindowMs: Long = 10_000L,
     private val settingsProvider: SettingsProvider? = null
 ) {
     private val tag = "Session"
@@ -505,8 +506,8 @@ class Session(
             return
         }
 
-        // Check device awake state (Android only)
-        if (!callback.isDeviceAwake()) {
+        // Give the user a short window to unlock/wake the device before rejecting.
+        if (!waitForDeviceAwake()) {
             val rejectJson = JSONObject().apply {
                 put("reason", "device_locked")
             }
@@ -804,6 +805,18 @@ class Session(
         json.put("richMediaEnabledChangedAt", sp.getRichMediaEnabledChangedAt())
         val msg = Message(MessageType.CONFIG_UPDATE, json.toString().toByteArray())
         configUpdateQueue.put(msg)
+    }
+
+    private fun waitForDeviceAwake(): Boolean {
+        if (callback.isDeviceAwake()) return true
+
+        val deadline = System.currentTimeMillis() + inboundImageAcceptWindowMs
+        while (!closed.get() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(100)
+            if (callback.isDeviceAwake()) return true
+        }
+
+        return callback.isDeviceAwake()
     }
 
     companion object {

--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -822,8 +822,7 @@ class Session(
             if (callback.isDeviceAwake()) return true
         }
 
-        if (closed.get()) return false
-        return callback.isDeviceAwake()
+        return false
     }
 
     companion object {

--- a/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
+++ b/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
@@ -1372,6 +1372,7 @@ class SessionTest {
             callback = callback,
             sharedSecretHex = testSharedSecret,
             handshakeTimeoutMs = 2000,
+            inboundImageAcceptWindowMs = 100,
             settingsProvider = sp
         )
 
@@ -1398,6 +1399,64 @@ class SessionTest {
         assertEquals(MessageType.REJECT, reject.type)
         val rejectJson = JSONObject(String(reject.payload))
         assertEquals("device_locked", rejectJson.getString("reason"))
+
+        session.close()
+        macInput.close(); toMac.close(); macOutput.close(); fromMac.close()
+    }
+
+    @Test
+    fun `handleInboundImageOffer waits briefly for device to wake before accepting`() {
+        val macInput = PipedInputStream()
+        val toMac = PipedOutputStream(macInput)
+        val macOutput = PipedOutputStream()
+        val fromMac = PipedInputStream(macOutput)
+
+        val sp = TestSettingsProvider(enabled = true, changedAt = 1000)
+        val readyLatch = CountDownLatch(1)
+        val callback = TestCallback()
+        callback.onReady = { readyLatch.countDown() }
+        callback.deviceAwake = false
+
+        val session = Session(
+            input = macInput,
+            output = macOutput,
+            isInitiator = true,
+            callback = callback,
+            sharedSecretHex = testSharedSecret,
+            handshakeTimeoutMs = 2000,
+            transferTimeoutMs = 5000,
+            inboundImageAcceptWindowMs = 500,
+            settingsProvider = sp
+        )
+
+        Thread {
+            session.performHandshake()
+            session.listenForMessages()
+        }.start()
+
+        val hello = MessageCodec.decode(fromMac)
+        sendValidWelcome(toMac, hello)
+        assertTrue("Session should be ready", readyLatch.await(3, TimeUnit.SECONDS))
+
+        val offerJson = JSONObject().apply {
+            put("hash", "abc123")
+            put("size", 100)
+            put("type", "image/png")
+            put("senderIp", "127.0.0.1")
+        }
+        MessageCodec.write(toMac, Message(MessageType.OFFER, offerJson.toString().toByteArray()))
+
+        Thread {
+            Thread.sleep(150)
+            callback.deviceAwake = true
+        }.start()
+
+        val accept = MessageCodec.decode(fromMac)
+        assertEquals(MessageType.ACCEPT, accept.type)
+
+        val acceptJson = JSONObject(String(accept.payload))
+        assertTrue("ACCEPT should have tcpHost", acceptJson.has("tcpHost"))
+        assertTrue("ACCEPT should have tcpPort", acceptJson.has("tcpPort"))
 
         session.close()
         macInput.close(); toMac.close(); macOutput.close(); fromMac.close()

--- a/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
+++ b/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
@@ -1835,6 +1835,7 @@ class SessionTest {
         var onRichMediaChanged: (Boolean) -> Unit = {}
         var onImageReceived: (ByteArray, String, String) -> Unit = { _, _, _ -> }
         var onImageRejected: (String) -> Unit = {}
+        @Volatile
         var deviceAwake: Boolean = true
         val knownHashes = CopyOnWriteArrayList<String>()
 

--- a/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
+++ b/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
@@ -8,6 +8,7 @@ import java.io.PipedOutputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import org.json.JSONObject
 
 /**
@@ -1413,9 +1414,14 @@ class SessionTest {
 
         val sp = TestSettingsProvider(enabled = true, changedAt = 1000)
         val readyLatch = CountDownLatch(1)
+        val wakeWaitStarted = CountDownLatch(1)
+        val deviceAwake = AtomicBoolean(false)
         val callback = TestCallback()
         callback.onReady = { readyLatch.countDown() }
-        callback.deviceAwake = false
+        callback.deviceAwakeProvider = {
+            wakeWaitStarted.countDown()
+            deviceAwake.get()
+        }
 
         val session = Session(
             input = macInput,
@@ -1446,10 +1452,8 @@ class SessionTest {
         }
         MessageCodec.write(toMac, Message(MessageType.OFFER, offerJson.toString().toByteArray()))
 
-        Thread {
-            Thread.sleep(150)
-            callback.deviceAwake = true
-        }.start()
+        assertTrue("Session should start waiting for device wake", wakeWaitStarted.await(1, TimeUnit.SECONDS))
+        deviceAwake.set(true)
 
         val accept = MessageCodec.decode(fromMac)
         assertEquals(MessageType.ACCEPT, accept.type)
@@ -1837,6 +1841,7 @@ class SessionTest {
         var onImageRejected: (String) -> Unit = {}
         @Volatile
         var deviceAwake: Boolean = true
+        var deviceAwakeProvider: (() -> Boolean)? = null
         val knownHashes = CopyOnWriteArrayList<String>()
 
         override fun onSessionReady() = onReady()
@@ -1853,7 +1858,7 @@ class SessionTest {
             onImageReceived.invoke(data, contentType, hash)
         override fun onImageRejected(reason: String) =
             onImageRejected.invoke(reason)
-        override fun isDeviceAwake(): Boolean = deviceAwake
+        override fun isDeviceAwake(): Boolean = deviceAwakeProvider?.invoke() ?: deviceAwake
     }
 
     /** In-memory settings provider for tests. */


### PR DESCRIPTION
## Summary
- wait up to 10 seconds before rejecting inbound image offers when Android is locked or asleep
- keep the existing reject path once that wake window expires
- add Android protocol tests for both the delayed accept and timed-out reject cases

## Verification
- env ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./scripts/test-all.sh
- env ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./scripts/build-all.sh
- installed dist/cliprelay-debug.apk on a connected Android device and launched the app