### PR TITLE
Add anonymous hourly check-in telemetry (macOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ website/downloads/
 docs/superpowers/specs/2026-03-12-1password-ci-secrets-design.md
 docs/superpowers/plans/2026-03-12-1password-ci-secrets.md
 scripts/setup-github-secrets.sh
+docs/2026-03-28-mac-heartbeat-stats-plan.md

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -36,6 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastReceivedHash: String?
     private var lastReceivedImageHash: String?
 
+    private var telemetryManager: TelemetryManager?
     private var clipboardMonitor: ClipboardMonitor?
     private var awaitingNewPairingConnection = false
     private var hasShownBluetoothAlert = false
@@ -119,10 +120,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Refresh trusted device list in the menu
         refreshTrustedPeersMenu()
+
+        // Anonymous usage check-ins
+        telemetryManager = TelemetryManager { [weak self] in
+            guard let self else { return .noPeering }
+            if self.connectedSecret != nil { return .activePeering }
+            if !self.pairingManager.loadDevices().isEmpty { return .idlePeering }
+            return .noPeering
+        }
+        telemetryManager?.start()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         bluetoothOffDebounceTimer?.invalidate()
+        telemetryManager?.stop()
         clipboardMonitor?.stop()
         activeSession?.close()
         connectionManager?.disconnect()

--- a/macos/ClipRelayMac/Sources/Telemetry/TelemetryManager.swift
+++ b/macos/ClipRelayMac/Sources/Telemetry/TelemetryManager.swift
@@ -1,0 +1,110 @@
+// Sends periodic check-ins with app state for anonymous usage insights.
+
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "org.cliprelay", category: "Telemetry")
+
+final class TelemetryManager {
+    enum CheckinState: String {
+        case noPeering = "no_peering"
+        case idlePeering = "idle_peering"
+        case activePeering = "active_peering"
+    }
+
+    private static let iso8601 = ISO8601DateFormatter()
+
+    private let stateProvider: () -> CheckinState
+    private let installId: String
+    private var timer: Timer?
+
+    private static let checkinURL = URL(string: "https://updates.cliprelay.org/v1/checkin")!
+    private static let keychainAccount = "telemetry_install_id"
+
+    init(stateProvider: @escaping () -> CheckinState) {
+        self.stateProvider = stateProvider
+        self.installId = Self.resolveInstallId()
+    }
+
+    func start() {
+        let startupDelay = Double.random(in: 30...90)
+        logger.notice("[Telemetry] Scheduling first check-in in \(Int(startupDelay))s")
+
+        let t = Timer(timeInterval: startupDelay, repeats: false) { [weak self] _ in
+            self?.sendCheckin()
+            self?.scheduleRecurring()
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    // MARK: - Private
+
+    private func scheduleRecurring() {
+        let jitter = Double.random(in: -300...300)
+        let interval = 3600.0 + jitter
+
+        let t = Timer(timeInterval: interval, repeats: false) { [weak self] _ in
+            self?.sendCheckin()
+            self?.scheduleRecurring()
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+
+    private func sendCheckin() {
+        let state = stateProvider()
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let osVersionString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+
+        let payload: [String: String] = [
+            "installId": installId,
+            "sentAt": Self.iso8601.string(from: Date()),
+            "appVersion": appVersion,
+            "appBuild": appBuild,
+            "platform": "macos",
+            "osVersion": osVersionString,
+            "state": state.rawValue,
+        ]
+
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else { return }
+
+        var request = URLRequest(url: Self.checkinURL, timeoutInterval: 15)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+
+        URLSession.shared.dataTask(with: request) { _, response, error in
+            if let error {
+                logger.debug("[Telemetry] Check-in failed: \(error.localizedDescription)")
+            } else if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
+                logger.debug("[Telemetry] Check-in sent (state: \(state.rawValue))")
+            } else {
+                logger.debug("[Telemetry] Check-in returned unexpected status")
+            }
+        }.resume()
+    }
+
+    private static func resolveInstallId() -> String {
+        let store = KeychainStore(service: "org.cliprelay")
+        if let existing = store.data(for: keychainAccount),
+           let id = String(data: existing, encoding: .utf8), !id.isEmpty {
+            return id
+        }
+        let newId = UUID().uuidString
+        if let data = newId.data(using: .utf8) {
+            if !store.setData(data, for: keychainAccount) {
+                logger.warning("[Telemetry] Failed to persist install ID — will reset on next launch")
+            }
+        }
+        logger.notice("[Telemetry] Generated new install ID")
+        return newId
+    }
+}

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy — ClipRelay</title>
-  <meta name="description" content="ClipRelay privacy policy. We collect no data. Your clipboard stays between your devices.">
+  <meta name="description" content="ClipRelay privacy policy. Your clipboard stays between your devices. Only anonymous usage check-ins are collected.">
   <meta name="theme-color" content="#111820">
 
   <link rel="canonical" href="https://cliprelay.org/privacy.html">
@@ -96,13 +96,25 @@
     <a href="index.html" class="back-link">&larr; Back to home</a>
 
     <h1>Privacy Policy</h1>
-    <p class="last-updated">Last updated: March 1, 2026</p>
+    <p class="last-updated">Last updated: March 28, 2026</p>
 
     <p>ClipRelay transfers clipboard data exclusively over Bluetooth Low Energy (BLE), directly between your devices. No servers, no cloud, no internet connection required.</p>
 
     <p>All transfers are fully end-to-end encrypted with AES-256-GCM. Encryption keys are generated during pairing and never leave your devices.</p>
 
-    <p>That's it. ClipRelay has no backend, so there is nothing to collect.</p>
+    <h2>Anonymous Usage Check-In</h2>
+
+    <p>The macOS app sends an anonymous hourly usage check-in to our server while running. This check-in includes:</p>
+
+    <ul>
+      <li>A random, anonymous install identifier (not tied to your Apple ID or hardware)</li>
+      <li>Whether the app currently has paired devices and whether a session is active</li>
+      <li>App version and macOS version</li>
+    </ul>
+
+    <p>The check-in does <strong>not</strong> include any clipboard contents, Apple device identifiers, hardware identifiers, or personal information.</p>
+
+    <p>This data helps us understand how many people use ClipRelay and how the app is being used, so we can prioritize improvements.</p>
 
     <h2>Contact</h2>
     <p>If you have any questions about this privacy policy, you can reach us at <a href="mailto:info@cliprelay.org">info@cliprelay.org</a>.</p>


### PR DESCRIPTION
## Summary
- Add `TelemetryManager` to the macOS app — sends an anonymous hourly check-in with peering state (`no_peering` / `idle_peering` / `active_peering`) to get high-level stats how many users actively use cliprelay.
- Install ID persisted in Keychain (random UUID)
- Update website privacy policy to disclose the check-in

Backend changes are in geekflyer/cliprelay-stats#1 (already deployed).

## Test plan
- [ ] 132 macOS unit tests pass
- [ ] Launch mac app, confirm check-in fires after ~30-90s startup delay
- [ ] Verify install ID persists across app restarts (Keychain)
- [ ] Verify state transitions: unpaired → `no_peering`, paired but disconnected → `idle_peering`, connected → `active_peering`