### PR TITLE
fix(ci): make Claude review workflow aware of prior comment context

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -26,12 +26,44 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+            EVENT TYPE: ${{ github.event.action }}
 
-            Please review this pull request with a focus on:
+            ## Step 1: Read existing review context
+
+            BEFORE reviewing any code, read ALL existing comments and review threads on this PR:
+
+            ```
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --paginate
+            gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --paginate
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --paginate
+            ```
+
+            Pay close attention to:
+            - Your own previous review comments (from "github-actions" bot)
+            - The author's replies and pushback on those comments
+            - Any feedback that was already acknowledged, resolved, or intentionally declined
+
+            ## Step 2: Determine review scope
+
+            If EVENT TYPE is "synchronize" (new commits pushed):
+            - Focus your review on the NEW changes since the last review
+            - Use `gh pr diff` to see the current full diff
+            - Do NOT re-raise issues that:
+              - Were already discussed and the author pushed back with a valid reason
+              - Were already resolved by the new commits
+              - You previously commented on and the author acknowledged
+
+            If EVENT TYPE is "opened" or "ready_for_review":
+            - Review the full PR diff
+
+            ## Step 3: Review with focus on
+
             - Code quality and best practices
             - Potential bugs or issues
             - Security implications
             - Performance considerations
+
+            ## Step 4: Post comments
 
             Note: The PR branch is already checked out in the current working directory.
 
@@ -39,5 +71,8 @@ jobs:
             Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
             Only post GitHub comments - don't submit review text as messages.
 
+            IMPORTANT: Do not repeat or re-raise feedback that has already been discussed
+            and resolved or deliberately declined by the PR author. Respect prior conversation context.
+
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep"


### PR DESCRIPTION
## Summary
- Claude's PR review workflow ran as a blank slate on each trigger — it never read existing comments, so it would re-raise issues the author had already pushed back on or resolved.
- Now the workflow fetches all prior PR comments, inline review comments, and reviews before posting new feedback.
- On `synchronize` (new push) events, reviews are scoped to only new changes, and Claude is instructed not to repeat resolved/declined feedback.

## Changes
- `fetch-depth: 0` for full git history (enables diffing between pushes)
- Added Step 1: read existing review context via `gh api`
- Added Step 2: scope review based on event type (full review vs incremental)
- Added `Bash(gh api:*)` to allowed tools
- Explicit instruction to respect prior conversation context

## Test plan
- [ ] Open a new PR and verify Claude reviews the full diff
- [ ] Push a follow-up commit and verify Claude only reviews new changes
- [ ] Reply to a Claude comment pushing back, push again, and verify Claude doesn't re-raise the same issue