### PR TITLE
Add prerelease input to release workflows

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version to release (e.g., 0.1.2)'
         type: string
         required: false
+      prerelease:
+        description: 'Prerelease build (internal track only, no promotion)'
+        type: boolean
+        default: false
       promote:
         description: 'Promote from internal to production'
         type: boolean
@@ -95,9 +99,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "android/v${{ steps.version.outputs.version }}" \
-            -m "Android release ${{ steps.version.outputs.version }}"
-          git push origin "android/v${{ steps.version.outputs.version }}"
+          TAG="android/v${{ steps.version.outputs.version }}"
+          git tag -a "$TAG" -m "Android release ${{ steps.version.outputs.version }}"
+          git push origin "$TAG"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -105,6 +109,7 @@ jobs:
           tag_name: "android/v${{ steps.version.outputs.version }}"
           name: "Android v${{ steps.version.outputs.version }}"
           body: ${{ steps.changelog.outputs.body }}
+          prerelease: ${{ inputs.prerelease }}
           files: dist/cliprelay-release.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version to release (e.g., 0.1.2)'
         type: string
         required: true
+      prerelease:
+        description: 'Prerelease build (skip Sparkle appcast update)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -99,11 +103,13 @@ jobs:
           tag_name: "mac/v${{ steps.version.outputs.version }}"
           name: "macOS v${{ steps.version.outputs.version }}"
           body: ${{ steps.changelog.outputs.body }}
+          prerelease: ${{ inputs.prerelease }}
           files: dist/ClipRelay-${{ steps.version.outputs.version }}.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Sparkle tools
+        if: ${{ !inputs.prerelease }}
         run: |
           SPARKLE_VERSION="2.9.0"
           curl -sL "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" -o /tmp/sparkle.tar.xz
@@ -111,6 +117,7 @@ jobs:
           tar xf /tmp/sparkle.tar.xz -C /tmp/sparkle-tools
 
       - name: Generate Sparkle EdDSA signature
+        if: ${{ !inputs.prerelease }}
         id: sparkle-sign
         run: |
           DMG_SIZE=$(stat -f%z dist/ClipRelay-${{ steps.version.outputs.version }}.dmg)
@@ -124,12 +131,14 @@ jobs:
           echo "size=$DMG_SIZE" >> "$GITHUB_OUTPUT"
 
       - name: Compute build metadata
+        if: ${{ !inputs.prerelease }}
         id: build-meta
         run: |
           echo "build_number=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
           echo "git_hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Update appcast.xml on sparkle branch
+        if: ${{ !inputs.prerelease }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- Adds a `prerelease` boolean input to both `release-mac.yml` and `release-android.yml`
- For macOS: skips Sparkle appcast update, EdDSA signing, and build metadata steps
- For both: marks the GitHub Release as prerelease so it doesn't show as "Latest"
- Enables prerelease builds from any branch via `gh workflow run --ref <branch> -f prerelease=true`

## Test plan
- [ ] Trigger `release-mac.yml` with `prerelease=true` from a branch and verify Sparkle steps are skipped
- [ ] Trigger `release-android.yml` with `prerelease=true` and verify GitHub Release is marked as prerelease
- [ ] Verify normal releases (prerelease=false) still update the appcast and behave as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that primarily gates existing release steps and metadata; main risk is mislabeling releases or unintentionally skipping Sparkle/appcast updates when `prerelease` is set.
> 
> **Overview**
> Adds a `prerelease` input to the Android and macOS GitHub Actions release workflows and passes it through to `softprops/action-gh-release` so GitHub Releases can be marked as prereleases.
> 
> For macOS, `prerelease=true` now *skips* Sparkle-related steps (tool download, EdDSA signing, build metadata, and appcast update) to avoid publishing update feeds for prerelease builds. Android also slightly refactors tag creation to use a `TAG` variable (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6269a6715918f295aee54775c5e098c3f67f2fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->