### PR TITLE
macOS: Sparkle beta update channel and release plumbing

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -7,6 +7,17 @@ on:
         description: 'Version to release (e.g., 0.1.2)'
         type: string
         required: true
+      git_ref:
+        description: 'Git branch or ref to build (main = production, beta = integration branch)'
+        type: string
+        default: main
+      sparkle_channel:
+        description: 'Which Sparkle feed to update on the sparkle branch'
+        type: choice
+        options:
+          - stable
+          - beta
+        default: stable
       prerelease:
         description: 'Prerelease build (skip Sparkle appcast update)'
         type: boolean
@@ -22,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.git_ref }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -103,7 +115,7 @@ jobs:
           tag_name: "mac/v${{ steps.version.outputs.version }}"
           name: "macOS v${{ steps.version.outputs.version }}"
           body: ${{ steps.changelog.outputs.body }}
-          prerelease: ${{ inputs.prerelease }}
+          prerelease: ${{ inputs.prerelease == true || inputs.sparkle_channel == 'beta' }}
           files: dist/ClipRelay-${{ steps.version.outputs.version }}.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -137,23 +149,32 @@ jobs:
           echo "build_number=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
           echo "git_hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Update appcast.xml on sparkle branch
+      - name: Update Sparkle appcast on sparkle branch
         if: ${{ !inputs.prerelease }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin sparkle
           git worktree add /tmp/sparkle-branch origin/sparkle
+          CHANNEL="${{ inputs.sparkle_channel }}"
+          if [[ "$CHANNEL" == "beta" ]]; then
+            APPCAST_FILE="/tmp/sparkle-branch/appcast-beta.xml"
+            if [[ ! -f "$APPCAST_FILE" ]]; then
+              cp "${GITHUB_WORKSPACE}/scripts/sparkle-appcast-beta-skeleton.xml" "$APPCAST_FILE"
+            fi
+          else
+            APPCAST_FILE="/tmp/sparkle-branch/appcast.xml"
+          fi
           ./scripts/update-appcast.sh \
-            --appcast /tmp/sparkle-branch/appcast.xml \
+            --appcast "$APPCAST_FILE" \
             --version "${{ steps.version.outputs.version }} (${{ steps.build-meta.outputs.git_hash }})" \
             --build-number "${{ steps.build-meta.outputs.build_number }}" \
             --signature "${{ steps.sparkle-sign.outputs.signature }}" \
             --size "${{ steps.sparkle-sign.outputs.size }}" \
             --url "https://github.com/geekflyer/cliprelay/releases/download/mac/v${{ steps.version.outputs.version }}/ClipRelay-${{ steps.version.outputs.version }}.dmg"
           cd /tmp/sparkle-branch
-          git add appcast.xml
-          git commit -m "update appcast for v${{ steps.version.outputs.version }}"
+          git add "$(basename "$APPCAST_FILE")"
+          git commit -m "update ${CHANNEL} appcast for v${{ steps.version.outputs.version }}"
           git push origin HEAD:sparkle
           cd -
           git worktree remove /tmp/sparkle-branch

--- a/docs/CI-SETUP.md
+++ b/docs/CI-SETUP.md
@@ -54,22 +54,27 @@ To rotate the service account token, generate a new one in 1Password admin conso
 | Workflow | Trigger | What it does |
 |----------|---------|-------------|
 | `ci.yml` | Push to main, PRs | Lint, test, build for both platforms |
-| `release-mac.yml` | Tag `mac/v*` | Build, sign, notarize, create GitHub Release, update Sparkle appcast |
+| `release-mac.yml` | Manual dispatch (`version`, optional `git_ref`, `sparkle_channel`) | Build from `main` or `beta`, sign, notarize, GitHub Release; update `appcast.xml` or `appcast-beta.xml` on branch `sparkle` |
 | `release-android.yml` | Tag `android/v*` | Build, sign, publish to Play Store internal track, create GitHub Release |
 | `release-android.yml` | Manual dispatch (promote) | Promote from internal to production track |
 
 ## Release Process
 
 ```bash
-# Release macOS only
+# Release macOS only (production feed: appcast.xml, branch main)
 ./scripts/release.sh --mac 0.2.0
+
+# macOS beta integration build: check out branch `beta`, then:
+./scripts/release.sh --mac 0.3.0 --beta
 
 # Release Android only
 ./scripts/release.sh --android 0.2.0
 
-# Release both
+# Release both (must be on main; production mac feed only)
 ./scripts/release.sh --all 0.2.0
 
 # Promote Android to production (after testing internal build)
 # Go to GitHub Actions → Release Android → Run workflow → Check "Promote"
 ```
+
+Host `appcast-beta.xml` next to `appcast.xml` on your updates origin (for example `https://updates.cliprelay.org/appcast-beta.xml`).

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -12,6 +12,7 @@ private let appLogger = Logger(subsystem: "org.cliprelay", category: "App")
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private let updaterController: SPUStandardUpdaterController
+    private let sparkleUpdaterDelegate = ClipRelaySparkleUpdaterDelegate()
     private let updaterDriverDelegate = UpdaterDriverDelegate()
     private let pairingManager = PairingManager()
     private let statusBarController: StatusBarController
@@ -21,7 +22,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     override init() {
         updaterController = SPUStandardUpdaterController(
-            startingUpdater: false, updaterDelegate: nil, userDriverDelegate: updaterDriverDelegate)
+            startingUpdater: false, updaterDelegate: sparkleUpdaterDelegate, userDriverDelegate: updaterDriverDelegate)
         statusBarController = StatusBarController(updaterController: updaterController)
         super.init()
     }
@@ -49,6 +50,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Creating the controller with startingUpdater:false in init() and
         // deferring start to here avoids a race where the updater's scheduled
         // cycle fires before the runloop is running.
+        // Ignore any feed URL stored via deprecated setFeedURL — channel is driven by
+        // ClipRelaySparkleUpdaterDelegate + UserDefaults.
+        _ = updaterController.updater.clearFeedURLFromUserDefaults()
+
         updaterController.startUpdater()
         if updaterController.updater.automaticallyChecksForUpdates {
             updaterController.updater.checkForUpdatesInBackground()
@@ -96,6 +101,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         statusBarController.isDeviceConnected = { [weak self] in
             self?.connectedSecret != nil
+        }
+        statusBarController.isBetaUpdateChannelEnabled = {
+            SparkleUpdateChannel.prefersBeta
+        }
+        statusBarController.onToggleBetaUpdateChannel = { [weak self] in
+            guard let self else { return }
+            SparkleUpdateChannel.prefersBeta.toggle()
+            self.updaterDriverDelegate.clearAvailableUpdateBadge()
+            self.updaterController.updater.resetUpdateCycleAfterShortDelay()
+            if self.updaterController.updater.automaticallyChecksForUpdates {
+                self.updaterController.updater.checkForUpdatesInBackground()
+            }
         }
         pairingWindowController.onDidClose = { [weak self] in
             self?.handlePairingWindowClosed()

--- a/macos/ClipRelayMac/Sources/App/SparkleUpdateChannel.swift
+++ b/macos/ClipRelayMac/Sources/App/SparkleUpdateChannel.swift
@@ -1,0 +1,30 @@
+// Sparkle feed selection: stable production appcast vs beta integration appcast.
+
+import Foundation
+import Sparkle
+
+enum SparkleUpdateChannel {
+    static let prefersBetaDefaultsKey = "ClipRelaySparklePrefersBetaUpdates"
+
+    static var prefersBeta: Bool {
+        get { UserDefaults.standard.bool(forKey: prefersBetaDefaultsKey) }
+        set { UserDefaults.standard.set(newValue, forKey: prefersBetaDefaultsKey) }
+    }
+
+    /// Resolved HTTPS appcast URL for the current preference.
+    static func resolvedFeedURLString() -> String {
+        let stable = Bundle.main.object(forInfoDictionaryKey: "ClipRelaySparkleFeedStable") as? String
+            ?? Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String
+        let beta = Bundle.main.object(forInfoDictionaryKey: "ClipRelaySparkleFeedBeta") as? String
+        let fallbackStable = stable ?? "https://updates.cliprelay.org/appcast.xml"
+        let fallbackBeta = beta ?? "https://updates.cliprelay.org/appcast-beta.xml"
+        return prefersBeta ? fallbackBeta : fallbackStable
+    }
+}
+
+/// Supplies `feedURLStringForUpdater:` without capturing `AppDelegate` before `super.init()`.
+final class ClipRelaySparkleUpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    func feedURLString(for updater: SPUUpdater) -> String? {
+        SparkleUpdateChannel.resolvedFeedURLString()
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -13,6 +13,8 @@ final class StatusBarController {
     var onToggleImageSync: (() -> Void)?
     var isImageSyncEnabled: (() -> Bool)?
     var isDeviceConnected: (() -> Bool)?
+    var onToggleBetaUpdateChannel: (() -> Void)?
+    var isBetaUpdateChannelEnabled: (() -> Bool)?
 
     private var availableUpdateVersion: String?
 
@@ -203,6 +205,17 @@ final class StatusBarController {
         }
         menu.addItem(autoUpdateItem)
 
+        let betaChannelItem = NSMenuItem(
+            title: "Beta Update Channel",
+            action: #selector(handleToggleBetaUpdateChannel),
+            keyEquivalent: ""
+        )
+        betaChannelItem.target = self
+        if isBetaUpdateChannelEnabled?() == true {
+            betaChannelItem.image = NSImage(systemSymbolName: "checkmark", accessibilityDescription: "enabled")
+        }
+        menu.addItem(betaChannelItem)
+
         menu.addItem(NSMenuItem.separator())
 
         menu.addItem(NSMenuItem(
@@ -298,6 +311,12 @@ final class StatusBarController {
     @objc
     private func handleToggleAutoUpdates() {
         updaterController.updater.automaticallyChecksForUpdates.toggle()
+        renderMenu()
+    }
+
+    @objc
+    private func handleToggleBetaUpdateChannel() {
+        onToggleBetaUpdateChannel?()
         renderMenu()
     }
 

--- a/macos/ClipRelayMac/Sources/App/UpdaterDriverDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/UpdaterDriverDelegate.swift
@@ -17,6 +17,10 @@ final class UpdaterDriverDelegate: NSObject, SPUStandardUserDriverDelegate {
     /// Called when availableUpdateVersion changes so the menu can refresh.
     var onUpdateAvailabilityChanged: (() -> Void)?
 
+    func clearAvailableUpdateBadge() {
+        availableUpdateVersion = nil
+    }
+
     var supportsGentleScheduledUpdateReminders: Bool { true }
 
     func standardUserDriverWillHandleShowingUpdate(

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -13,6 +13,10 @@ ANDROID_PROJECT_DIR="$ROOT_DIR/android"
 # EdDSA public key for Sparkle update signature verification.
 # This is the verification (public) key — safe to commit. Override via SPARKLE_PUBLIC_KEY env var if needed.
 SPARKLE_PUBLIC_KEY="${SPARKLE_PUBLIC_KEY:-MvvTVBZwmJX4xjRViW6SBISRMDdzdVkVdO5KVB/7z8I=}"
+SPARKLE_FEED_STABLE="${CLIPRELAY_SPARKLE_FEED_URL:-https://updates.cliprelay.org/appcast.xml}"
+SPARKLE_FEED_BETA="${CLIPRELAY_SPARKLE_FEED_URL_BETA:-https://updates.cliprelay.org/appcast-beta.xml}"
+# Default SUFeedURL in Info.plist (Sparkle fallback). Runtime channel uses both stable + beta keys.
+SPARKLE_INFO_DEFAULT_FEED="$SPARKLE_FEED_STABLE"
 SPARKLE_PLIST_KEYS="<key>SUPublicEDKey</key>
     <string>${SPARKLE_PUBLIC_KEY}</string>"
 
@@ -27,10 +31,12 @@ Usage: ./scripts/build-all.sh [options]
 Builds the macOS app bundle and Android app artifacts.
 
 Options:
-  --mac-only       Build only macOS app
-  --android-only   Build only Android artifacts
-  --release        Build Android release AAB/APK instead of debug APK
-  -h, --help       Show this help message
+  --mac-only           Build only macOS app
+  --android-only       Build only Android artifacts
+  --release            Build Android release AAB/APK instead of debug APK
+  --sparkle-feed-url   macOS: set stable + default SUFeedURL (overrides CLIPRELAY_SPARKLE_FEED_URL)
+  --beta-mac           macOS: point SUFeedURL at the beta appcast (testing only; use menu toggle at runtime)
+  -h, --help           Show this help message
 EOF
 }
 
@@ -46,6 +52,19 @@ while [[ $# -gt 0 ]]; do
       ;;
     --release)
       ANDROID_RELEASE=true
+      shift
+      ;;
+    --sparkle-feed-url)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing URL for --sparkle-feed-url" >&2
+        exit 1
+      fi
+      SPARKLE_FEED_STABLE="$2"
+      SPARKLE_INFO_DEFAULT_FEED="$SPARKLE_FEED_STABLE"
+      shift 2
+      ;;
+    --beta-mac)
+      SPARKLE_INFO_DEFAULT_FEED="$SPARKLE_FEED_BETA"
       shift
       ;;
     -h|--help)
@@ -146,7 +165,11 @@ build_mac() {
   <key>LSUIElement</key>
   <true/>
   <key>SUFeedURL</key>
-  <string>https://updates.cliprelay.org/appcast.xml</string>
+  <string>${SPARKLE_INFO_DEFAULT_FEED}</string>
+  <key>ClipRelaySparkleFeedStable</key>
+  <string>${SPARKLE_FEED_STABLE}</string>
+  <key>ClipRelaySparkleFeedBeta</key>
+  <string>${SPARKLE_FEED_BETA}</string>
   <key>SUScheduledCheckInterval</key>
   <integer>7200</integer>
   ${SPARKLE_PLIST_KEYS}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,29 +10,51 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 PLATFORMS=()
 VERSION=""
+# macOS workflow_dispatch: git ref to build and Sparkle feed to update
+MAC_GIT_REF=""
+MAC_SPARKLE_CHANNEL="stable"
 
 usage() {
-    cat <<'EOF'
+  cat <<'EOF'
 Usage: ./scripts/release.sh --mac|--android|--all <version>
 
 Options:
-  --mac       Release macOS only
-  --android   Release Android only
-  --all       Release both platforms
-  -h, --help  Show this help
+  --mac                Release macOS only
+  --android            Release Android only
+  --all                Release both platforms
+  --beta               macOS: release from branch beta (integration); updates beta Sparkle feed
+  --git-ref <ref>      macOS: branch or ref for CI checkout (default: main, or beta with --beta)
+  --sparkle-channel <stable|beta>  macOS: which appcast to update (default: stable)
+  -h, --help           Show this help
 
 Example:
   ./scripts/release.sh --mac 0.3.2
+  ./scripts/release.sh --mac 0.4.0 --beta
   ./scripts/release.sh --all 0.4.0
 EOF
-    exit 1
+  exit 1
 }
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
+  case "$1" in
         --mac) PLATFORMS+=("mac"); shift ;;
         --android) PLATFORMS+=("android"); shift ;;
         --all) PLATFORMS+=("mac" "android"); shift ;;
+        --beta)
+            MAC_GIT_REF="beta"
+            MAC_SPARKLE_CHANNEL="beta"
+            shift
+            ;;
+        --git-ref)
+            [[ $# -lt 2 ]] && usage
+            MAC_GIT_REF="$2"
+            shift 2
+            ;;
+        --sparkle-channel)
+            [[ $# -lt 2 ]] && usage
+            MAC_SPARKLE_CHANNEL="$2"
+            shift 2
+            ;;
         -h|--help) usage ;;
         *)
             if [[ -z "$VERSION" ]]; then
@@ -48,17 +70,49 @@ done
 
 [[ ${#PLATFORMS[@]} -eq 0 || -z "$VERSION" ]] && usage
 
+if [[ "$MAC_SPARKLE_CHANNEL" != "stable" && "$MAC_SPARKLE_CHANNEL" != "beta" ]]; then
+    echo "Error: --sparkle-channel must be stable or beta" >&2
+    exit 1
+fi
+
 # Validate semver format
 if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
     echo "Error: Version must be semver (e.g., 0.3.2)" >&2
     exit 1
 fi
 
-# Confirm on main branch
 BRANCH=$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD)
-if [[ "$BRANCH" != "main" ]]; then
-    echo "Error: Must be on main branch (currently on '$BRANCH')" >&2
-    exit 1
+if [[ -z "$MAC_GIT_REF" ]]; then
+    MAC_GIT_REF="main"
+fi
+
+# Android releases stay on main; macOS can track a long-lived beta branch.
+if printf '%s\n' "${PLATFORMS[@]}" | grep -q '^android$'; then
+    if [[ "$BRANCH" != "main" ]]; then
+        echo "Error: Android releases must be run from main (currently on '$BRANCH')" >&2
+        exit 1
+    fi
+fi
+
+if printf '%s\n' "${PLATFORMS[@]}" | grep -q '^mac$'; then
+    if [[ "$BRANCH" != "$MAC_GIT_REF" ]]; then
+        echo "Error: macOS release uses git ref '$MAC_GIT_REF' but workspace is on '$BRANCH'. Check out the matching branch." >&2
+        exit 1
+    fi
+    if [[ "$MAC_GIT_REF" == "main" && "$MAC_SPARKLE_CHANNEL" == "beta" ]]; then
+        echo "Warning: Updating beta Sparkle feed while on main is unusual — confirm this is intentional." >&2
+    fi
+fi
+
+if printf '%s\n' "${PLATFORMS[@]}" | grep -q '^android$' && printf '%s\n' "${PLATFORMS[@]}" | grep -q '^mac$'; then
+    if [[ "$BRANCH" != "main" ]]; then
+        echo "Error: Combined --all releases must be run from main" >&2
+        exit 1
+    fi
+    if [[ "$MAC_GIT_REF" != "main" || "$MAC_SPARKLE_CHANNEL" != "stable" ]]; then
+        echo "Error: Use separate ./scripts/release.sh --android and --mac ... --beta for mixed channels" >&2
+        exit 1
+    fi
 fi
 
 # Confirm working tree is clean
@@ -113,7 +167,14 @@ for platform in "${PLATFORMS[@]}"; do
         android) WORKFLOW="release-android.yml" ;;
     esac
     echo "==> Dispatching $WORKFLOW with version=$VERSION..."
-    gh workflow run "$WORKFLOW" --repo "$REPO" -f version="$VERSION"
+    if [[ "$platform" == "mac" ]]; then
+        gh workflow run "$WORKFLOW" --repo "$REPO" \
+            -f version="$VERSION" \
+            -f git_ref="$MAC_GIT_REF" \
+            -f sparkle_channel="$MAC_SPARKLE_CHANNEL"
+    else
+        gh workflow run "$WORKFLOW" --repo "$REPO" -f version="$VERSION"
+    fi
 
     echo "    Polling for workflow run..."
     RUN_URL=""

--- a/scripts/sparkle-appcast-beta-skeleton.xml
+++ b/scripts/sparkle-appcast-beta-skeleton.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>ClipRelay Beta</title>
+        <description>Beta updates for ClipRelay (integration builds).</description>
+        <language>en</language>
+    </channel>
+</rss>


### PR DESCRIPTION
Adds a menu toggle for the beta Sparkle feed, embeds stable/beta appcast URLs in Info.plist, extends `release-mac.yml` (`git_ref`, `sparkle_channel`) and `release.sh` (`--beta`) for a long-lived `beta` branch, and documents hosting `appcast-beta.xml`.

Made with [Cursor](https://cursor.com)