### PR TITLE
[codex] Keep website download link on stable macOS releases

### DIFF
--- a/website/js/download.js
+++ b/website/js/download.js
@@ -6,7 +6,7 @@
         try {
             const response = await fetch(API_URL + '?per_page=10');
             const releases = await response.json();
-            const macRelease = releases.find(r =>
+            const response = await fetch(API_URL + '?per_page=50');
                 r.tag_name.startsWith('mac/') &&
                 !r.prerelease &&
                 !r.draft


### PR DESCRIPTION
## What changed
Filter the website's macOS download resolver to ignore GitHub draft and prerelease releases.

## Why
Beta macOS releases were being surfaced by the public website because the resolver picked the first `mac/` release returned by the GitHub Releases API. That moved the main download button to beta artifacts, which should stay off the stable website path.

## Impact
The public website will keep linking to the latest stable macOS DMG, while beta releases can still be published on GitHub without affecting the main download link.

## Root cause
`website/js/download.js` only matched `tag_name.startsWith('mac/')` and did not filter out `prerelease` or `draft` releases.

## Validation
- `./scripts/test-all.sh`
- `./scripts/build-all.sh`
- `adb get-state` returned no connected device, so hardware smoke tests and Android restart were skipped
- Restarted macOS app with `open dist/ClipRelay.app`
