### PR TITLE
[codex] Fix release workflow dispatch args under nounset

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -127,12 +127,12 @@ for platform in "${PLATFORMS[@]}"; do
         mac) WORKFLOW="release-mac.yml" ;;
         android) WORKFLOW="release-android.yml" ;;
     esac
-    EXTRA_ARGS=()
+    GH_WORKFLOW_ARGS=(--repo "$REPO" --ref "$BRANCH" -f version="$VERSION")
     if [[ "$IS_BETA" == "true" ]]; then
-        EXTRA_ARGS=(-f beta=true -f "ref=$BRANCH")
+        GH_WORKFLOW_ARGS+=(-f beta=true -f "ref=$BRANCH")
     fi
     echo "==> Dispatching $WORKFLOW with version=$VERSION (beta=$IS_BETA)..."
-    gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" -f version="$VERSION" "${EXTRA_ARGS[@]}"
+    gh workflow run "$WORKFLOW" "${GH_WORKFLOW_ARGS[@]}"
 
     echo "    Polling for workflow run..."
     RUN_URL=""


### PR DESCRIPTION
## What changed
- replace the optional `EXTRA_ARGS` array in `scripts/release.sh` with a single `GH_WORKFLOW_ARGS` array that is always initialized
- append beta-only flags onto that array instead of expanding an empty array under `set -u`

## Why
Running `./scripts/release.sh --all 0.5.0` failed after dispatching the macOS workflow with:
`line 135: EXTRA_ARGS[@]: unbound variable`

On Bash setups that treat empty array expansion as unset when `nounset` is enabled, `"${EXTRA_ARGS[@]}"` aborts even when the array was assigned `()`. Building the full argument list in one initialized array avoids that failure path.

## Impact
- stable releases continue to dispatch with `version`
- beta/pre-release dispatches still include `beta=true` and the branch ref
- `gh workflow run` no longer crashes when there are no extra flags to pass

## Validation
- `bash -n scripts/release.sh`
- `./scripts/build-all.sh`
- `./scripts/test-all.sh` could not be completed in this session because sandbox elevation for `~/.gradle` lockfile access was denied
- `adb get-state` returned `device`
- `scripts/hardware-smoke-test.sh` ran but failed during macOS pairing-token import with `Abort trap: 6`
