### PR TITLE
Fix Mac download button redirecting to GitHub releases

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -24,7 +24,7 @@ The website is hosted on **Cloudflare Pages**.
 ### Deploy command
 
 ```bash
-npx wrangler pages deploy website --project-name cliprelay --commit-dirty=true
+npx wrangler pages deploy website --project-name cliprelay --commit-dirty=true --branch main
 ```
 
 ### Authentication

--- a/website/_headers
+++ b/website/_headers
@@ -1,0 +1,5 @@
+/js/*
+  Cache-Control: no-cache
+
+/css/*
+  Cache-Control: no-cache

--- a/website/index.html
+++ b/website/index.html
@@ -125,7 +125,7 @@
       <a href="https://play.google.com/store/apps/details?id=org.cliprelay" target="_blank" rel="noopener" class="store-badge">
         <img src="assets/google-play-badge.svg" alt="Get it on Google Play">
       </a>
-      <a href="/downloads/ClipRelay.dmg" data-download="mac" class="btn btn-outline">
+      <a href="https://github.com/geekflyer/cliprelay/releases" data-download="mac" class="btn btn-outline">
         <!-- Apple icon -->
         <svg class="btn-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
         Download for Mac
@@ -557,7 +557,7 @@
           <h4>Download</h4>
           <ul>
             <li><a href="https://play.google.com/store/apps/details?id=org.cliprelay">Google Play</a></li>
-            <li><a href="/downloads/ClipRelay.dmg" data-download="mac">macOS Download</a></li>
+            <li><a href="https://github.com/geekflyer/cliprelay/releases" data-download="mac">macOS Download</a></li>
           </ul>
         </div>
 

--- a/website/js/download.js
+++ b/website/js/download.js
@@ -4,9 +4,9 @@
 
     async function getLatestMacDownloadUrl() {
         try {
-            const response = await fetch(API_URL + '?per_page=10');
-            const releases = await response.json();
             const response = await fetch(API_URL + '?per_page=50');
+            const releases = await response.json();
+            const macRelease = releases.find(r =>
                 r.tag_name.startsWith('mac/') &&
                 !r.prerelease &&
                 !r.draft


### PR DESCRIPTION
## Summary
- Fixed broken JavaScript in `download.js` that had a duplicate `const response` declaration and missing `.find()` call, causing a SyntaxError that prevented the direct .dmg download URL from resolving
- Changed fallback `href` in `index.html` from non-existent `/downloads/ClipRelay.dmg` to the GitHub releases page, so users who click before JS loads land somewhere useful
- Added `_headers` file to set `Cache-Control: no-cache` on JS/CSS assets so Cloudflare revalidates on each deploy

## Test plan
- [ ] Open https://cliprelay.org, inspect the Mac download link href — should be a direct `.dmg` URL
- [ ] Click the Mac download button — should start a direct download, not navigate to GitHub releases
- [ ] Check browser DevTools console for no JavaScript errors