### PR TITLE
Website: fix deep-link asset resolution on Cloudflare Pages

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -7,6 +7,9 @@
   <meta name="description" content="ClipRelay — clipboard sharing between Android and Mac. End-to-end encrypted. Bluetooth only. No cloud or servers.">
   <meta name="theme-color" content="#111820">
 
+  <!-- Ensure relative asset URLs resolve correctly on any path -->
+  <base href="/">
+
   <!-- Canonical -->
   <link rel="canonical" href="https://cliprelay.org/">
 

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -7,6 +7,9 @@
   <meta name="description" content="ClipRelay privacy policy. Your clipboard stays between your devices. Only anonymous usage check-ins are collected.">
   <meta name="theme-color" content="#111820">
 
+  <!-- Ensure relative asset URLs resolve correctly on any path -->
+  <base href="/">
+
   <link rel="canonical" href="https://cliprelay.org/privacy.html">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem
Visiting arbitrary deep paths (e.g. `/downloads/ssdsaf`) could render a broken-looking page because the static site uses relative `css/` and `js/` URLs; when the hosting layer serves the HTML shell on a deep path, the browser resolves assets under that path and they 404.

### Fix
Add `<base href="/">` so relative asset URLs always resolve from the site root.

### Changes
- Add root base URL to `website/index.html`.
- Add root base URL to `website/privacy.html`.

### How to verify
- Visit `https://cliprelay.org/downloads/ssdsaf` and confirm CSS/JS load and the site renders normally.
- Visit `https://cliprelay.org/privacy.html` and confirm styling still loads correctly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d26fcef2-854f-4518-b635-1e4461f24ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d26fcef2-854f-4518-b635-1e4461f24ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

