### PR TITLE
fix(protocol): handle CONFIG_UPDATE during in-flight transfers

### DIFF
--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -359,7 +359,7 @@ class Session(
         MessageCodec.write(output, offer)
 
         // Wait for ACCEPT or DONE
-        val response = readWithTimeout(transferTimeoutMs)
+        val response = readWithConfigUpdates(transferTimeoutMs)
         when (response.type) {
             MessageType.ACCEPT -> {
                 // Send PAYLOAD
@@ -367,7 +367,7 @@ class Session(
                 MessageCodec.write(output, payload)
 
                 // Wait for DONE
-                val done = readWithTimeout(transferTimeoutMs)
+                val done = readWithConfigUpdates(transferTimeoutMs)
                 if (done.type != MessageType.DONE) {
                     throw ProtocolException("Expected DONE, got ${done.type}")
                 }
@@ -410,7 +410,7 @@ class Session(
         MessageCodec.write(output, offer)
 
         // Read response: ACCEPT, REJECT, or ERROR
-        val response = readWithTimeout(transferTimeoutMs)
+        val response = readWithConfigUpdates(transferTimeoutMs)
         when (response.type) {
             MessageType.ACCEPT -> {
                 val acceptJson = JSONObject(String(response.payload))
@@ -457,7 +457,7 @@ class Session(
                 }
 
                 // Wait for DONE or ERROR
-                val done = readWithTimeout(transferTimeoutMs)
+                val done = readWithConfigUpdates(transferTimeoutMs)
                 when (done.type) {
                     MessageType.DONE -> {
                         callback.onTransferComplete(hash)
@@ -626,7 +626,7 @@ class Session(
         MessageCodec.write(output, accept)
 
         // Wait for PAYLOAD
-        val payload = readWithTimeout(transferTimeoutMs)
+        val payload = readWithConfigUpdates(transferTimeoutMs)
         if (payload.type != MessageType.PAYLOAD) {
             throw ProtocolException("Expected PAYLOAD, got ${payload.type}")
         }
@@ -682,6 +682,29 @@ class Session(
         }
         // Otherwise (during handshake), read directly from the stream
         return readDirectWithTimeout(timeoutMs)
+    }
+
+    /**
+     * Read the next transfer-related message while allowing CONFIG_UPDATE to
+     * arrive out of band. Settings changes should not poison an active
+     * transfer's request/response flow.
+     */
+    private fun readWithConfigUpdates(timeoutMs: Long): Message {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (!closed.get()) {
+            val remaining = deadline - System.currentTimeMillis()
+            if (remaining <= 0) {
+                throw ProtocolException("Timeout waiting for message (${timeoutMs}ms)")
+            }
+
+            val msg = readWithTimeout(remaining)
+            if (msg.type == MessageType.CONFIG_UPDATE) {
+                handleConfigUpdate(msg)
+                continue
+            }
+            return msg
+        }
+        throw ProtocolException("Session closed while waiting for message")
     }
 
     private fun readDirectWithTimeout(timeoutMs: Long): Message {

--- a/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
+++ b/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
@@ -1194,6 +1194,83 @@ class SessionTest {
         macInput.close(); toMac.close(); macOutput.close(); fromMac.close()
     }
 
+    @Test
+    fun `sendClipboard ignores interleaved CONFIG_UPDATE before ACCEPT`() {
+        val macInput = PipedInputStream()
+        val toMac = PipedOutputStream(macInput)
+        val macOutput = PipedOutputStream()
+        val fromMac = PipedInputStream(macOutput)
+
+        val sp = TestSettingsProvider(enabled = false, changedAt = 1000)
+        val readyLatch = CountDownLatch(1)
+        val transferLatch = CountDownLatch(1)
+        val settingChangedLatch = CountDownLatch(1)
+        val errorLatch = CountDownLatch(1)
+        var capturedError: Exception? = null
+        val callback = TestCallback()
+        callback.onReady = { readyLatch.countDown() }
+        callback.onTransfer = { transferLatch.countDown() }
+        callback.onRichMediaChanged = { enabled ->
+            assertTrue(enabled)
+            settingChangedLatch.countDown()
+        }
+        callback.onError = { error ->
+            capturedError = error
+            errorLatch.countDown()
+        }
+
+        val session = Session(
+            input = macInput,
+            output = macOutput,
+            isInitiator = true,
+            callback = callback,
+            sharedSecretHex = testSharedSecret,
+            handshakeTimeoutMs = 2000,
+            transferTimeoutMs = 2000,
+            settingsProvider = sp
+        )
+
+        Thread {
+            session.performHandshake()
+            session.listenForMessages()
+        }.start()
+
+        val hello = MessageCodec.decode(fromMac)
+        sendValidWelcome(toMac, hello)
+        assertTrue("Session should be ready", readyLatch.await(3, TimeUnit.SECONDS))
+
+        session.sendClipboard("config-before-accept".toByteArray())
+
+        val offer = MessageCodec.decode(fromMac)
+        assertEquals(MessageType.OFFER, offer.type)
+
+        val configJson = JSONObject().apply {
+            put("richMediaEnabled", true)
+            put("richMediaEnabledChangedAt", 2000L)
+        }
+        MessageCodec.write(toMac, Message(MessageType.CONFIG_UPDATE, configJson.toString().toByteArray()))
+        MessageCodec.write(toMac, Message(MessageType.ACCEPT, ByteArray(0)))
+
+        val payload = MessageCodec.decode(fromMac)
+        assertEquals(MessageType.PAYLOAD, payload.type)
+
+        val doneJson = JSONObject().apply {
+            put("hash", "ignored")
+            put("ok", true)
+        }
+        MessageCodec.write(toMac, Message(MessageType.DONE, doneJson.toString().toByteArray()))
+
+        assertTrue("Setting change should be applied", settingChangedLatch.await(3, TimeUnit.SECONDS))
+        assertTrue("Transfer should complete", transferLatch.await(3, TimeUnit.SECONDS))
+        assertFalse("Session should not fail", errorLatch.await(500, TimeUnit.MILLISECONDS))
+        assertNull("Unexpected session error", capturedError)
+        assertTrue("Rich media should be enabled locally", sp.enabled)
+        assertEquals("ChangedAt should update from config", 2000L, sp.changedAt)
+
+        session.close()
+        macInput.close(); toMac.close(); macOutput.close(); fromMac.close()
+    }
+
     // ── Image transfer tests ───────────────────────────────────────
 
     @Test

--- a/macos/ClipRelayMac/Sources/Protocol/Session.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/Session.swift
@@ -442,7 +442,7 @@ final class Session {
         try writeMessage(offer)
 
         // Wait for ACCEPT or DONE
-        let response = try readWithTimeout(transferTimeoutSeconds)
+        let response = try readWithConfigUpdates(timeout: transferTimeoutSeconds)
         switch response.type {
         case .accept:
             // Send PAYLOAD
@@ -450,7 +450,7 @@ final class Session {
             try writeMessage(payload)
 
             // Wait for DONE
-            let done = try readWithTimeout(transferTimeoutSeconds)
+            let done = try readWithConfigUpdates(timeout: transferTimeoutSeconds)
             guard done.type == .done else {
                 throw SessionError.unexpectedMessage("Expected DONE, got \(done.type)")
             }
@@ -489,7 +489,7 @@ final class Session {
         try writeMessage(offer)
 
         // Read response: ACCEPT, REJECT, or ERROR
-        let response = try readWithTimeout(transferTimeoutSeconds)
+        let response = try readWithConfigUpdates(timeout: transferTimeoutSeconds)
         switch response.type {
         case .accept:
             guard let acceptJson = try? JSONSerialization.jsonObject(with: response.payload) as? [String: Any],
@@ -537,7 +537,7 @@ final class Session {
             }
 
             // Wait for DONE or ERROR
-            let done = try readWithTimeout(transferTimeoutSeconds)
+            let done = try readWithConfigUpdates(timeout: transferTimeoutSeconds)
             switch done.type {
             case .done:
                 delegate?.session(self, didCompleteTransfer: hash)
@@ -696,7 +696,7 @@ final class Session {
         try writeMessage(accept)
 
         // Wait for PAYLOAD
-        let payload = try readWithTimeout(transferTimeoutSeconds)
+        let payload = try readWithConfigUpdates(timeout: transferTimeoutSeconds)
         guard payload.type == .payload else {
             throw SessionError.unexpectedMessage("Expected PAYLOAD, got \(payload.type)")
         }
@@ -751,6 +751,27 @@ final class Session {
                 return try MessageCodec.decode(from: inputStream)
             }
             Thread.sleep(forTimeInterval: min(0.01, remaining))
+        }
+        throw SessionError.sessionClosed
+    }
+
+    /// Read the next transfer-related message while allowing CONFIG_UPDATE to
+    /// arrive out of band. Settings changes should not poison an active
+    /// transfer's request/response flow.
+    private func readWithConfigUpdates(timeout: TimeInterval) throws -> Message {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !closed {
+            let remaining = deadline.timeIntervalSinceNow
+            if remaining <= 0 {
+                throw SessionError.timeout("Timeout waiting for message (\(timeout)s)")
+            }
+
+            let msg = try readWithTimeout(remaining)
+            if msg.type == .configUpdate {
+                handleConfigUpdate(msg)
+                continue
+            }
+            return msg
         }
         throw SessionError.sessionClosed
     }

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/SessionTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/SessionTests.swift
@@ -1225,6 +1225,69 @@ final class SessionTests: XCTestCase {
         cleanup(env)
     }
 
+    func testSendClipboardIgnoresInterleavedConfigUpdateBeforeAccept() {
+        let env = createManualStreams()
+        let sp = TestSettingsProvider(richMediaEnabled: false, richMediaEnabledChangedAt: 1000)
+        let readyExpectation = expectation(description: "Session ready")
+        let transferExpectation = expectation(description: "Transfer complete")
+        let settingChangedExpectation = expectation(description: "Setting changed")
+
+        let delegate = TestSessionDelegate()
+        delegate.onReady = { _ in readyExpectation.fulfill() }
+        delegate.onTransferComplete = { _, _ in transferExpectation.fulfill() }
+        delegate.onRichMediaChanged = { _, enabled in
+            XCTAssertTrue(enabled)
+            settingChangedExpectation.fulfill()
+        }
+        delegate.onError = { _, error in
+            XCTFail("Session should not fail on interleaved CONFIG_UPDATE: \(error)")
+        }
+
+        let session = Session(inputStream: env.sessionInput, outputStream: env.sessionOutput,
+                              isInitiator: true, delegate: delegate,
+                              sharedSecretHex: testSharedSecret)
+        session.handshakeTimeoutSeconds = 3.0
+        session.transferTimeoutSeconds = 3.0
+        session.settingsProvider = sp
+
+        DispatchQueue.global().async {
+            session.performHandshake()
+            session.listenForMessages()
+        }
+
+        let hello = try? MessageCodec.decode(from: env.readFromSession)
+        sendValidWelcome(to: env.writeToSession, hello: hello!)
+        wait(for: [readyExpectation], timeout: 3.0)
+
+        session.sendClipboard(Data("config-before-accept".utf8))
+
+        let offer = try? MessageCodec.decode(from: env.readFromSession)
+        XCTAssertEqual(offer?.type, .offer)
+
+        let configJSON: [String: Any] = [
+            "richMediaEnabled": true,
+            "richMediaEnabledChangedAt": 2000
+        ]
+        let configData = try! JSONSerialization.data(withJSONObject: configJSON)
+        writeMessage(Message(type: .configUpdate, payload: configData), to: env.writeToSession)
+
+        writeMessage(Message(type: .accept, payload: Data()), to: env.writeToSession)
+
+        let payload = try? MessageCodec.decode(from: env.readFromSession)
+        XCTAssertEqual(payload?.type, .payload)
+
+        let doneJSON: [String: Any] = ["hash": "ignored", "ok": true]
+        let doneData = try! JSONSerialization.data(withJSONObject: doneJSON)
+        writeMessage(Message(type: .done, payload: doneData), to: env.writeToSession)
+
+        wait(for: [settingChangedExpectation, transferExpectation], timeout: 3.0)
+        XCTAssertTrue(sp.richMediaEnabled)
+        XCTAssertEqual(sp.richMediaEnabledChangedAt, 2000)
+
+        session.close()
+        cleanupManual(env)
+    }
+
     func testConcurrentTransferCancellationNewOfferCancelsInFlight() {
         // Start receiving image A (TCP server started), then verify it can be cancelled
         let env = createManualStreams()


### PR DESCRIPTION
Applies CONFIG_UPDATE handling inside transfer read loops on macOS and Android so image-sync toggles cannot interleave with OFFER/ACCEPT/DONE/PAYLOAD and wedge the session.

Includes regression tests for CONFIG_UPDATE arriving before ACCEPT during a clipboard send.

Made with [Cursor](https://cursor.com)