### PR TITLE
fix(macos): refresh paired-devices menu after forget completes

### DIFF
--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -178,8 +178,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Device Management
 
     private func forgetDevice(token: String) {
-        connectionController.forgetDevice(token: token)
-        refreshTrustedPeersMenu()
+        connectionController.forgetDevice(token: token) { [weak self] in
+            self?.refreshTrustedPeersMenu()
+        }
     }
 
     // MARK: - Bluetooth Alert

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -478,7 +478,7 @@ extension ConnectionController {
 
     // MARK: Device Management
 
-    func forgetDevice(token: String) {
+    func forgetDevice(token: String, completion: (() -> Void)? = nil) {
         queue.async { [self] in
             pairingManager.removeDevice(secret: token)
             switch state {
@@ -495,6 +495,9 @@ extension ConnectionController {
             }
             if case .idle = state, !pairingManager.loadDevices().isEmpty {
                 startScanning()
+            }
+            if let completion {
+                DispatchQueue.main.async(execute: completion)
             }
         }
     }


### PR DESCRIPTION
## Summary

When choosing **Forget Device** from the menu bar, the first click appeared to do nothing because `refreshTrustedPeersMenu()` ran on the main thread immediately, while `pairingManager.removeDevice` ran asynchronously on the connection queue. The menu was rebuilt from the keychain before removal finished.

This defers the menu refresh until `forgetDevice` completes on the connection queue, then runs the refresh on the main queue via an optional completion callback.

## Testing

- `scripts/build-all.sh` and `scripts/test-all.sh` passed locally.

Made with [Cursor](https://cursor.com)