### PR TITLE
Add Cursor Cloud specific dev environment instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,24 @@
 - Use `adb exec-out screencap -p > /tmp/cliprelay-screenshot.png` to capture, then read the image to visually inspect the layout.
 - Use this as a feedback loop: if something looks off, fix it before committing.
 - This applies to any change affecting UI layout, colors, spacing, icons, animations, or theming.
+
+## Cursor Cloud specific instructions
+
+This is a dual-platform project (Android + macOS). On Linux-based Cloud Agent VMs, only the **Android app** can be built and tested. The macOS app requires macOS with Xcode CLI tools (`swift` compiler + CoreBluetooth framework) and cannot be built on Linux.
+
+### Environment
+- **Android SDK** is installed at `/opt/android-sdk`. `ANDROID_HOME` is set in `~/.bashrc`.
+- **JDK 21** is pre-installed (JDK 17+ is required by the Gradle build).
+- Gradle wrapper (`android/gradlew`) auto-downloads Gradle 9.4.0 on first run.
+
+### Key commands (Android-only on Linux)
+- **Build**: `./scripts/build-all.sh --android-only` — produces `dist/cliprelay-debug.apk`
+- **Unit tests**: `cd android && ./gradlew testDebugUnitTest` (116 tests across 10 suites)
+- **Lint**: `cd android && ./gradlew lintDebug` — note: pre-existing lint errors exist (3 errors, 54 warnings); CI does not gate on lint.
+- **Full test suite**: `scripts/test-all.sh` requires `swift` so will fail on Linux; run Android tests directly instead.
+- **Full build**: `scripts/build-all.sh` requires `swift` so will fail on Linux; use `--android-only` flag.
+
+### Caveats
+- No Android device is available in Cloud Agent VMs, so hardware smoke tests (`scripts/hardware-smoke-test.sh`) and APK installation/restart steps from AGENTS.md cannot be performed. Skip those and report them as skipped.
+- The website (`website/`) is static HTML/CSS/JS with no build step. Deployment requires `wrangler` + Cloudflare auth.
+- Release signing (Android AAB/APK) requires keystore credentials not present in the VM. Debug builds work without them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,8 @@ This is a dual-platform project (Android + macOS). On Linux-based Cloud Agent VM
 
 ### Key commands (Android-only on Linux)
 - **Build**: `./scripts/build-all.sh --android-only` — produces `dist/cliprelay-debug.apk`
-- **Unit tests**: `cd android && ./gradlew testDebugUnitTest` (116 tests across 10 suites)
-- **Lint**: `cd android && ./gradlew lintDebug` — note: pre-existing lint errors exist (3 errors, 54 warnings); CI does not gate on lint.
+- **Unit tests**: `cd android && ./gradlew testDebugUnitTest`
+- **Lint**: `cd android && ./gradlew lintDebug` — note: pre-existing lint errors and warnings exist; CI does not gate on lint.
 - **Full test suite**: `scripts/test-all.sh` requires `swift` so will fail on Linux; run Android tests directly instead.
 - **Full build**: `scripts/build-all.sh` requires `swift` so will fail on Linux; use `--android-only` flag.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting the Linux-based Cloud Agent development environment for this dual-platform (Android + macOS) project.

### What's included

- Android SDK location (`/opt/android-sdk`) and JDK requirements
- Key build/test commands scoped to Android-only (Linux limitation)
- Caveats about macOS builds, hardware tests, lint baseline, and release signing
- Guidance for future Cloud Agents on what can/cannot run in the VM

### Environment verification

All commands verified working on Ubuntu 24.04 Cloud Agent VM:

- **Unit tests**: 116 tests across 10 suites, all passing
- **Debug build**: `dist/cliprelay-debug.apk` (~30 MB) built successfully
- **Lint**: Runs successfully; pre-existing warnings/errors noted (not gated in CI)

Build log:
[android_build.log](https://cursor.com/agents/bc-4c2c06c5-7976-48f8-9770-3615d01f2776/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fandroid_build.log)

Test log:
[android_unit_tests.log](https://cursor.com/agents/bc-4c2c06c5-7976-48f8-9770-3615d01f2776/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fandroid_unit_tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c2c06c5-7976-48f8-9770-3615d01f2776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c2c06c5-7976-48f8-9770-3615d01f2776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

