### PR TITLE
feat: add share logs support

### DIFF
--- a/android/app/src/main/java/org/cliprelay/feedback/LogShareExporter.kt
+++ b/android/app/src/main/java/org/cliprelay/feedback/LogShareExporter.kt
@@ -1,0 +1,88 @@
+package org.cliprelay.feedback
+
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.os.Process
+import androidx.core.content.FileProvider
+import java.io.File
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+object LogShareExporter {
+    private const val LOG_DIR = "shared_logs"
+    private const val LOG_FILE_PREFIX = "cliprelay-android-logs"
+    private const val LOG_LINE_LIMIT = "2000"
+    private val fileTimestampFormatter =
+        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss", Locale.US).withZone(ZoneOffset.UTC)
+
+    fun createShareIntent(context: Context, bleState: String): Intent {
+        val now = Instant.now()
+        val logFile = writeLogFile(context, now, bleState, captureLogcat())
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", logFile)
+        return Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_SUBJECT, "ClipRelay Android logs")
+            putExtra(Intent.EXTRA_STREAM, uri)
+            clipData = ClipData.newUri(context.contentResolver, "ClipRelay Android logs", uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+
+    internal fun writeLogFile(
+        context: Context,
+        now: Instant,
+        bleState: String,
+        logOutput: String
+    ): File {
+        val shareDir = File(context.cacheDir, LOG_DIR).apply { mkdirs() }
+        val file = File(shareDir, buildFileName(now))
+        file.writeText(buildFileContents(SupportLinks.diagnosticsContext(bleState), now, logOutput))
+        return file
+    }
+
+    internal fun buildFileName(now: Instant): String =
+        "$LOG_FILE_PREFIX-${fileTimestampFormatter.format(now)}.txt"
+
+    internal fun buildFileContents(
+        diagnosticsContext: List<Pair<String, String>>,
+        generatedAt: Instant,
+        logOutput: String
+    ): String = buildString {
+        appendLine("ClipRelay Android diagnostics")
+        appendLine("Generated: ${DateTimeFormatter.ISO_INSTANT.format(generatedAt)}")
+        appendLine("Included logs: current ClipRelay process logcat snapshot (up to $LOG_LINE_LIMIT lines)")
+        appendLine()
+        diagnosticsContext.forEach { (label, value) ->
+            appendLine("$label: $value")
+        }
+        appendLine()
+        appendLine("---- LOGCAT ----")
+        appendLine(logOutput.ifBlank { "No recent ClipRelay logs were available for this process." })
+    }
+
+    private fun captureLogcat(): String = runCatching {
+        val process = ProcessBuilder(
+            "logcat",
+            "-d",
+            "-v",
+            "threadtime",
+            "--pid=${Process.myPid()}",
+            "-t",
+            LOG_LINE_LIMIT
+        )
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText().trimEnd() }
+        val exitCode = process.waitFor()
+        if (exitCode == 0) {
+            output
+        } else {
+            "logcat exited with code $exitCode.\n$output"
+        }
+    }.getOrElse { error ->
+        "Unable to capture logcat: ${error.message ?: error.javaClass.simpleName}"
+    }
+}

--- a/android/app/src/main/java/org/cliprelay/feedback/SupportLinks.kt
+++ b/android/app/src/main/java/org/cliprelay/feedback/SupportLinks.kt
@@ -13,8 +13,11 @@ object SupportLinks {
         "Device" to "${Build.MANUFACTURER} ${Build.MODEL}",
     )
 
+    fun diagnosticsContext(bleState: String): List<Pair<String, String>> =
+        deviceContext() + ("BLE State" to bleState)
+
     fun gitHubIssueUrl(bleState: String): String {
-        val lines = (deviceContext() + ("BLE State" to bleState))
+        val lines = diagnosticsContext(bleState)
             .joinToString("\n") { "- **${it.first}:** ${it.second}" }
         val body = "\n\n---\n$lines"
         return Uri.parse("https://github.com/geekflyer/cliprelay/issues/new").buildUpon()
@@ -25,7 +28,7 @@ object SupportLinks {
     }
 
     fun emailUrl(bleState: String): String {
-        val lines = (deviceContext() + ("BLE State" to bleState))
+        val lines = diagnosticsContext(bleState)
             .joinToString("\n") { "${it.first}: ${it.second}" }
         val body = "\n\n---\n$lines"
         return "mailto:info@cliprelay.org" +

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -97,6 +97,7 @@ fun ClipRelayScreen(
     onAutoCopyFixClick: () -> Unit = {},
     onHelpClick: () -> Unit = {},
     onSupportLinkClick: (String) -> Unit = {},
+    onShareLogsClick: (String) -> Unit = {},
 ) {
     val isConnected = state is AppState.Connected
     val isPaired = state !is AppState.Unpaired
@@ -185,6 +186,7 @@ fun ClipRelayScreen(
                 bleState = if (isConnected) "connected" else if (isPaired) "searching" else "unpaired",
                 onHelpClick = onHelpClick,
                 onSupportLinkClick = onSupportLinkClick,
+                onShareLogsClick = onShareLogsClick,
             )
         }
 
@@ -902,7 +904,13 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawMacIcon(tint: C
 
 // ─── Footer ──────────────────────────────────────────────────────────────────
 @Composable
-private fun FooterSection(isPaired: Boolean, bleState: String = "unknown", onHelpClick: () -> Unit, onSupportLinkClick: (String) -> Unit) {
+private fun FooterSection(
+    isPaired: Boolean,
+    bleState: String = "unknown",
+    onHelpClick: () -> Unit,
+    onSupportLinkClick: (String) -> Unit,
+    onShareLogsClick: (String) -> Unit
+) {
     var showSupportDialog by remember { mutableStateOf(false) }
 
     Column(
@@ -948,17 +956,29 @@ private fun FooterSection(isPaired: Boolean, bleState: String = "unknown", onHel
                 showSupportDialog = false
                 onSupportLinkClick(url)
             },
+            onShareLogsClick = {
+                showSupportDialog = false
+                onShareLogsClick(bleState)
+            },
         )
     }
 }
 
 @Composable
-private fun SupportDialog(bleState: String, onDismiss: () -> Unit, onLinkClick: (String) -> Unit) {
+private fun SupportDialog(
+    bleState: String,
+    onDismiss: () -> Unit,
+    onLinkClick: (String) -> Unit,
+    onShareLogsClick: () -> Unit
+) {
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Feedback & Support") },
         text = {
             Column {
+                TextButton(onClick = onShareLogsClick) {
+                    Text(stringResource(R.string.support_share_logs), modifier = Modifier.fillMaxWidth())
+                }
                 TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.gitHubIssueUrl(bleState)) }) {
                     Text("Report Issue on GitHub", modifier = Modifier.fillMaxWidth())
                 }

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -24,12 +24,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
+import org.cliprelay.R
 import org.cliprelay.crypto.E2ECrypto
+import org.cliprelay.feedback.LogShareExporter
 import org.cliprelay.pairing.PairingStore
 import org.cliprelay.permissions.BlePermissions
 import org.cliprelay.service.ClipboardAccessibilityService
 import org.cliprelay.service.ClipRelayService
 import org.cliprelay.settings.ClipboardSettingsStore
+import kotlin.concurrent.thread
 
 class MainActivity : AppCompatActivity() {
 
@@ -200,6 +203,9 @@ class MainActivity : AppCompatActivity() {
                 onSupportLinkClick = { url ->
                     startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
                 },
+                onShareLogsClick = { bleState ->
+                    shareLogs(bleState)
+                },
             )
         }
     }
@@ -285,6 +291,33 @@ class MainActivity : AppCompatActivity() {
         }
         if (missing.isNotEmpty()) {
             permissionLauncher.launch(missing.toTypedArray())
+        }
+    }
+
+    private fun shareLogs(bleState: String) {
+        thread(name = "share-logs") {
+            val result = runCatching {
+                LogShareExporter.createShareIntent(applicationContext, bleState)
+            }
+            runOnUiThread {
+                result.onSuccess { shareIntent ->
+                    val chooser = Intent.createChooser(
+                        shareIntent,
+                        getString(R.string.share_logs_chooser_title)
+                    ).apply {
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        clipData = shareIntent.clipData
+                    }
+                    startActivity(chooser)
+                }.onFailure { error ->
+                    val reason = error.message ?: error.javaClass.simpleName
+                    Toast.makeText(
+                        this,
+                        getString(R.string.share_logs_failed, reason),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -47,4 +47,7 @@
     <string name="accessibility_disclosure_body">ClipRelay uses Android\'s Accessibility Service to detect when you copy text, so it can automatically send your clipboard to your paired Mac.\n\nThis permission allows ClipRelay to monitor tap actions only. It does not read, collect, or store any screen content or personal data.</string>
     <string name="accessibility_disclosure_allow">Allow</string>
     <string name="accessibility_disclosure_deny">Deny</string>
+    <string name="support_share_logs">Share Logs</string>
+    <string name="share_logs_chooser_title">Share ClipRelay logs</string>
+    <string name="share_logs_failed">Could not prepare logs to share: %1$s</string>
 </resources>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <cache-path name="shared_images" path="shared_images/" />
+    <cache-path name="shared_logs" path="shared_logs/" />
 </paths>

--- a/android/app/src/test/java/org/cliprelay/feedback/LogShareExporterTest.kt
+++ b/android/app/src/test/java/org/cliprelay/feedback/LogShareExporterTest.kt
@@ -1,0 +1,35 @@
+package org.cliprelay.feedback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class LogShareExporterTest {
+
+    @Test
+    fun `build file name uses utc timestamp`() {
+        val name = LogShareExporter.buildFileName(Instant.parse("2026-04-11T15:42:05Z"))
+
+        assertEquals("cliprelay-android-logs-20260411-154205.txt", name)
+    }
+
+    @Test
+    fun `build file contents includes diagnostics and logs`() {
+        val contents = LogShareExporter.buildFileContents(
+            diagnosticsContext = listOf(
+                "App Version" to "1.2.3 (abc123)",
+                "BLE State" to "connected"
+            ),
+            generatedAt = Instant.parse("2026-04-11T15:42:05Z"),
+            logOutput = "04-11 15:42:05.000 ClipRelayService: ready"
+        )
+
+        assertTrue(contents.contains("ClipRelay Android diagnostics"))
+        assertTrue(contents.contains("Generated: 2026-04-11T15:42:05Z"))
+        assertTrue(contents.contains("App Version: 1.2.3 (abc123)"))
+        assertTrue(contents.contains("BLE State: connected"))
+        assertTrue(contents.contains("---- LOGCAT ----"))
+        assertTrue(contents.contains("ClipRelayService: ready"))
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
+++ b/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
@@ -42,7 +42,6 @@ enum LogShareExporter {
 
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return "Unable to capture unified logs: \(error.localizedDescription)"
         }
@@ -51,6 +50,7 @@ enum LogShareExporter {
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let errorOutput = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        process.waitUntilExit()
 
         guard process.terminationStatus == 0 else {
             return """

--- a/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
+++ b/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+enum LogShareExporter {
+    private static let shareDirectoryName = "ClipRelaySharedLogs"
+
+    static func exportLogs(deviceContext: [(String, String)]) throws -> URL {
+        let now = Date()
+        let shareDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(shareDirectoryName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: shareDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let fileURL = shareDirectory.appendingPathComponent(buildFileName(for: now), isDirectory: false)
+        let contents = buildFileContents(
+            deviceContext: deviceContext,
+            generatedAt: now,
+            logs: captureUnifiedLogs()
+        )
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL
+    }
+
+    private static func captureUnifiedLogs() -> String {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        process.arguments = [
+            "show",
+            "--style",
+            "compact",
+            "--last",
+            "24h",
+            "--predicate",
+            "subsystem == \"org.cliprelay\"",
+        ]
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return "Unable to capture unified logs: \(error.localizedDescription)"
+        }
+
+        let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let errorOutput = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            return """
+            `log show` exited with status \(process.terminationStatus).
+
+            \(errorOutput)
+
+            \(output)
+            """.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return output.isEmpty ? "No recent ClipRelay unified logs were available." : output
+    }
+
+    private static func buildFileName(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return "cliprelay-mac-logs-\(formatter.string(from: date)).txt"
+    }
+
+    private static func buildFileContents(
+        deviceContext: [(String, String)],
+        generatedAt: Date,
+        logs: String
+    ) -> String {
+        let formatter = ISO8601DateFormatter()
+        let contextLines = deviceContext.map { "\($0.0): \($0.1)" }.joined(separator: "\n")
+        return """
+        ClipRelay macOS diagnostics
+        Generated: \(formatter.string(from: generatedAt))
+        Included logs: ClipRelay unified log snapshot from the last 24 hours
+
+        \(contextLines)
+
+        ---- UNIFIED LOGS ----
+        \(logs)
+        """
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -32,6 +32,7 @@ final class StatusBarController {
 
     private var baseStatusBarImage: NSImage?
     private var syncPulseTimer: Timer?
+    private var sharingPicker: NSSharingServicePicker?
 
     init(updaterController: SPUStandardUpdaterController) {
         self.updaterController = updaterController
@@ -191,6 +192,9 @@ final class StatusBarController {
         let emailItem = NSMenuItem(title: "Email Support\u{2026}", action: #selector(handleOpenEmail), keyEquivalent: "")
         emailItem.target = self
         supportMenu.addItem(emailItem)
+        let shareLogsItem = NSMenuItem(title: "Share Logs\u{2026}", action: #selector(handleShareLogs), keyEquivalent: "")
+        shareLogsItem.target = self
+        supportMenu.addItem(shareLogsItem)
         supportMenu.addItem(NSMenuItem.separator())
         let discussionsItem = NSMenuItem(title: "Community Discussions\u{2026}", action: #selector(handleOpenDiscussions), keyEquivalent: "")
         discussionsItem.target = self
@@ -347,6 +351,23 @@ final class StatusBarController {
     }
 
     @objc
+    private func handleShareLogs() {
+        let context = deviceContext()
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let result = Result(catching: { try LogShareExporter.exportLogs(deviceContext: context) })
+            DispatchQueue.main.async {
+                guard let self else { return }
+                switch result {
+                case .success(let fileURL):
+                    self.presentSharingPicker(for: fileURL)
+                case .failure(let error):
+                    self.presentShareLogsError(message: error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    @objc
     private func handleOpenDiscussions() {
         if let url = URL(string: "https://github.com/geekflyer/cliprelay/discussions") {
             NSWorkspace.shared.open(url)
@@ -373,6 +394,24 @@ final class StatusBarController {
             ("Device", model),
             ("BLE State", bleState),
         ]
+    }
+
+    private func presentSharingPicker(for fileURL: URL) {
+        guard let button = statusItem.button else {
+            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+            return
+        }
+        let picker = NSSharingServicePicker(items: [fileURL])
+        sharingPicker = picker
+        picker.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+    }
+
+    private func presentShareLogsError(message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Could not prepare ClipRelay logs"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.runModal()
     }
 
     @objc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- add Android support-dialog log sharing that exports a bounded ClipRelay `logcat` snapshot with app/device diagnostics into the system share sheet
- add macOS menu-bar log sharing that exports recent `org.cliprelay` unified logs plus device context via the native sharing picker
- add focused Android test coverage for the exported log filename/content format
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b26141b-e738-4898-8f6f-ff13f8a4ea31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b26141b-e738-4898-8f6f-ff13f8a4ea31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

