### PR TITLE
Improve Android auto-copy reliability for popup-based copy flows

### DIFF
--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -77,6 +77,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         private const val TAG = "ClipRelayService"
         private const val MAX_CLIPBOARD_BYTES = 102_400
         private const val CLIPBOARD_DEBOUNCE_MS = 200L
+        private const val TOOLBAR_CLIPBOARD_TIMESTAMP_SKEW_MS = 1_000L
 
         const val CLIPBOARD_TRIGGER_DIRECT = "direct"
         const val CLIPBOARD_TRIGGER_TOOLBAR_CLOSE = "toolbar_close"
@@ -627,9 +628,11 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         }
 
         if (
-            triggerSource == CLIPBOARD_TRIGGER_TOOLBAR_CLOSE &&
-            (clipboardTimestampMs == null || minClipboardTimestampMs == null ||
-                clipboardTimestampMs < minClipboardTimestampMs)
+            !toolbarCloseHasFreshClipboardTimestamp(
+                triggerSource = triggerSource,
+                clipboardTimestampMs = clipboardTimestampMs,
+                minClipboardTimestampMs = minClipboardTimestampMs
+            )
         ) {
             Log.d(
                 TAG,
@@ -673,6 +676,20 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             textHash == lastSentTextHash &&
             clipboardTimestampMs != null &&
             clipboardTimestampMs == lastSentClipboardTimestampMs
+    }
+
+    internal fun toolbarCloseHasFreshClipboardTimestamp(
+        triggerSource: String,
+        clipboardTimestampMs: Long?,
+        minClipboardTimestampMs: Long?
+    ): Boolean {
+        if (triggerSource != CLIPBOARD_TRIGGER_TOOLBAR_CLOSE) {
+            return true
+        }
+        if (clipboardTimestampMs == null || minClipboardTimestampMs == null) {
+            return false
+        }
+        return clipboardTimestampMs + TOOLBAR_CLIPBOARD_TIMESTAMP_SKEW_MS >= minClipboardTimestampMs
     }
 
     private fun pushImageToMac(imagePath: String, mimeType: String) {

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -54,6 +54,8 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         const val ACTION_PAIRING_COMPLETE = "org.cliprelay.action.PAIRING_COMPLETE"
         const val EXTRA_TEXT = "extra_text"
         const val EXTRA_CLIPBOARD_TRIGGER_SOURCE = "extra_clipboard_trigger_source"
+        const val EXTRA_CLIPBOARD_TIMESTAMP_MS = "extra_clipboard_timestamp_ms"
+        const val EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS = "extra_min_clipboard_timestamp_ms"
         const val EXTRA_CONNECTED = "extra_connected"
         const val EXTRA_DEVICE_NAME = "extra_device_name"
         const val EXTRA_DEVICE_TAG = "extra_device_tag"
@@ -211,8 +213,12 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             }
             ACTION_ACCESSIBILITY_COPY_DETECTED -> {
                 handleClipboardChanged(
-                    intent.getStringExtra(EXTRA_CLIPBOARD_TRIGGER_SOURCE)
-                        ?: CLIPBOARD_TRIGGER_DIRECT
+                    triggerSource = intent.getStringExtra(EXTRA_CLIPBOARD_TRIGGER_SOURCE)
+                        ?: CLIPBOARD_TRIGGER_DIRECT,
+                    minClipboardTimestampMs = intent.getLongExtra(
+                        EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS,
+                        0L
+                    ).takeIf { intent.hasExtra(EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS) }
                 )
                 return START_STICKY
             }
@@ -234,9 +240,22 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                 val text = intent.getStringExtra(EXTRA_TEXT)
                 val triggerSource = intent.getStringExtra(EXTRA_CLIPBOARD_TRIGGER_SOURCE)
                     ?: CLIPBOARD_TRIGGER_DIRECT
+                val clipboardTimestampMs = intent.getLongExtra(
+                    EXTRA_CLIPBOARD_TIMESTAMP_MS,
+                    0L
+                ).takeIf { intent.hasExtra(EXTRA_CLIPBOARD_TIMESTAMP_MS) }
+                val minClipboardTimestampMs = intent.getLongExtra(
+                    EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS,
+                    0L
+                ).takeIf { intent.hasExtra(EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS) }
                 if (!text.isNullOrBlank()) {
                     executor.execute {
-                        pushPlainTextToMac(text, triggerSource)
+                        pushPlainTextToMac(
+                            text = text,
+                            triggerSource = triggerSource,
+                            clipboardTimestampMs = clipboardTimestampMs,
+                            minClipboardTimestampMs = minClipboardTimestampMs
+                        )
                     }
                 }
             }
@@ -581,7 +600,12 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
     // ── Outbound (Android → Mac) ─────────────────────────────────────
 
-    private fun pushPlainTextToMac(text: String, triggerSource: String) {
+    private fun pushPlainTextToMac(
+        text: String,
+        triggerSource: String,
+        clipboardTimestampMs: Long? = null,
+        minClipboardTimestampMs: Long? = null
+    ) {
         if (isDestroyed) return
         val plaintext = text.toByteArray(Charsets.UTF_8)
         if (plaintext.isEmpty() || plaintext.size > MAX_CLIPBOARD_BYTES) {
@@ -594,6 +618,18 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         val session = activeSession
         if (session == null) {
             Log.d(TAG, "No active L2CAP session; skipping Android->Mac push")
+            return
+        }
+
+        if (
+            triggerSource == CLIPBOARD_TRIGGER_TOOLBAR_CLOSE &&
+            (clipboardTimestampMs == null || minClipboardTimestampMs == null ||
+                clipboardTimestampMs < minClipboardTimestampMs)
+        ) {
+            Log.d(
+                TAG,
+                "Skipping send — toolbar close was not backed by a fresh clipboard timestamp"
+            )
             return
         }
 
@@ -719,7 +755,10 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
     // ── Auto-copy (triggered by AccessibilityService) ────────────────
 
-    private fun handleClipboardChanged(triggerSource: String) {
+    private fun handleClipboardChanged(
+        triggerSource: String,
+        minClipboardTimestampMs: Long? = null
+    ) {
         Log.d(TAG, "Clipboard changed — activeSession=${activeSession != null}, ghostInFlight=$ghostActivityInFlight")
 
         // Skip if no active session (no Mac connected)
@@ -752,6 +791,9 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                     Intent.FLAG_ACTIVITY_NO_ANIMATION or
                     Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
             putExtra(EXTRA_CLIPBOARD_TRIGGER_SOURCE, triggerSource)
+            minClipboardTimestampMs?.let {
+                putExtra(EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS, it)
+            }
         }
         startActivity(ghostIntent)
     }

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -78,6 +78,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         private const val MAX_CLIPBOARD_BYTES = 102_400
         private const val CLIPBOARD_DEBOUNCE_MS = 200L
         private const val TOOLBAR_CLIPBOARD_TIMESTAMP_SKEW_MS = 1_000L
+        private const val GHOST_ACTIVITY_TIMEOUT_MS = 3_000L
 
         const val CLIPBOARD_TRIGGER_DIRECT = "direct"
         const val CLIPBOARD_TRIGGER_TOOLBAR_CLOSE = "toolbar_close"
@@ -106,6 +107,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     private val executor = Executors.newSingleThreadExecutor()
     private val clipboardAutoClearHandler = Handler(Looper.getMainLooper())
     private var pendingClipboardAutoClear: Runnable? = null
+    private var pendingGhostActivityClear: Runnable? = null
     private val clipboardSendGate = ClipboardSendGate()
     @Volatile
     private var lastSentTextHash: String? = null
@@ -830,6 +832,15 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         // Only an Activity with window focus can call getPrimaryClip() successfully.
         Log.d(TAG, "Launching ghost activity for clipboard read")
         ghostActivityInFlight = true
+        pendingGhostActivityClear?.let(clipboardAutoClearHandler::removeCallbacks)
+        pendingGhostActivityClear = Runnable {
+            if (ghostActivityInFlight) {
+                Log.w(TAG, "Ghost activity timeout — clearing in-flight flag")
+                clearGhostActivityInFlight()
+            }
+        }.also { runnable ->
+            clipboardAutoClearHandler.postDelayed(runnable, GHOST_ACTIVITY_TIMEOUT_MS)
+        }
         val ghostIntent = Intent(this, ClipboardGhostActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or
                     Intent.FLAG_ACTIVITY_NO_ANIMATION or
@@ -839,11 +850,18 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                 putExtra(EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS, it)
             }
         }
-        startActivity(ghostIntent)
+        try {
+            startActivity(ghostIntent)
+        } catch (t: Throwable) {
+            Log.e(TAG, "Could not launch ghost activity", t)
+            clearGhostActivityInFlight()
+        }
     }
 
     fun clearGhostActivityInFlight() {
         ghostActivityInFlight = false
+        pendingGhostActivityClear?.let(clipboardAutoClearHandler::removeCallbacks)
+        pendingGhostActivityClear = null
     }
 
     // ── Direct Share shortcut ─────────────────────────────────────────

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -89,8 +89,6 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     @Volatile
     private var lastInboundHash: String? = null
     @Volatile
-    private var lastSentTextHash: String? = null
-    @Volatile
     private var lastReceivedImageHash: String? = null
 
     // Support
@@ -100,6 +98,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     private val executor = Executors.newSingleThreadExecutor()
     private val clipboardAutoClearHandler = Handler(Looper.getMainLooper())
     private var pendingClipboardAutoClear: Runnable? = null
+    private val clipboardSendGate = ClipboardSendGate()
 
     @Volatile
     private var bleStarted = false
@@ -474,6 +473,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         Log.e(TAG, "Session error: ${error.message}")
         activeSession = null
         sessionThread = null
+        clipboardSendGate.reset()
         sendConnectionBroadcast(false)
         DebugSmokeProbe.onConnectionChanged(this, false)
 
@@ -571,18 +571,17 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             return
         }
 
-        // Dedup: skip if we already sent this exact text
         val textHash = MessageDigest.getInstance("SHA-256")
             .digest(plaintext).joinToString("") { "%02x".format(it) }
-        if (textHash == lastSentTextHash) {
-            Log.d(TAG, "Skipping send — same text already sent")
-            return
-        }
-        lastSentTextHash = textHash
 
         val session = activeSession
         if (session == null) {
             Log.d(TAG, "No active L2CAP session; skipping Android->Mac push")
+            return
+        }
+
+        if (!clipboardSendGate.shouldSend(textHash)) {
+            Log.d(TAG, "Skipping send — same text was sent very recently")
             return
         }
 

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -108,6 +108,8 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     private val clipboardSendGate = ClipboardSendGate()
     @Volatile
     private var lastSentTextHash: String? = null
+    @Volatile
+    private var lastSentClipboardTimestampMs: Long? = null
 
     @Volatile
     private var bleStarted = false
@@ -371,6 +373,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         sessionThread = null
         clipboardSendGate.reset()
         lastSentTextHash = null
+        lastSentClipboardTimestampMs = null
 
         // Stop BLE stack
         advertiser?.stop()
@@ -467,6 +470,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         Log.w(TAG, "L2CAP session ready")
         clipboardSendGate.reset()
         lastSentTextHash = null
+        lastSentClipboardTimestampMs = null
 
         // If the advertiser's device tag was updated during pairing (without a
         // restart), restart it now so future reconnections use the correct tag.
@@ -510,6 +514,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         sessionThread = null
         clipboardSendGate.reset()
         lastSentTextHash = null
+        lastSentClipboardTimestampMs = null
         sendConnectionBroadcast(false)
         DebugSmokeProbe.onConnectionChanged(this, false)
 
@@ -633,7 +638,15 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             return
         }
 
-        if (triggerSource == CLIPBOARD_TRIGGER_TOOLBAR_CLOSE && textHash == lastSentTextHash) {
+        if (
+            shouldSkipToolbarCloseReplay(
+                triggerSource = triggerSource,
+                textHash = textHash,
+                clipboardTimestampMs = clipboardTimestampMs,
+                lastSentTextHash = lastSentTextHash,
+                lastSentClipboardTimestampMs = lastSentClipboardTimestampMs
+            )
+        ) {
             Log.d(TAG, "Skipping send — toolbar close resolved to already-synced clipboard")
             return
         }
@@ -645,7 +658,21 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
         session.sendClipboard(plaintext)
         lastSentTextHash = textHash
+        lastSentClipboardTimestampMs = clipboardTimestampMs
         DebugSmokeProbe.onOutboundClipboardPublished(this, text)
+    }
+
+    internal fun shouldSkipToolbarCloseReplay(
+        triggerSource: String,
+        textHash: String,
+        clipboardTimestampMs: Long?,
+        lastSentTextHash: String?,
+        lastSentClipboardTimestampMs: Long?
+    ): Boolean {
+        return triggerSource == CLIPBOARD_TRIGGER_TOOLBAR_CLOSE &&
+            textHash == lastSentTextHash &&
+            clipboardTimestampMs != null &&
+            clipboardTimestampMs == lastSentClipboardTimestampMs
     }
 
     private fun pushImageToMac(imagePath: String, mimeType: String) {

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -18,6 +18,7 @@ import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import android.os.ParcelUuid
+import android.os.SystemClock
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.pm.ShortcutInfoCompat
@@ -52,6 +53,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         const val ACTION_CLIPBOARD_TRANSFER = "org.cliprelay.action.CLIPBOARD_TRANSFER"
         const val ACTION_PAIRING_COMPLETE = "org.cliprelay.action.PAIRING_COMPLETE"
         const val EXTRA_TEXT = "extra_text"
+        const val EXTRA_CLIPBOARD_TRIGGER_SOURCE = "extra_clipboard_trigger_source"
         const val EXTRA_CONNECTED = "extra_connected"
         const val EXTRA_DEVICE_NAME = "extra_device_name"
         const val EXTRA_DEVICE_TAG = "extra_device_tag"
@@ -73,6 +75,9 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         private const val TAG = "ClipRelayService"
         private const val MAX_CLIPBOARD_BYTES = 102_400
         private const val CLIPBOARD_DEBOUNCE_MS = 200L
+
+        const val CLIPBOARD_TRIGGER_DIRECT = "direct"
+        const val CLIPBOARD_TRIGGER_TOOLBAR_CLOSE = "toolbar_close"
     }
 
     // BLE components
@@ -99,6 +104,8 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     private val clipboardAutoClearHandler = Handler(Looper.getMainLooper())
     private var pendingClipboardAutoClear: Runnable? = null
     private val clipboardSendGate = ClipboardSendGate()
+    @Volatile
+    private var lastSentTextHash: String? = null
 
     @Volatile
     private var bleStarted = false
@@ -203,7 +210,10 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                 return START_STICKY
             }
             ACTION_ACCESSIBILITY_COPY_DETECTED -> {
-                handleClipboardChanged()
+                handleClipboardChanged(
+                    intent.getStringExtra(EXTRA_CLIPBOARD_TRIGGER_SOURCE)
+                        ?: CLIPBOARD_TRIGGER_DIRECT
+                )
                 return START_STICKY
             }
             ACTION_SEND_CONFIG_UPDATE -> {
@@ -222,9 +232,11 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             ACTION_PUSH_TEXT -> {
                 clearGhostActivityInFlight()
                 val text = intent.getStringExtra(EXTRA_TEXT)
+                val triggerSource = intent.getStringExtra(EXTRA_CLIPBOARD_TRIGGER_SOURCE)
+                    ?: CLIPBOARD_TRIGGER_DIRECT
                 if (!text.isNullOrBlank()) {
                     executor.execute {
-                        pushPlainTextToMac(text)
+                        pushPlainTextToMac(text, triggerSource)
                     }
                 }
             }
@@ -339,6 +351,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         activeSession = null
         sessionThread = null
         clipboardSendGate.reset()
+        lastSentTextHash = null
 
         // Stop BLE stack
         advertiser?.stop()
@@ -434,6 +447,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     override fun onSessionReady() {
         Log.w(TAG, "L2CAP session ready")
         clipboardSendGate.reset()
+        lastSentTextHash = null
 
         // If the advertiser's device tag was updated during pairing (without a
         // restart), restart it now so future reconnections use the correct tag.
@@ -476,6 +490,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         activeSession = null
         sessionThread = null
         clipboardSendGate.reset()
+        lastSentTextHash = null
         sendConnectionBroadcast(false)
         DebugSmokeProbe.onConnectionChanged(this, false)
 
@@ -566,7 +581,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
     // ── Outbound (Android → Mac) ─────────────────────────────────────
 
-    private fun pushPlainTextToMac(text: String) {
+    private fun pushPlainTextToMac(text: String, triggerSource: String) {
         if (isDestroyed) return
         val plaintext = text.toByteArray(Charsets.UTF_8)
         if (plaintext.isEmpty() || plaintext.size > MAX_CLIPBOARD_BYTES) {
@@ -582,12 +597,18 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             return
         }
 
+        if (triggerSource == CLIPBOARD_TRIGGER_TOOLBAR_CLOSE && textHash == lastSentTextHash) {
+            Log.d(TAG, "Skipping send — toolbar close resolved to already-synced clipboard")
+            return
+        }
+
         if (!clipboardSendGate.shouldSend(textHash)) {
             Log.d(TAG, "Skipping send — same text was sent very recently")
             return
         }
 
         session.sendClipboard(plaintext)
+        lastSentTextHash = textHash
         DebugSmokeProbe.onOutboundClipboardPublished(this, text)
     }
 
@@ -698,7 +719,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
     // ── Auto-copy (triggered by AccessibilityService) ────────────────
 
-    private fun handleClipboardChanged() {
+    private fun handleClipboardChanged(triggerSource: String) {
         Log.d(TAG, "Clipboard changed — activeSession=${activeSession != null}, ghostInFlight=$ghostActivityInFlight")
 
         // Skip if no active session (no Mac connected)
@@ -708,7 +729,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         }
 
         // 200ms time guard to prevent double-fires from text classification
-        val now = System.currentTimeMillis()
+        val now = SystemClock.elapsedRealtime()
         if (now - lastClipboardLaunchMs < CLIPBOARD_DEBOUNCE_MS) {
             Log.d(TAG, "Skipping clipboard: debounce (${now - lastClipboardLaunchMs}ms)")
             return
@@ -730,6 +751,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or
                     Intent.FLAG_ACTIVITY_NO_ANIMATION or
                     Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+            putExtra(EXTRA_CLIPBOARD_TRIGGER_SOURCE, triggerSource)
         }
         startActivity(ghostIntent)
     }

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -338,6 +338,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         }
         activeSession = null
         sessionThread = null
+        clipboardSendGate.reset()
 
         // Stop BLE stack
         advertiser?.stop()
@@ -432,6 +433,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
     override fun onSessionReady() {
         Log.w(TAG, "L2CAP session ready")
+        clipboardSendGate.reset()
 
         // If the advertiser's device tag was updated during pairing (without a
         // restart), restart it now so future reconnections use the correct tag.

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -37,6 +37,16 @@ internal class ClipboardAccessibilityHeuristics(
             .any(COPY_WORDS::contains)
     }
 
+    @Synchronized
+    fun containsCopyCommandText(values: Sequence<String>): Boolean {
+        return values
+            .map(::normalize)
+            .any { normalized ->
+                COPY_WORDS.contains(normalized) ||
+                    COPY_COMMAND_PREFIXES.any { prefix -> normalized.startsWith("$prefix ") }
+            }
+    }
+
     private fun normalize(value: String): String {
         return value
             .lowercase(Locale.ROOT)
@@ -83,6 +93,23 @@ internal class ClipboardAccessibilityHeuristics(
             "העתק",
             "نسخ",
             "कॉपी करें",
+        )
+
+        private val COPY_COMMAND_PREFIXES = setOf(
+            "copy",
+            "copiar",
+            "copier",
+            "kopieren",
+            "copia",
+            "copiare",
+            "копировать",
+            "скопировать",
+            "kopyala",
+            "kopiuj",
+            "skopiuj",
+            "kopírovat",
+            "kopiera",
+            "kopioi",
         )
     }
 }

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -4,12 +4,14 @@ package org.cliprelay.service
 // Reference-only source code. See the repository LICENSE for terms.
 
 import android.os.SystemClock
+import android.view.accessibility.AccessibilityEvent
 import java.util.Locale
 
 internal class ClipboardAccessibilityHeuristics(
     private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
     private val wallClockMs: () -> Long = { System.currentTimeMillis() },
-    private val toolbarGracePeriodMs: Long = DEFAULT_TOOLBAR_GRACE_PERIOD_MS
+    private val toolbarGracePeriodMs: Long = DEFAULT_TOOLBAR_GRACE_PERIOD_MS,
+    private val aggressiveMutationDelayMs: Long = DEFAULT_AGGRESSIVE_MUTATION_DELAY_MS
 ) {
     private var copyAffordanceVisible = false
     private var lastCopyAffordanceSeenElapsedAtMs = 0L
@@ -42,6 +44,50 @@ internal class ClipboardAccessibilityHeuristics(
         resetToolbarState()
     }
 
+    @Synchronized
+    fun onWindowsRemoved(windowChanges: Int): Long? {
+        if (windowChanges and AccessibilityEvent.WINDOWS_CHANGE_REMOVED == 0) {
+            return null
+        }
+
+        val now = elapsedRealtimeMs()
+        val seenWallClockAtMs = if (
+            copyAffordanceVisible &&
+            now - lastCopyAffordanceSeenElapsedAtMs <= toolbarGracePeriodMs
+        ) {
+            lastCopyAffordanceSeenWallClockAtMs
+        } else {
+            null
+        }
+
+        if (seenWallClockAtMs != null) {
+            resetToolbarState()
+        }
+        return seenWallClockAtMs
+    }
+
+    @Synchronized
+    fun onAggressiveWindowMutation(windowChanges: Int): Long? {
+        if (windowChanges and AGGRESSIVE_MUTATION_MASK == 0) {
+            return null
+        }
+
+        val now = elapsedRealtimeMs()
+        val seenWallClockAtMs = if (
+            copyAffordanceVisible &&
+            now - lastCopyAffordanceSeenElapsedAtMs in aggressiveMutationDelayMs..toolbarGracePeriodMs
+        ) {
+            lastCopyAffordanceSeenWallClockAtMs
+        } else {
+            null
+        }
+
+        if (seenWallClockAtMs != null) {
+            resetToolbarState()
+        }
+        return seenWallClockAtMs
+    }
+
     fun containsCopyText(values: Sequence<String>): Boolean {
         return values
             .map(::normalize)
@@ -56,6 +102,11 @@ internal class ClipboardAccessibilityHeuristics(
 
     fun containsCopyCommandText(values: Sequence<String>): Boolean {
         return containsCopyWindowText(values)
+    }
+
+    fun shouldUseConservativeDelayedProbe(packageName: CharSequence?): Boolean {
+        val normalizedPackage = packageName?.toString()?.lowercase(Locale.ROOT) ?: return false
+        return CONSERVATIVE_DELAYED_PROBE_PACKAGES.contains(normalizedPackage)
     }
 
     fun debugCopyCandidates(values: Sequence<String>): List<String> {
@@ -96,7 +147,15 @@ internal class ClipboardAccessibilityHeuristics(
 
     companion object {
         const val DEFAULT_TOOLBAR_GRACE_PERIOD_MS = 1_500L
+        const val DEFAULT_AGGRESSIVE_MUTATION_DELAY_MS = 150L
         private const val MAX_DEBUG_CANDIDATES = 4
+        private const val AGGRESSIVE_MUTATION_MASK =
+            AccessibilityEvent.WINDOWS_CHANGE_CHILDREN or
+                AccessibilityEvent.WINDOWS_CHANGE_REMOVED
+        private val CONSERVATIVE_DELAYED_PROBE_PACKAGES = setOf(
+            "com.reddit.frontpage",
+            "com.reddit.frontpage.debug",
+        )
 
         private val WHITESPACE_REGEX = "\\s+".toRegex()
 

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -1,9 +1,10 @@
 package org.cliprelay.service
 
+import android.os.SystemClock
 import java.util.Locale
 
 internal class ClipboardAccessibilityHeuristics(
-    private val nowMs: () -> Long = { System.currentTimeMillis() },
+    private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
     private val toolbarGracePeriodMs: Long = DEFAULT_TOOLBAR_GRACE_PERIOD_MS
 ) {
     private var copyAffordanceVisible = false
@@ -43,7 +44,9 @@ internal class ClipboardAccessibilityHeuristics(
             .map(::normalize)
             .any { normalized ->
                 COPY_WORDS.contains(normalized) ||
-                    COPY_COMMAND_PREFIXES.any { prefix -> normalized.startsWith("$prefix ") }
+                    COPY_COMMAND_PREFIXES.any { prefix ->
+                        normalized.startsWith("$prefix ") && !normalized.startsWith("$prefix to ")
+                    }
             }
     }
 

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -108,16 +108,7 @@ internal class ClipboardAccessibilityHeuristics(
         packageName: CharSequence?,
         aggressiveMode: Boolean
     ): WindowProbeStrategy {
-        if (aggressiveMode) {
-            return WindowProbeStrategy.AGGRESSIVE
-        }
-        val normalizedPackage = packageName?.toString()?.lowercase(Locale.ROOT)
-            ?: return WindowProbeStrategy.NONE
-        return if (BALANCED_DELAYED_PROBE_PACKAGES.contains(normalizedPackage)) {
-            WindowProbeStrategy.BALANCED
-        } else {
-            WindowProbeStrategy.NONE
-        }
+        return if (aggressiveMode) WindowProbeStrategy.AGGRESSIVE else WindowProbeStrategy.NONE
     }
 
     fun debugCopyCandidates(values: Sequence<String>): List<String> {
@@ -163,11 +154,6 @@ internal class ClipboardAccessibilityHeuristics(
         private const val AGGRESSIVE_MUTATION_MASK =
             AccessibilityEvent.WINDOWS_CHANGE_CHILDREN or
                 AccessibilityEvent.WINDOWS_CHANGE_REMOVED
-        private val BALANCED_DELAYED_PROBE_PACKAGES = setOf(
-            "com.reddit.frontpage",
-            "com.reddit.frontpage.debug",
-        )
-
         private val WHITESPACE_REGEX = "\\s+".toRegex()
 
         private val COPY_WORDS = setOf(
@@ -226,6 +212,5 @@ internal class ClipboardAccessibilityHeuristics(
 
 internal enum class WindowProbeStrategy {
     NONE,
-    BALANCED,
     AGGRESSIVE,
 }

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -104,9 +104,20 @@ internal class ClipboardAccessibilityHeuristics(
         return containsCopyWindowText(values)
     }
 
-    fun shouldUseConservativeDelayedProbe(packageName: CharSequence?): Boolean {
-        val normalizedPackage = packageName?.toString()?.lowercase(Locale.ROOT) ?: return false
-        return CONSERVATIVE_DELAYED_PROBE_PACKAGES.contains(normalizedPackage)
+    fun windowProbeStrategy(
+        packageName: CharSequence?,
+        aggressiveMode: Boolean
+    ): WindowProbeStrategy {
+        if (aggressiveMode) {
+            return WindowProbeStrategy.AGGRESSIVE
+        }
+        val normalizedPackage = packageName?.toString()?.lowercase(Locale.ROOT)
+            ?: return WindowProbeStrategy.NONE
+        return if (BALANCED_DELAYED_PROBE_PACKAGES.contains(normalizedPackage)) {
+            WindowProbeStrategy.BALANCED
+        } else {
+            WindowProbeStrategy.NONE
+        }
     }
 
     fun debugCopyCandidates(values: Sequence<String>): List<String> {
@@ -152,7 +163,7 @@ internal class ClipboardAccessibilityHeuristics(
         private const val AGGRESSIVE_MUTATION_MASK =
             AccessibilityEvent.WINDOWS_CHANGE_CHILDREN or
                 AccessibilityEvent.WINDOWS_CHANGE_REMOVED
-        private val CONSERVATIVE_DELAYED_PROBE_PACKAGES = setOf(
+        private val BALANCED_DELAYED_PROBE_PACKAGES = setOf(
             "com.reddit.frontpage",
             "com.reddit.frontpage.debug",
         )
@@ -211,4 +222,10 @@ internal class ClipboardAccessibilityHeuristics(
             "kopioi",
         )
     }
+}
+
+internal enum class WindowProbeStrategy {
+    NONE,
+    BALANCED,
+    AGGRESSIVE,
 }

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -37,13 +37,34 @@ internal class ClipboardAccessibilityHeuristics(
     fun containsCopyText(values: Sequence<String>): Boolean {
         return values
             .map(::normalize)
-            .any(::isCopyAffordanceText)
+            .any(COPY_WORDS::contains)
+    }
+
+    fun containsCopyWindowText(packageName: String?, values: Sequence<String>): Boolean {
+        return values
+            .map(::normalize)
+            .any { normalized ->
+                if (packageName in BROAD_WINDOW_COMMAND_PACKAGES) {
+                    isCopyAffordanceText(normalized)
+                } else {
+                    COPY_WORDS.contains(normalized)
+                }
+            }
     }
 
     fun containsCopyCommandText(values: Sequence<String>): Boolean {
         return values
             .map(::normalize)
             .any(::isCopyAffordanceText)
+    }
+
+    fun debugCopyCandidates(values: Sequence<String>): List<String> {
+        return values
+            .map(::normalize)
+            .filter(::looksCopyRelated)
+            .distinct()
+            .take(MAX_DEBUG_CANDIDATES)
+            .toList()
     }
 
     private fun normalize(value: String): String {
@@ -61,10 +82,24 @@ internal class ClipboardAccessibilityHeuristics(
             }
     }
 
+    private fun looksCopyRelated(normalized: String): Boolean {
+        return isCopyAffordanceText(normalized) ||
+            COPY_COMMAND_PREFIXES.any { prefix -> normalized.startsWith("$prefix ") }
+    }
+
     companion object {
         const val DEFAULT_TOOLBAR_GRACE_PERIOD_MS = 1_500L
+        private const val MAX_DEBUG_CANDIDATES = 4
 
         private val WHITESPACE_REGEX = "\\s+".toRegex()
+        private val BROAD_WINDOW_COMMAND_PACKAGES = setOf(
+            "com.reddit.frontpage",
+            "com.android.chrome",
+            "org.mozilla.firefox",
+            "com.brave.browser",
+            "com.microsoft.emmx",
+            "com.sec.android.app.sbrowser",
+        )
 
         private val COPY_WORDS = setOf(
             "copy",

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -34,23 +34,16 @@ internal class ClipboardAccessibilityHeuristics(
         lastCopyAffordanceSeenAtMs = 0L
     }
 
-    @Synchronized
     fun containsCopyText(values: Sequence<String>): Boolean {
         return values
             .map(::normalize)
-            .any(COPY_WORDS::contains)
+            .any(::isCopyAffordanceText)
     }
 
-    @Synchronized
     fun containsCopyCommandText(values: Sequence<String>): Boolean {
         return values
             .map(::normalize)
-            .any { normalized ->
-                COPY_WORDS.contains(normalized) ||
-                    COPY_COMMAND_PREFIXES.any { prefix ->
-                        normalized.startsWith("$prefix ") && !normalized.startsWith("$prefix to ")
-                    }
-            }
+            .any(::isCopyAffordanceText)
     }
 
     private fun normalize(value: String): String {
@@ -59,6 +52,13 @@ internal class ClipboardAccessibilityHeuristics(
             .trim()
             .trim { !it.isLetterOrDigit() && !it.isWhitespace() }
             .replace(WHITESPACE_REGEX, " ")
+    }
+
+    private fun isCopyAffordanceText(normalized: String): Boolean {
+        return COPY_WORDS.contains(normalized) ||
+            COPY_COMMAND_PREFIXES.any { prefix ->
+                normalized.startsWith("$prefix ") && !normalized.startsWith("$prefix to ")
+            }
     }
 
     companion object {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -55,9 +55,7 @@ internal class ClipboardAccessibilityHeuristics(
     }
 
     fun containsCopyCommandText(values: Sequence<String>): Boolean {
-        return values
-            .map(::normalize)
-            .any(::isCopyAffordanceText)
+        return containsCopyWindowText(values)
     }
 
     fun debugCopyCandidates(values: Sequence<String>): List<String> {
@@ -75,6 +73,7 @@ internal class ClipboardAccessibilityHeuristics(
             .trim()
             .trim { !it.isLetterOrDigit() && !it.isWhitespace() }
             .replace(WHITESPACE_REGEX, " ")
+            .trim()
     }
 
     private fun isCopyAffordanceText(normalized: String): Boolean {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -1,5 +1,8 @@
 package org.cliprelay.service
 
+// Copyright (c) 2026 Christian T. All Rights Reserved.
+// Reference-only source code. See the repository LICENSE for terms.
+
 import android.os.SystemClock
 import java.util.Locale
 

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -7,31 +7,39 @@ import android.os.SystemClock
 import java.util.Locale
 
 internal class ClipboardAccessibilityHeuristics(
-    private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
+    private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
+    private val wallClockMs: () -> Long = { System.currentTimeMillis() },
     private val toolbarGracePeriodMs: Long = DEFAULT_TOOLBAR_GRACE_PERIOD_MS
 ) {
     private var copyAffordanceVisible = false
-    private var lastCopyAffordanceSeenAtMs = 0L
+    private var lastCopyAffordanceSeenElapsedAtMs = 0L
+    private var lastCopyAffordanceSeenWallClockAtMs = 0L
 
     @Synchronized
-    fun onCopyAffordanceChanged(hasCopyAffordance: Boolean): Boolean {
-        val now = nowMs()
+    fun onCopyAffordanceChanged(hasCopyAffordance: Boolean): Long? {
+        val now = elapsedRealtimeMs()
         return if (hasCopyAffordance) {
             copyAffordanceVisible = true
-            lastCopyAffordanceSeenAtMs = now
-            false
+            lastCopyAffordanceSeenElapsedAtMs = now
+            lastCopyAffordanceSeenWallClockAtMs = wallClockMs()
+            null
         } else {
-            val shouldTrigger = copyAffordanceVisible &&
-                now - lastCopyAffordanceSeenAtMs <= toolbarGracePeriodMs
-            copyAffordanceVisible = false
-            shouldTrigger
+            val seenWallClockAtMs = if (
+                copyAffordanceVisible &&
+                now - lastCopyAffordanceSeenElapsedAtMs <= toolbarGracePeriodMs
+            ) {
+                lastCopyAffordanceSeenWallClockAtMs
+            } else {
+                null
+            }
+            resetToolbarState()
+            seenWallClockAtMs
         }
     }
 
     @Synchronized
     fun resetAfterDirectDetection() {
-        copyAffordanceVisible = false
-        lastCopyAffordanceSeenAtMs = 0L
+        resetToolbarState()
     }
 
     fun containsCopyText(values: Sequence<String>): Boolean {
@@ -40,16 +48,10 @@ internal class ClipboardAccessibilityHeuristics(
             .any(COPY_WORDS::contains)
     }
 
-    fun containsCopyWindowText(packageName: String?, values: Sequence<String>): Boolean {
+    fun containsCopyWindowText(values: Sequence<String>): Boolean {
         return values
             .map(::normalize)
-            .any { normalized ->
-                if (packageName in BROAD_WINDOW_COMMAND_PACKAGES) {
-                    isCopyAffordanceText(normalized)
-                } else {
-                    COPY_WORDS.contains(normalized)
-                }
-            }
+            .any(::isCopyAffordanceText)
     }
 
     fun containsCopyCommandText(values: Sequence<String>): Boolean {
@@ -87,19 +89,17 @@ internal class ClipboardAccessibilityHeuristics(
             COPY_COMMAND_PREFIXES.any { prefix -> normalized.startsWith("$prefix ") }
     }
 
+    private fun resetToolbarState() {
+        copyAffordanceVisible = false
+        lastCopyAffordanceSeenElapsedAtMs = 0L
+        lastCopyAffordanceSeenWallClockAtMs = 0L
+    }
+
     companion object {
         const val DEFAULT_TOOLBAR_GRACE_PERIOD_MS = 1_500L
         private const val MAX_DEBUG_CANDIDATES = 4
 
         private val WHITESPACE_REGEX = "\\s+".toRegex()
-        private val BROAD_WINDOW_COMMAND_PACKAGES = setOf(
-            "com.reddit.frontpage",
-            "com.android.chrome",
-            "org.mozilla.firefox",
-            "com.brave.browser",
-            "com.microsoft.emmx",
-            "com.sec.android.app.sbrowser",
-        )
 
         private val COPY_WORDS = setOf(
             "copy",

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -1,5 +1,7 @@
 package org.cliprelay.service
 
+import java.util.Locale
+
 internal class ClipboardAccessibilityHeuristics(
     private val nowMs: () -> Long = { System.currentTimeMillis() },
     private val toolbarGracePeriodMs: Long = DEFAULT_TOOLBAR_GRACE_PERIOD_MS
@@ -7,6 +9,7 @@ internal class ClipboardAccessibilityHeuristics(
     private var copyAffordanceVisible = false
     private var lastCopyAffordanceSeenAtMs = 0L
 
+    @Synchronized
     fun onCopyAffordanceChanged(hasCopyAffordance: Boolean): Boolean {
         val now = nowMs()
         return if (hasCopyAffordance) {
@@ -21,36 +24,33 @@ internal class ClipboardAccessibilityHeuristics(
         }
     }
 
+    @Synchronized
     fun resetAfterDirectDetection() {
         copyAffordanceVisible = false
         lastCopyAffordanceSeenAtMs = 0L
     }
 
+    @Synchronized
     fun containsCopyText(values: Sequence<String>): Boolean {
         return values
             .map(::normalize)
-            .filter { it.isNotEmpty() && !it.contains("copyright") }
-            .any { normalized -> COPY_WORDS.any { word -> normalized.contains(word) } }
-    }
-
-    fun containsCopyConfirmationText(values: Sequence<String>): Boolean {
-        return values
-            .map(::normalize)
-            .filter { it.isNotEmpty() }
-            .any { normalized ->
-                COPIED_WORDS.any { word -> normalized.contains(word) } ||
-                    (normalized.contains("clipboard") && COPY_WORDS.any { word -> normalized.contains(word) })
-            }
+            .any(COPY_WORDS::contains)
     }
 
     private fun normalize(value: String): String {
-        return value.lowercase().trim()
+        return value
+            .lowercase(Locale.ROOT)
+            .trim()
+            .trim { !it.isLetterOrDigit() && !it.isWhitespace() }
+            .replace(WHITESPACE_REGEX, " ")
     }
 
     companion object {
         const val DEFAULT_TOOLBAR_GRACE_PERIOD_MS = 1_500L
 
-        val COPY_WORDS = setOf(
+        private val WHITESPACE_REGEX = "\\s+".toRegex()
+
+        private val COPY_WORDS = setOf(
             "copy",
             "copy text",
             "copy code",
@@ -83,17 +83,6 @@ internal class ClipboardAccessibilityHeuristics(
             "העתק",
             "نسخ",
             "कॉपी करें",
-        )
-
-        private val COPIED_WORDS = setOf(
-            "copied",
-            "copied to clipboard",
-            "text copied",
-            "link copied",
-            "copied link",
-            "copied text",
-            "copied code",
-            "copying to clipboard",
         )
     }
 }

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityHeuristics.kt
@@ -1,0 +1,99 @@
+package org.cliprelay.service
+
+internal class ClipboardAccessibilityHeuristics(
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+    private val toolbarGracePeriodMs: Long = DEFAULT_TOOLBAR_GRACE_PERIOD_MS
+) {
+    private var copyAffordanceVisible = false
+    private var lastCopyAffordanceSeenAtMs = 0L
+
+    fun onCopyAffordanceChanged(hasCopyAffordance: Boolean): Boolean {
+        val now = nowMs()
+        return if (hasCopyAffordance) {
+            copyAffordanceVisible = true
+            lastCopyAffordanceSeenAtMs = now
+            false
+        } else {
+            val shouldTrigger = copyAffordanceVisible &&
+                now - lastCopyAffordanceSeenAtMs <= toolbarGracePeriodMs
+            copyAffordanceVisible = false
+            shouldTrigger
+        }
+    }
+
+    fun resetAfterDirectDetection() {
+        copyAffordanceVisible = false
+        lastCopyAffordanceSeenAtMs = 0L
+    }
+
+    fun containsCopyText(values: Sequence<String>): Boolean {
+        return values
+            .map(::normalize)
+            .filter { it.isNotEmpty() && !it.contains("copyright") }
+            .any { normalized -> COPY_WORDS.any { word -> normalized.contains(word) } }
+    }
+
+    fun containsCopyConfirmationText(values: Sequence<String>): Boolean {
+        return values
+            .map(::normalize)
+            .filter { it.isNotEmpty() }
+            .any { normalized ->
+                COPIED_WORDS.any { word -> normalized.contains(word) } ||
+                    (normalized.contains("clipboard") && COPY_WORDS.any { word -> normalized.contains(word) })
+            }
+    }
+
+    private fun normalize(value: String): String {
+        return value.lowercase().trim()
+    }
+
+    companion object {
+        const val DEFAULT_TOOLBAR_GRACE_PERIOD_MS = 1_500L
+
+        val COPY_WORDS = setOf(
+            "copy",
+            "copy text",
+            "copy code",
+            "copy link",
+            "copy image",
+            "copy to clipboard",
+            "copiar",
+            "copiar texto",
+            "copier",
+            "kopieren",
+            "kopiëren",
+            "copia",
+            "copiare",
+            "コピー",
+            "복사",
+            "复制",
+            "複製",
+            "копировать",
+            "скопировать",
+            "kopyala",
+            "คัดลอก",
+            "sao chép",
+            "salin",
+            "kopiuj",
+            "skopiuj",
+            "kopírovat",
+            "kopiera",
+            "kopioi",
+            "αντιγραφή",
+            "העתק",
+            "نسخ",
+            "कॉपी करें",
+        )
+
+        private val COPIED_WORDS = setOf(
+            "copied",
+            "copied to clipboard",
+            "text copied",
+            "link copied",
+            "copied link",
+            "copied text",
+            "copied code",
+            "copying to clipboard",
+        )
+    }
+}

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -46,7 +46,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
     private fun handleClickEvent(event: AccessibilityEvent) {
         if (eventMatchesCopy(event)) {
-            triggerCopyDetected("click")
+            triggerCopyDetected("click", ClipRelayService.CLIPBOARD_TRIGGER_DIRECT)
         }
     }
 
@@ -55,7 +55,10 @@ class ClipboardAccessibilityService : AccessibilityService() {
     private fun handleWindowStateChanged(event: AccessibilityEvent) {
         val hasCopyAffordance = heuristics.containsCopyText(eventSignals(event))
         if (heuristics.onCopyAffordanceChanged(hasCopyAffordance)) {
-            triggerCopyDetected("window state changed close")
+            triggerCopyDetected(
+                "window state changed close",
+                ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE
+            )
         } else if (hasCopyAffordance) {
             Log.d(TAG, "Copy affordance visible via window state changed")
         }
@@ -91,11 +94,12 @@ class ClipboardAccessibilityService : AccessibilityService() {
         private const val TAG = "ClipboardA11y"
     }
 
-    private fun triggerCopyDetected(reason: String) {
+    private fun triggerCopyDetected(reason: String, triggerSource: String) {
         heuristics.resetAfterDirectDetection()
         Log.d(TAG, "Copy detected via $reason")
         val intent = Intent(this, ClipRelayService::class.java).apply {
             action = ClipRelayService.ACTION_ACCESSIBILITY_COPY_DETECTED
+            putExtra(ClipRelayService.EXTRA_CLIPBOARD_TRIGGER_SOURCE, triggerSource)
         }
         ContextCompat.startForegroundService(this, intent)
     }

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -15,6 +15,7 @@ package org.cliprelay.service
 import android.accessibilityservice.AccessibilityService
 import android.content.Intent
 import android.util.Log
+import androidx.core.content.ContextCompat
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import org.cliprelay.settings.ClipboardSettingsStore
@@ -22,10 +23,7 @@ import org.cliprelay.settings.ClipboardSettingsStore
 class ClipboardAccessibilityService : AccessibilityService() {
 
     private lateinit var settingsStore: ClipboardSettingsStore
-
-    // Tracks whether a copy toolbar was recently visible
-    @Volatile
-    private var copyToolbarVisible = false
+    private val heuristics = ClipboardAccessibilityHeuristics()
 
     override fun onServiceConnected() {
         super.onServiceConnected()
@@ -40,6 +38,8 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
         when (event.eventType) {
             AccessibilityEvent.TYPE_VIEW_CLICKED -> handleClickEvent(event)
+            AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED -> handleNotificationEvent(event)
+            AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> handleWindowSnapshotEvent(event, "window content changed")
             AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> handleWindowStateChanged(event)
         }
     }
@@ -47,98 +47,117 @@ class ClipboardAccessibilityService : AccessibilityService() {
     // ── TYPE_VIEW_CLICKED detection (most apps) ──────────────────────
 
     private fun handleClickEvent(event: AccessibilityEvent) {
-        // Check source node for ACTION_COPY (Tier 1)
-        val source = event.source
-        if (source != null) {
-            try {
-                if (hasActionCopy(source)) {
-                    Log.d(TAG, "ACTION_COPY detected on clicked node")
-                    copyToolbarVisible = false
-                    notifyService()
-                    return
-                }
-            } finally {
-                source.recycle()
-            }
-        }
-
-        // Check event text for "Copy" (Tier 3)
-        if (isCopyText(event)) {
-            Log.d(TAG, "Copy text detected in click event")
-            copyToolbarVisible = false
-            notifyService()
+        if (eventMatchesCopy(event)) {
+            triggerCopyDetected("click")
         }
     }
 
     // ── TYPE_WINDOW_STATE_CHANGED detection (Chrome, etc.) ───────────
 
     private fun handleWindowStateChanged(event: AccessibilityEvent) {
-        val text = event.text?.joinToString(" ")?.lowercase() ?: ""
+        handleWindowSnapshotEvent(event, "window state changed")
+    }
 
-        val hasCopyOption = COPY_WORDS.any { text.contains(it) }
-
-        if (hasCopyOption) {
-            // Toolbar with "Copy" option appeared — just note it, don't act yet
-            if (!copyToolbarVisible) {
-                Log.d(TAG, "Copy toolbar appeared")
-            }
-            copyToolbarVisible = true
-        } else if (copyToolbarVisible) {
-            // Toolbar was visible but this window state change doesn't have copy text
-            // → toolbar closed (user tapped an option or dismissed it)
-            copyToolbarVisible = false
-            Log.d(TAG, "Copy toolbar closed → checking clipboard")
-            notifyService()
+    private fun handleNotificationEvent(event: AccessibilityEvent) {
+        if (heuristics.containsCopyConfirmationText(eventSignals(event))) {
+            triggerCopyDetected("notification")
         }
     }
 
     // ── Helpers ──────────────────────────────────────────────────────
 
+    private fun handleWindowSnapshotEvent(event: AccessibilityEvent, reason: String) {
+        val hasCopyAffordance = snapshotHasCopyAffordance(event)
+        if (heuristics.onCopyAffordanceChanged(hasCopyAffordance)) {
+            triggerCopyDetected("$reason close")
+        } else if (hasCopyAffordance) {
+            Log.d(TAG, "Copy affordance visible via $reason")
+        }
+    }
+
+    private fun eventMatchesCopy(event: AccessibilityEvent): Boolean {
+        if (snapshotHasCopyAffordance(event)) {
+            return true
+        }
+        return heuristics.containsCopyText(eventSignals(event))
+    }
+
+    private fun snapshotHasCopyAffordance(event: AccessibilityEvent): Boolean {
+        val source = event.source
+        if (source != null) {
+            try {
+                if (nodeContainsCopySignal(source, 0)) {
+                    return true
+                }
+            } finally {
+                @Suppress("DEPRECATION")
+                source.recycle()
+            }
+        }
+
+        val root = rootInActiveWindow
+        if (root != null) {
+            try {
+                if (nodeContainsCopySignal(root, 0)) {
+                    return true
+                }
+            } finally {
+                @Suppress("DEPRECATION")
+                root.recycle()
+            }
+        }
+
+        return heuristics.containsCopyText(eventSignals(event))
+    }
+
+    private fun nodeContainsCopySignal(node: AccessibilityNodeInfo, depth: Int): Boolean {
+        if (depth > MAX_NODE_DEPTH) return false
+        if (hasActionCopy(node)) return true
+
+        val nodeSignals = sequenceOf(
+            node.text?.toString(),
+            node.contentDescription?.toString()
+        ).filterNotNull()
+        if (heuristics.containsCopyText(nodeSignals)) {
+            return true
+        }
+
+        for (index in 0 until node.childCount) {
+            val child = node.getChild(index) ?: continue
+            try {
+                if (nodeContainsCopySignal(child, depth + 1)) {
+                    return true
+                }
+            } finally {
+                @Suppress("DEPRECATION")
+                child.recycle()
+            }
+        }
+        return false
+    }
+
     private fun hasActionCopy(node: AccessibilityNodeInfo): Boolean {
         return node.actionList.any { it.id == AccessibilityNodeInfo.ACTION_COPY }
     }
 
-    private fun isCopyText(event: AccessibilityEvent): Boolean {
-        val text = event.text?.joinToString(" ")?.lowercase()?.trim() ?: return false
-        if (text.contains("copyright")) return false
-        return text in COPY_WORDS
+    private fun eventSignals(event: AccessibilityEvent): Sequence<String> {
+        val eventText = event.text.asSequence().map { it.toString() }
+        val contentDescription = sequenceOf(event.contentDescription?.toString()).filterNotNull()
+        return eventText + contentDescription
     }
 
     companion object {
         private const val TAG = "ClipboardA11y"
-
-        private val COPY_WORDS = setOf(
-            "copy", "copy text",           // English
-            "copiar", "copiar texto",       // Spanish, Portuguese
-            "copier",                       // French
-            "kopieren",                     // German
-            "kopiëren",                     // Dutch
-            "copia", "copiare",             // Italian
-            "コピー",                        // Japanese
-            "복사",                          // Korean
-            "复制",                          // Chinese (Simplified)
-            "複製",                          // Chinese (Traditional)
-            "копировать", "скопировать",     // Russian
-            "kopyala",                      // Turkish
-            "คัดลอก",                       // Thai
-            "sao chép",                     // Vietnamese
-            "salin",                        // Filipino/Malay
-            "kopiuj", "skopiuj",            // Polish
-            "kopírovat",                    // Czech
-            "kopiera",                      // Swedish
-            "kopioi",                       // Finnish
-            "αντιγραφή",                    // Greek
-            "העתק",                         // Hebrew
-            "نسخ",                          // Arabic
-            "कॉपी करें",                     // Hindi
-        )
+        private const val MAX_NODE_DEPTH = 5
     }
 
-    private fun notifyService() {
+    private fun triggerCopyDetected(reason: String) {
+        heuristics.resetAfterDirectDetection()
+        Log.d(TAG, "Copy detected via $reason")
         val intent = Intent(this, ClipRelayService::class.java).apply {
             action = ClipRelayService.ACTION_ACCESSIBILITY_COPY_DETECTED
         }
-        startService(intent)
+        ContextCompat.startForegroundService(this, intent)
     }
 
     override fun onInterrupt() {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -305,6 +305,15 @@ class ClipboardAccessibilityService : AccessibilityService() {
         pendingWindowProbe?.let(mainHandler::removeCallbacks)
         pendingWindowProbe = Runnable {
             if (windowProbeToken.get() != token) return@Runnable
+            if (!shouldAllowScheduledProbe(strategy)) {
+                if (BuildConfig.DEBUG) {
+                    Log.d(
+                        TAG,
+                        "Skipping delayed probe: strategy=$strategy disabled by current settings"
+                    )
+                }
+                return@Runnable
+            }
             val clipboardTimestampMs = currentClipboardTimestampMs()
             if (!shouldPreflightToolbarRead(strategy, clipboardTimestampMs, seenWallClockAtMs)) {
                 if (BuildConfig.DEBUG) {
@@ -330,6 +339,13 @@ class ClipboardAccessibilityService : AccessibilityService() {
             )
         }
         mainHandler.postDelayed(pendingWindowProbe!!, WINDOW_PROBE_DELAY_MS)
+    }
+
+    private fun shouldAllowScheduledProbe(strategy: WindowProbeStrategy): Boolean {
+        if (!::settingsStore.isInitialized) return false
+        val autoCopyEnabled = settingsStore.isAutoCopyEnabled()
+        val aggressiveModeEnabled = settingsStore.isAggressiveAutoCopyEnabled()
+        return shouldAllowScheduledProbe(strategy, autoCopyEnabled, aggressiveModeEnabled)
     }
 
     private fun triggerToolbarCloseIfFresh(
@@ -456,6 +472,17 @@ class ClipboardAccessibilityService : AccessibilityService() {
                 return strategy != WindowProbeStrategy.NONE
             }
             return clipboardTimestampMs + TOOLBAR_CLOSE_CLIPBOARD_SKEW_MS >= minClipboardTimestampMs
+        }
+
+        internal fun shouldAllowScheduledProbe(
+            strategy: WindowProbeStrategy,
+            autoCopyEnabled: Boolean,
+            aggressiveModeEnabled: Boolean
+        ): Boolean {
+            if (!autoCopyEnabled) {
+                return false
+            }
+            return strategy != WindowProbeStrategy.AGGRESSIVE || aggressiveModeEnabled
         }
     }
 

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -14,17 +14,23 @@ package org.cliprelay.service
 
 import android.accessibilityservice.AccessibilityService
 import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.core.content.ContextCompat
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import org.cliprelay.BuildConfig
 import org.cliprelay.settings.ClipboardSettingsStore
+import java.util.concurrent.atomic.AtomicLong
 
 class ClipboardAccessibilityService : AccessibilityService() {
 
     private lateinit var settingsStore: ClipboardSettingsStore
     private val heuristics = ClipboardAccessibilityHeuristics()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var pendingWindowProbe: Runnable? = null
+    private val windowProbeToken = AtomicLong(0L)
 
     override fun onServiceConnected() {
         super.onServiceConnected()
@@ -36,11 +42,12 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
         // Only process if auto-copy is enabled
         if (!::settingsStore.isInitialized || !settingsStore.isAutoCopyEnabled()) return
+        val aggressiveMode = settingsStore.isAggressiveAutoCopyEnabled()
 
         when (event.eventType) {
             AccessibilityEvent.TYPE_VIEW_CLICKED -> handleClickEvent(event)
             AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
-            AccessibilityEvent.TYPE_WINDOWS_CHANGED -> handleWindowChangeEvent(event)
+            AccessibilityEvent.TYPE_WINDOWS_CHANGED -> handleWindowChangeEvent(event, aggressiveMode)
         }
     }
 
@@ -49,6 +56,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
     private fun handleClickEvent(event: AccessibilityEvent) {
         val matched = eventMatchesCopy(event)
         if (matched) {
+            cancelWindowProbe()
             triggerCopyDetected("click", ClipRelayService.CLIPBOARD_TRIGGER_DIRECT)
         } else {
             logPotentialMissIfDebug("click", event)
@@ -57,10 +65,49 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
     // ── TYPE_WINDOW_STATE_CHANGED detection (Chrome, etc.) ───────────
 
-    private fun handleWindowChangeEvent(event: AccessibilityEvent) {
-        val hasCopyAffordance = hasWindowCopyAffordance(event)
+    private fun handleWindowChangeEvent(event: AccessibilityEvent, aggressiveMode: Boolean) {
+        if (aggressiveMode) {
+            val removedWindowSeenAtMs = heuristics.onWindowsRemoved(event.windowChanges)
+            if (removedWindowSeenAtMs != null) {
+                cancelWindowProbe()
+                if (BuildConfig.DEBUG) {
+                    Log.d(
+                        TAG,
+                        "Aggressive removal trigger: type=${eventTypeName(event.eventType)} " +
+                            "windowChanges=${event.windowChanges}"
+                    )
+                }
+                triggerCopyDetected(
+                    "${eventTypeName(event.eventType)} removed",
+                    ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                    minClipboardTimestampMs = removedWindowSeenAtMs
+                )
+                return
+            }
+
+            val mutationSeenAtMs = heuristics.onAggressiveWindowMutation(event.windowChanges)
+            if (mutationSeenAtMs != null) {
+                cancelWindowProbe()
+                if (BuildConfig.DEBUG) {
+                    Log.d(
+                        TAG,
+                        "Aggressive mutation trigger: type=${eventTypeName(event.eventType)} " +
+                            "windowChanges=${event.windowChanges}"
+                    )
+                }
+                triggerCopyDetected(
+                    "${eventTypeName(event.eventType)} mutation",
+                    ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                    minClipboardTimestampMs = mutationSeenAtMs
+                )
+                return
+            }
+        }
+
+        val hasCopyAffordance = hasWindowCopyAffordance(event, aggressiveMode)
         val affordanceSeenAtMs = heuristics.onCopyAffordanceChanged(hasCopyAffordance)
         if (affordanceSeenAtMs != null) {
+            cancelWindowProbe()
             triggerCopyDetected(
                 "${eventTypeName(event.eventType)} close",
                 ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
@@ -68,7 +115,11 @@ class ClipboardAccessibilityService : AccessibilityService() {
             )
         } else if (hasCopyAffordance) {
             Log.d(TAG, "Copy affordance visible via ${eventTypeName(event.eventType)}")
+            if (aggressiveMode || heuristics.shouldUseConservativeDelayedProbe(event.packageName)) {
+                scheduleWindowProbe(event)
+            }
         } else {
+            cancelWindowProbe()
             logPotentialMissIfDebug("window_state", event)
         }
     }
@@ -127,16 +178,22 @@ class ClipboardAccessibilityService : AccessibilityService() {
         return signals.asSequence()
     }
 
-    private fun hasWindowCopyAffordance(event: AccessibilityEvent): Boolean {
-        if (heuristics.containsCopyWindowText(windowStateSignals(event))) {
+    private fun hasWindowCopyAffordance(event: AccessibilityEvent, aggressiveMode: Boolean): Boolean {
+        val windowSignals = windowStateSignals(event).toList()
+        if (heuristics.containsCopyWindowText(windowSignals.asSequence())) {
+            logWindowSignalsIfDebug("event", event, windowSignals)
             return true
         }
 
         val root = rootInActiveWindow ?: return false
-        return activeWindowHasCopyAffordance(root)
+        return activeWindowHasCopyAffordance(root, aggressiveMode, event)
     }
 
-    private fun activeWindowHasCopyAffordance(root: AccessibilityNodeInfo): Boolean {
+    private fun activeWindowHasCopyAffordance(
+        root: AccessibilityNodeInfo,
+        aggressiveMode: Boolean,
+        event: AccessibilityEvent
+    ): Boolean {
         val queue = ArrayDeque<AccessibilityNodeInfo>()
         queue.add(root)
         var inspectedNodes = 0
@@ -146,10 +203,12 @@ class ClipboardAccessibilityService : AccessibilityService() {
             try {
                 inspectedNodes += 1
                 if (node.actionList.any { it.id == AccessibilityNodeInfo.ACTION_COPY }) {
+                    logRootMatchIfDebug(event, "action_copy", nodeSignals(node).toList())
                     recycleQueue(queue)
                     return true
                 }
-                if (nodeHasActionableCopyLabel(node)) {
+                val nodeSignals = nodeSignals(node).toList()
+                if (nodeHasActionableCopyLabel(node, nodeSignals, aggressiveMode, event)) {
                     recycleQueue(queue)
                     return true
                 }
@@ -167,12 +226,23 @@ class ClipboardAccessibilityService : AccessibilityService() {
         return false
     }
 
-    private fun nodeHasActionableCopyLabel(node: AccessibilityNodeInfo): Boolean {
-        if (!heuristics.containsCopyWindowText(nodeSignals(node))) {
+    private fun nodeHasActionableCopyLabel(
+        node: AccessibilityNodeInfo,
+        nodeSignals: List<String>,
+        aggressiveMode: Boolean,
+        event: AccessibilityEvent
+    ): Boolean {
+        if (!heuristics.containsCopyWindowText(nodeSignals.asSequence())) {
             return false
         }
 
+        if (aggressiveMode) {
+            logRootMatchIfDebug(event, "aggressive_text", nodeSignals)
+            return true
+        }
+
         if (isActionableNode(node)) {
+            logRootMatchIfDebug(event, "node_actionable", nodeSignals)
             return true
         }
 
@@ -181,6 +251,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
         while (currentParent != null && depth < MAX_ACTIONABLE_ANCESTOR_DEPTH) {
             val parent = currentParent
             if (isActionableNode(parent)) {
+                logRootMatchIfDebug(event, "ancestor_actionable_$depth", nodeSignals)
                 parent.recycle()
                 return true
             }
@@ -189,6 +260,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
             depth += 1
         }
 
+        logRootMatchIfDebug(event, "copy_text_without_actionable_parent", nodeSignals)
         return false
     }
 
@@ -206,6 +278,41 @@ class ClipboardAccessibilityService : AccessibilityService() {
         while (queue.isNotEmpty()) {
             queue.removeFirst().recycle()
         }
+    }
+
+    private fun scheduleWindowProbe(event: AccessibilityEvent) {
+        if (
+            event.eventType != AccessibilityEvent.TYPE_WINDOWS_CHANGED ||
+            event.windowChanges and AccessibilityEvent.WINDOWS_CHANGE_CHILDREN == 0
+        ) {
+            return
+        }
+
+        val token = windowProbeToken.incrementAndGet()
+        val seenWallClockAtMs = System.currentTimeMillis()
+        pendingWindowProbe?.let(mainHandler::removeCallbacks)
+        pendingWindowProbe = Runnable {
+            if (windowProbeToken.get() != token) return@Runnable
+            if (BuildConfig.DEBUG) {
+                Log.d(
+                    TAG,
+                    "Aggressive delayed probe: type=${eventTypeName(event.eventType)} " +
+                        "windowChanges=${event.windowChanges}"
+                )
+            }
+            triggerCopyDetected(
+                "${eventTypeName(event.eventType)} delayed_probe",
+                ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                minClipboardTimestampMs = seenWallClockAtMs
+            )
+        }
+        mainHandler.postDelayed(pendingWindowProbe!!, WINDOW_PROBE_DELAY_MS)
+    }
+
+    private fun cancelWindowProbe() {
+        windowProbeToken.incrementAndGet()
+        pendingWindowProbe?.let(mainHandler::removeCallbacks)
+        pendingWindowProbe = null
     }
 
     private fun logPotentialMissIfDebug(reason: String, event: AccessibilityEvent) {
@@ -247,10 +354,41 @@ class ClipboardAccessibilityService : AccessibilityService() {
         return heuristics.debugCopyCandidates(signals.asSequence())
     }
 
+    private fun logWindowSignalsIfDebug(
+        source: String,
+        event: AccessibilityEvent,
+        signals: List<String>
+    ) {
+        if (!BuildConfig.DEBUG) return
+        val candidates = heuristics.debugCopyCandidates(signals.asSequence())
+        if (candidates.isEmpty()) return
+        Log.d(
+            TAG,
+            "Window copy candidates: source=$source type=${eventTypeName(event.eventType)} " +
+                "windowChanges=${event.windowChanges} candidates=$candidates"
+        )
+    }
+
+    private fun logRootMatchIfDebug(
+        event: AccessibilityEvent,
+        reason: String,
+        signals: List<String>
+    ) {
+        if (!BuildConfig.DEBUG) return
+        val candidates = heuristics.debugCopyCandidates(signals.asSequence())
+        if (candidates.isEmpty()) return
+        Log.d(
+            TAG,
+            "Root copy match: reason=$reason type=${eventTypeName(event.eventType)} " +
+                "windowChanges=${event.windowChanges} candidates=$candidates"
+        )
+    }
+
     companion object {
         private const val TAG = "ClipboardA11y"
         private const val MAX_WINDOW_SCAN_NODES = 64
         private const val MAX_ACTIONABLE_ANCESTOR_DEPTH = 2
+        private const val WINDOW_PROBE_DELAY_MS = 900L
     }
 
     private fun triggerCopyDetected(
@@ -271,6 +409,12 @@ class ClipboardAccessibilityService : AccessibilityService() {
     }
 
     override fun onInterrupt() {
+        cancelWindowProbe()
         Log.d(TAG, "Accessibility service interrupted")
+    }
+
+    override fun onDestroy() {
+        cancelWindowProbe()
+        super.onDestroy()
     }
 }

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -70,7 +70,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
         val source = event.source
         if (source != null) {
             try {
-                if (hasActionCopy(source)) {
+                if (nodeMatchesCopy(source)) {
                     return true
                 }
             } finally {
@@ -80,14 +80,25 @@ class ClipboardAccessibilityService : AccessibilityService() {
         return heuristics.containsCopyCommandText(eventSignals(event))
     }
 
-    private fun hasActionCopy(node: AccessibilityNodeInfo): Boolean {
-        return node.actionList.any { it.id == AccessibilityNodeInfo.ACTION_COPY }
+    private fun nodeMatchesCopy(node: AccessibilityNodeInfo): Boolean {
+        if (node.actionList.any { it.id == AccessibilityNodeInfo.ACTION_COPY }) {
+            return true
+        }
+
+        return heuristics.containsCopyCommandText(nodeSignals(node))
     }
 
     private fun eventSignals(event: AccessibilityEvent): Sequence<String> {
         val eventText = event.text.asSequence().map { it.toString() }
         val contentDescription = sequenceOf(event.contentDescription?.toString()).filterNotNull()
         return eventText + contentDescription
+    }
+
+    private fun nodeSignals(node: AccessibilityNodeInfo): Sequence<String> {
+        val nodeText = sequenceOf(node.text?.toString()).filterNotNull()
+        val contentDescription = sequenceOf(node.contentDescription?.toString()).filterNotNull()
+        val actionLabels = node.actionList.asSequence().mapNotNull { it.label?.toString() }
+        return nodeText + contentDescription + actionLabels
     }
 
     companion object {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -38,8 +38,6 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
         when (event.eventType) {
             AccessibilityEvent.TYPE_VIEW_CLICKED -> handleClickEvent(event)
-            AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED -> handleNotificationEvent(event)
-            AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> handleWindowSnapshotEvent(event, "window content changed")
             AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> handleWindowStateChanged(event)
         }
     }
@@ -55,85 +53,28 @@ class ClipboardAccessibilityService : AccessibilityService() {
     // ── TYPE_WINDOW_STATE_CHANGED detection (Chrome, etc.) ───────────
 
     private fun handleWindowStateChanged(event: AccessibilityEvent) {
-        handleWindowSnapshotEvent(event, "window state changed")
-    }
-
-    private fun handleNotificationEvent(event: AccessibilityEvent) {
-        if (heuristics.containsCopyConfirmationText(eventSignals(event))) {
-            triggerCopyDetected("notification")
+        val hasCopyAffordance = heuristics.containsCopyText(eventSignals(event))
+        if (heuristics.onCopyAffordanceChanged(hasCopyAffordance)) {
+            triggerCopyDetected("window state changed close")
+        } else if (hasCopyAffordance) {
+            Log.d(TAG, "Copy affordance visible via window state changed")
         }
     }
 
     // ── Helpers ──────────────────────────────────────────────────────
 
-    private fun handleWindowSnapshotEvent(event: AccessibilityEvent, reason: String) {
-        val hasCopyAffordance = snapshotHasCopyAffordance(event)
-        if (heuristics.onCopyAffordanceChanged(hasCopyAffordance)) {
-            triggerCopyDetected("$reason close")
-        } else if (hasCopyAffordance) {
-            Log.d(TAG, "Copy affordance visible via $reason")
-        }
-    }
-
     private fun eventMatchesCopy(event: AccessibilityEvent): Boolean {
-        if (snapshotHasCopyAffordance(event)) {
-            return true
-        }
-        return heuristics.containsCopyText(eventSignals(event))
-    }
-
-    private fun snapshotHasCopyAffordance(event: AccessibilityEvent): Boolean {
         val source = event.source
         if (source != null) {
             try {
-                if (nodeContainsCopySignal(source, 0)) {
+                if (hasActionCopy(source)) {
                     return true
                 }
             } finally {
-                @Suppress("DEPRECATION")
                 source.recycle()
             }
         }
-
-        val root = rootInActiveWindow
-        if (root != null) {
-            try {
-                if (nodeContainsCopySignal(root, 0)) {
-                    return true
-                }
-            } finally {
-                @Suppress("DEPRECATION")
-                root.recycle()
-            }
-        }
-
         return heuristics.containsCopyText(eventSignals(event))
-    }
-
-    private fun nodeContainsCopySignal(node: AccessibilityNodeInfo, depth: Int): Boolean {
-        if (depth > MAX_NODE_DEPTH) return false
-        if (hasActionCopy(node)) return true
-
-        val nodeSignals = sequenceOf(
-            node.text?.toString(),
-            node.contentDescription?.toString()
-        ).filterNotNull()
-        if (heuristics.containsCopyText(nodeSignals)) {
-            return true
-        }
-
-        for (index in 0 until node.childCount) {
-            val child = node.getChild(index) ?: continue
-            try {
-                if (nodeContainsCopySignal(child, depth + 1)) {
-                    return true
-                }
-            } finally {
-                @Suppress("DEPRECATION")
-                child.recycle()
-            }
-        }
-        return false
     }
 
     private fun hasActionCopy(node: AccessibilityNodeInfo): Boolean {
@@ -148,7 +89,6 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
     companion object {
         private const val TAG = "ClipboardA11y"
-        private const val MAX_NODE_DEPTH = 5
     }
 
     private fun triggerCopyDetected(reason: String) {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -68,7 +68,12 @@ class ClipboardAccessibilityService : AccessibilityService() {
     // ── TYPE_WINDOW_STATE_CHANGED detection (Chrome, etc.) ───────────
 
     private fun handleWindowChangeEvent(event: AccessibilityEvent, aggressiveMode: Boolean) {
-        if (aggressiveMode) {
+        val probeStrategy = heuristics.windowProbeStrategy(
+            packageName = event.packageName,
+            aggressiveMode = aggressiveMode
+        )
+
+        if (probeStrategy == WindowProbeStrategy.AGGRESSIVE) {
             val removedWindowSeenAtMs = heuristics.onWindowsRemoved(event.windowChanges)
             if (removedWindowSeenAtMs != null) {
                 cancelWindowProbe()
@@ -79,9 +84,8 @@ class ClipboardAccessibilityService : AccessibilityService() {
                             "windowChanges=${event.windowChanges}"
                     )
                 }
-                triggerCopyDetected(
-                    "${eventTypeName(event.eventType)} removed",
-                    ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                triggerToolbarCloseIfFresh(
+                    reason = "${eventTypeName(event.eventType)} removed",
                     minClipboardTimestampMs = removedWindowSeenAtMs
                 )
                 return
@@ -97,9 +101,8 @@ class ClipboardAccessibilityService : AccessibilityService() {
                             "windowChanges=${event.windowChanges}"
                     )
                 }
-                triggerCopyDetected(
-                    "${eventTypeName(event.eventType)} mutation",
-                    ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                triggerToolbarCloseIfFresh(
+                    reason = "${eventTypeName(event.eventType)} mutation",
                     minClipboardTimestampMs = mutationSeenAtMs
                 )
                 return
@@ -110,14 +113,13 @@ class ClipboardAccessibilityService : AccessibilityService() {
         val affordanceSeenAtMs = heuristics.onCopyAffordanceChanged(hasCopyAffordance)
         if (affordanceSeenAtMs != null) {
             cancelWindowProbe()
-            triggerCopyDetected(
-                "${eventTypeName(event.eventType)} close",
-                ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+            triggerToolbarCloseIfFresh(
+                reason = "${eventTypeName(event.eventType)} close",
                 minClipboardTimestampMs = affordanceSeenAtMs
             )
         } else if (hasCopyAffordance) {
             Log.d(TAG, "Copy affordance visible via ${eventTypeName(event.eventType)}")
-            if (aggressiveMode || heuristics.shouldUseConservativeDelayedProbe(event.packageName)) {
+            if (probeStrategy != WindowProbeStrategy.NONE) {
                 scheduleWindowProbe(event)
             }
         } else {
@@ -298,7 +300,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
         pendingWindowProbe = Runnable {
             if (windowProbeToken.get() != token) return@Runnable
             val clipboardTimestampMs = currentClipboardTimestampMs()
-            if (!delayedProbeHasFreshClipboardTimestamp(clipboardTimestampMs, seenWallClockAtMs)) {
+            if (!toolbarCloseShouldTriggerRead(clipboardTimestampMs, seenWallClockAtMs)) {
                 if (BuildConfig.DEBUG) {
                     Log.d(
                         TAG,
@@ -322,6 +324,25 @@ class ClipboardAccessibilityService : AccessibilityService() {
             )
         }
         mainHandler.postDelayed(pendingWindowProbe!!, WINDOW_PROBE_DELAY_MS)
+    }
+
+    private fun triggerToolbarCloseIfFresh(reason: String, minClipboardTimestampMs: Long) {
+        val clipboardTimestampMs = currentClipboardTimestampMs()
+        if (!toolbarCloseShouldTriggerRead(clipboardTimestampMs, minClipboardTimestampMs)) {
+            if (BuildConfig.DEBUG) {
+                Log.d(
+                    TAG,
+                    "Skipping toolbar close trigger: clipboard timestamp=$clipboardTimestampMs " +
+                        "min=$minClipboardTimestampMs reason=$reason"
+                )
+            }
+            return
+        }
+        triggerCopyDetected(
+            reason = reason,
+            triggerSource = ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+            minClipboardTimestampMs = minClipboardTimestampMs
+        )
     }
 
     private fun currentClipboardTimestampMs(): Long? {
@@ -414,14 +435,14 @@ class ClipboardAccessibilityService : AccessibilityService() {
         private const val MAX_WINDOW_SCAN_NODES = 64
         private const val MAX_ACTIONABLE_ANCESTOR_DEPTH = 2
         private const val WINDOW_PROBE_DELAY_MS = 900L
-        private const val DELAYED_PROBE_CLIPBOARD_SKEW_MS = 250L
+        private const val TOOLBAR_CLOSE_CLIPBOARD_SKEW_MS = 1_000L
 
-        internal fun delayedProbeHasFreshClipboardTimestamp(
+        internal fun toolbarCloseShouldTriggerRead(
             clipboardTimestampMs: Long?,
             minClipboardTimestampMs: Long
         ): Boolean {
             return clipboardTimestampMs != null &&
-                clipboardTimestampMs + DELAYED_PROBE_CLIPBOARD_SKEW_MS >= minClipboardTimestampMs
+                clipboardTimestampMs + TOOLBAR_CLOSE_CLIPBOARD_SKEW_MS >= minClipboardTimestampMs
         }
     }
 

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -39,7 +39,8 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
         when (event.eventType) {
             AccessibilityEvent.TYPE_VIEW_CLICKED -> handleClickEvent(event)
-            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> handleWindowStateChanged(event)
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+            AccessibilityEvent.TYPE_WINDOWS_CHANGED -> handleWindowChangeEvent(event)
         }
     }
 
@@ -56,17 +57,17 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
     // ── TYPE_WINDOW_STATE_CHANGED detection (Chrome, etc.) ───────────
 
-    private fun handleWindowStateChanged(event: AccessibilityEvent) {
-        val hasCopyAffordance = heuristics.containsCopyWindowText(eventSignals(event))
+    private fun handleWindowChangeEvent(event: AccessibilityEvent) {
+        val hasCopyAffordance = hasWindowCopyAffordance(event)
         val affordanceSeenAtMs = heuristics.onCopyAffordanceChanged(hasCopyAffordance)
         if (affordanceSeenAtMs != null) {
             triggerCopyDetected(
-                "window state changed close",
+                "${eventTypeName(event.eventType)} close",
                 ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
                 minClipboardTimestampMs = affordanceSeenAtMs
             )
         } else if (hasCopyAffordance) {
-            Log.d(TAG, "Copy affordance visible via window state changed")
+            Log.d(TAG, "Copy affordance visible via ${eventTypeName(event.eventType)}")
         } else {
             logPotentialMissIfDebug("window_state", event)
         }
@@ -109,6 +110,83 @@ class ClipboardAccessibilityService : AccessibilityService() {
         return nodeText + contentDescription + actionLabels
     }
 
+    private fun windowStateSignals(event: AccessibilityEvent): Sequence<String> {
+        val signals = mutableListOf<String>()
+        signals += event.text.map { it.toString() }
+        event.contentDescription?.toString()?.let(signals::add)
+
+        val source = event.source
+        if (source != null) {
+            try {
+                signals += nodeSignals(source).toList()
+            } finally {
+                source.recycle()
+            }
+        }
+
+        return signals.asSequence()
+    }
+
+    private fun hasWindowCopyAffordance(event: AccessibilityEvent): Boolean {
+        if (heuristics.containsCopyWindowText(windowStateSignals(event))) {
+            return true
+        }
+
+        val root = rootInActiveWindow ?: return false
+        return activeWindowHasCopyAffordance(root)
+    }
+
+    private fun activeWindowHasCopyAffordance(root: AccessibilityNodeInfo): Boolean {
+        val queue = ArrayDeque<AccessibilityNodeInfo>()
+        queue.add(root)
+        var inspectedNodes = 0
+
+        while (queue.isNotEmpty() && inspectedNodes < MAX_WINDOW_SCAN_NODES) {
+            val node = queue.removeFirst()
+            try {
+                inspectedNodes += 1
+                if (node.actionList.any { it.id == AccessibilityNodeInfo.ACTION_COPY }) {
+                    recycleQueue(queue)
+                    return true
+                }
+                if (nodeHasActionableCopyLabel(node)) {
+                    recycleQueue(queue)
+                    return true
+                }
+
+                val childCount = node.childCount
+                for (index in 0 until childCount) {
+                    node.getChild(index)?.let(queue::addLast)
+                }
+            } finally {
+                node.recycle()
+            }
+        }
+
+        recycleQueue(queue)
+        return false
+    }
+
+    private fun nodeHasActionableCopyLabel(node: AccessibilityNodeInfo): Boolean {
+        if (!heuristics.containsCopyWindowText(nodeSignals(node))) {
+            return false
+        }
+
+        return node.isClickable ||
+            node.isLongClickable ||
+            node.isFocusable ||
+            node.actionList.any { action ->
+                action.id == AccessibilityNodeInfo.ACTION_CLICK ||
+                    action.id == AccessibilityNodeInfo.ACTION_LONG_CLICK
+            }
+    }
+
+    private fun recycleQueue(queue: ArrayDeque<AccessibilityNodeInfo>) {
+        while (queue.isNotEmpty()) {
+            queue.removeFirst().recycle()
+        }
+    }
+
     private fun logPotentialMissIfDebug(reason: String, event: AccessibilityEvent) {
         if (!BuildConfig.DEBUG) return
 
@@ -126,6 +204,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
         return when (eventType) {
             AccessibilityEvent.TYPE_VIEW_CLICKED -> "view_clicked"
             AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> "window_state_changed"
+            AccessibilityEvent.TYPE_WINDOWS_CHANGED -> "windows_changed"
             else -> eventType.toString()
         }
     }
@@ -149,6 +228,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
     companion object {
         private const val TAG = "ClipboardA11y"
+        private const val MAX_WINDOW_SCAN_NODES = 64
     }
 
     private fun triggerCopyDetected(

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -57,11 +57,13 @@ class ClipboardAccessibilityService : AccessibilityService() {
     // ── TYPE_WINDOW_STATE_CHANGED detection (Chrome, etc.) ───────────
 
     private fun handleWindowStateChanged(event: AccessibilityEvent) {
-        val hasCopyAffordance = heuristics.containsCopyWindowText(packageName(event), eventSignals(event))
-        if (heuristics.onCopyAffordanceChanged(hasCopyAffordance)) {
+        val hasCopyAffordance = heuristics.containsCopyWindowText(eventSignals(event))
+        val affordanceSeenAtMs = heuristics.onCopyAffordanceChanged(hasCopyAffordance)
+        if (affordanceSeenAtMs != null) {
             triggerCopyDetected(
                 "window state changed close",
-                ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE
+                ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                minClipboardTimestampMs = affordanceSeenAtMs
             )
         } else if (hasCopyAffordance) {
             Log.d(TAG, "Copy affordance visible via window state changed")
@@ -107,8 +109,6 @@ class ClipboardAccessibilityService : AccessibilityService() {
         return nodeText + contentDescription + actionLabels
     }
 
-    private fun packageName(event: AccessibilityEvent): String? = event.packageName?.toString()
-
     private fun logPotentialMissIfDebug(reason: String, event: AccessibilityEvent) {
         if (!BuildConfig.DEBUG) return
 
@@ -118,7 +118,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
         Log.d(
             TAG,
             "Potential copy miss: reason=$reason type=${eventTypeName(event.eventType)} " +
-                "pkg=${packageName(event) ?: "unknown"} candidates=$candidates"
+                "pkg=${event.packageName?.toString() ?: "unknown"} candidates=$candidates"
         )
     }
 
@@ -151,12 +151,19 @@ class ClipboardAccessibilityService : AccessibilityService() {
         private const val TAG = "ClipboardA11y"
     }
 
-    private fun triggerCopyDetected(reason: String, triggerSource: String) {
+    private fun triggerCopyDetected(
+        reason: String,
+        triggerSource: String,
+        minClipboardTimestampMs: Long? = null
+    ) {
         heuristics.resetAfterDirectDetection()
         Log.d(TAG, "Copy detected via $reason")
         val intent = Intent(this, ClipRelayService::class.java).apply {
             action = ClipRelayService.ACTION_ACCESSIBILITY_COPY_DETECTED
             putExtra(ClipRelayService.EXTRA_CLIPBOARD_TRIGGER_SOURCE, triggerSource)
+            minClipboardTimestampMs?.let {
+                putExtra(ClipRelayService.EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS, it)
+            }
         }
         ContextCompat.startForegroundService(this, intent)
     }

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -74,7 +74,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
                 source.recycle()
             }
         }
-        return heuristics.containsCopyText(eventSignals(event))
+        return heuristics.containsCopyCommandText(eventSignals(event))
     }
 
     private fun hasActionCopy(node: AccessibilityNodeInfo): Boolean {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -172,6 +172,27 @@ class ClipboardAccessibilityService : AccessibilityService() {
             return false
         }
 
+        if (isActionableNode(node)) {
+            return true
+        }
+
+        var currentParent = node.parent
+        var depth = 0
+        while (currentParent != null && depth < MAX_ACTIONABLE_ANCESTOR_DEPTH) {
+            val parent = currentParent
+            if (isActionableNode(parent)) {
+                parent.recycle()
+                return true
+            }
+            currentParent = parent.parent
+            parent.recycle()
+            depth += 1
+        }
+
+        return false
+    }
+
+    private fun isActionableNode(node: AccessibilityNodeInfo): Boolean {
         return node.isClickable ||
             node.isLongClickable ||
             node.isFocusable ||
@@ -229,6 +250,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
     companion object {
         private const val TAG = "ClipboardA11y"
         private const val MAX_WINDOW_SCAN_NODES = 64
+        private const val MAX_ACTIONABLE_ANCESTOR_DEPTH = 2
     }
 
     private fun triggerCopyDetected(

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -281,9 +281,11 @@ class ClipboardAccessibilityService : AccessibilityService() {
     }
 
     private fun scheduleWindowProbe(event: AccessibilityEvent) {
+        val eventType = event.eventType
+        val windowChanges = event.windowChanges
         if (
-            event.eventType != AccessibilityEvent.TYPE_WINDOWS_CHANGED ||
-            event.windowChanges and AccessibilityEvent.WINDOWS_CHANGE_CHILDREN == 0
+            eventType != AccessibilityEvent.TYPE_WINDOWS_CHANGED ||
+            windowChanges and AccessibilityEvent.WINDOWS_CHANGE_CHILDREN == 0
         ) {
             return
         }
@@ -296,12 +298,12 @@ class ClipboardAccessibilityService : AccessibilityService() {
             if (BuildConfig.DEBUG) {
                 Log.d(
                     TAG,
-                    "Aggressive delayed probe: type=${eventTypeName(event.eventType)} " +
-                        "windowChanges=${event.windowChanges}"
+                    "Aggressive delayed probe: type=${eventTypeName(eventType)} " +
+                        "windowChanges=$windowChanges"
                 )
             }
             triggerCopyDetected(
-                "${eventTypeName(event.eventType)} delayed_probe",
+                "${eventTypeName(eventType)} delayed_probe",
                 ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
                 minClipboardTimestampMs = seenWallClockAtMs
             )

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -13,6 +13,8 @@ package org.cliprelay.service
 //      This avoids stealing focus while the toolbar is still visible.
 
 import android.accessibilityservice.AccessibilityService
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
@@ -295,6 +297,17 @@ class ClipboardAccessibilityService : AccessibilityService() {
         pendingWindowProbe?.let(mainHandler::removeCallbacks)
         pendingWindowProbe = Runnable {
             if (windowProbeToken.get() != token) return@Runnable
+            val clipboardTimestampMs = currentClipboardTimestampMs()
+            if (!delayedProbeHasFreshClipboardTimestamp(clipboardTimestampMs, seenWallClockAtMs)) {
+                if (BuildConfig.DEBUG) {
+                    Log.d(
+                        TAG,
+                        "Skipping delayed probe: clipboard timestamp=$clipboardTimestampMs " +
+                            "min=$seenWallClockAtMs"
+                    )
+                }
+                return@Runnable
+            }
             if (BuildConfig.DEBUG) {
                 Log.d(
                     TAG,
@@ -309,6 +322,16 @@ class ClipboardAccessibilityService : AccessibilityService() {
             )
         }
         mainHandler.postDelayed(pendingWindowProbe!!, WINDOW_PROBE_DELAY_MS)
+    }
+
+    private fun currentClipboardTimestampMs(): Long? {
+        val clipboardManager =
+            getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return null
+        return try {
+            clipboardManager.primaryClipDescription?.timestamp
+        } catch (_: SecurityException) {
+            null
+        }
     }
 
     private fun cancelWindowProbe() {
@@ -391,6 +414,15 @@ class ClipboardAccessibilityService : AccessibilityService() {
         private const val MAX_WINDOW_SCAN_NODES = 64
         private const val MAX_ACTIONABLE_ANCESTOR_DEPTH = 2
         private const val WINDOW_PROBE_DELAY_MS = 900L
+        private const val DELAYED_PROBE_CLIPBOARD_SKEW_MS = 250L
+
+        internal fun delayedProbeHasFreshClipboardTimestamp(
+            clipboardTimestampMs: Long?,
+            minClipboardTimestampMs: Long
+        ): Boolean {
+            return clipboardTimestampMs != null &&
+                clipboardTimestampMs + DELAYED_PROBE_CLIPBOARD_SKEW_MS >= minClipboardTimestampMs
+        }
     }
 
     private fun triggerCopyDetected(

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -85,6 +85,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
                     )
                 }
                 triggerToolbarCloseIfFresh(
+                    strategy = probeStrategy,
                     reason = "${eventTypeName(event.eventType)} removed",
                     minClipboardTimestampMs = removedWindowSeenAtMs
                 )
@@ -102,6 +103,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
                     )
                 }
                 triggerToolbarCloseIfFresh(
+                    strategy = probeStrategy,
                     reason = "${eventTypeName(event.eventType)} mutation",
                     minClipboardTimestampMs = mutationSeenAtMs
                 )
@@ -114,13 +116,14 @@ class ClipboardAccessibilityService : AccessibilityService() {
         if (affordanceSeenAtMs != null) {
             cancelWindowProbe()
             triggerToolbarCloseIfFresh(
+                strategy = probeStrategy,
                 reason = "${eventTypeName(event.eventType)} close",
                 minClipboardTimestampMs = affordanceSeenAtMs
             )
         } else if (hasCopyAffordance) {
             Log.d(TAG, "Copy affordance visible via ${eventTypeName(event.eventType)}")
             if (probeStrategy != WindowProbeStrategy.NONE) {
-                scheduleWindowProbe(event)
+                scheduleWindowProbe(event, probeStrategy)
             }
         } else {
             cancelWindowProbe()
@@ -284,7 +287,10 @@ class ClipboardAccessibilityService : AccessibilityService() {
         }
     }
 
-    private fun scheduleWindowProbe(event: AccessibilityEvent) {
+    private fun scheduleWindowProbe(
+        event: AccessibilityEvent,
+        strategy: WindowProbeStrategy
+    ) {
         val eventType = event.eventType
         val windowChanges = event.windowChanges
         if (
@@ -300,12 +306,12 @@ class ClipboardAccessibilityService : AccessibilityService() {
         pendingWindowProbe = Runnable {
             if (windowProbeToken.get() != token) return@Runnable
             val clipboardTimestampMs = currentClipboardTimestampMs()
-            if (!toolbarCloseShouldTriggerRead(clipboardTimestampMs, seenWallClockAtMs)) {
+            if (!shouldPreflightToolbarRead(strategy, clipboardTimestampMs, seenWallClockAtMs)) {
                 if (BuildConfig.DEBUG) {
                     Log.d(
                         TAG,
-                        "Skipping delayed probe: clipboard timestamp=$clipboardTimestampMs " +
-                            "min=$seenWallClockAtMs"
+                        "Skipping delayed probe: strategy=$strategy " +
+                            "clipboard timestamp=$clipboardTimestampMs min=$seenWallClockAtMs"
                     )
                 }
                 return@Runnable
@@ -326,14 +332,18 @@ class ClipboardAccessibilityService : AccessibilityService() {
         mainHandler.postDelayed(pendingWindowProbe!!, WINDOW_PROBE_DELAY_MS)
     }
 
-    private fun triggerToolbarCloseIfFresh(reason: String, minClipboardTimestampMs: Long) {
+    private fun triggerToolbarCloseIfFresh(
+        strategy: WindowProbeStrategy,
+        reason: String,
+        minClipboardTimestampMs: Long
+    ) {
         val clipboardTimestampMs = currentClipboardTimestampMs()
-        if (!toolbarCloseShouldTriggerRead(clipboardTimestampMs, minClipboardTimestampMs)) {
+        if (!shouldPreflightToolbarRead(strategy, clipboardTimestampMs, minClipboardTimestampMs)) {
             if (BuildConfig.DEBUG) {
                 Log.d(
                     TAG,
-                    "Skipping toolbar close trigger: clipboard timestamp=$clipboardTimestampMs " +
-                        "min=$minClipboardTimestampMs reason=$reason"
+                    "Skipping toolbar close trigger: strategy=$strategy " +
+                        "clipboard timestamp=$clipboardTimestampMs min=$minClipboardTimestampMs reason=$reason"
                 )
             }
             return
@@ -437,12 +447,15 @@ class ClipboardAccessibilityService : AccessibilityService() {
         private const val WINDOW_PROBE_DELAY_MS = 900L
         private const val TOOLBAR_CLOSE_CLIPBOARD_SKEW_MS = 1_000L
 
-        internal fun toolbarCloseShouldTriggerRead(
+        internal fun shouldPreflightToolbarRead(
+            strategy: WindowProbeStrategy,
             clipboardTimestampMs: Long?,
             minClipboardTimestampMs: Long
         ): Boolean {
-            return clipboardTimestampMs != null &&
-                clipboardTimestampMs + TOOLBAR_CLOSE_CLIPBOARD_SKEW_MS >= minClipboardTimestampMs
+            if (clipboardTimestampMs == null) {
+                return strategy != WindowProbeStrategy.NONE
+            }
+            return clipboardTimestampMs + TOOLBAR_CLOSE_CLIPBOARD_SKEW_MS >= minClipboardTimestampMs
         }
     }
 

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -18,6 +18,7 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import org.cliprelay.BuildConfig
 import org.cliprelay.settings.ClipboardSettingsStore
 
 class ClipboardAccessibilityService : AccessibilityService() {
@@ -45,15 +46,18 @@ class ClipboardAccessibilityService : AccessibilityService() {
     // ── TYPE_VIEW_CLICKED detection (most apps) ──────────────────────
 
     private fun handleClickEvent(event: AccessibilityEvent) {
-        if (eventMatchesCopy(event)) {
+        val matched = eventMatchesCopy(event)
+        if (matched) {
             triggerCopyDetected("click", ClipRelayService.CLIPBOARD_TRIGGER_DIRECT)
+        } else {
+            logPotentialMissIfDebug("click", event)
         }
     }
 
     // ── TYPE_WINDOW_STATE_CHANGED detection (Chrome, etc.) ───────────
 
     private fun handleWindowStateChanged(event: AccessibilityEvent) {
-        val hasCopyAffordance = heuristics.containsCopyText(eventSignals(event))
+        val hasCopyAffordance = heuristics.containsCopyWindowText(packageName(event), eventSignals(event))
         if (heuristics.onCopyAffordanceChanged(hasCopyAffordance)) {
             triggerCopyDetected(
                 "window state changed close",
@@ -61,6 +65,8 @@ class ClipboardAccessibilityService : AccessibilityService() {
             )
         } else if (hasCopyAffordance) {
             Log.d(TAG, "Copy affordance visible via window state changed")
+        } else {
+            logPotentialMissIfDebug("window_state", event)
         }
     }
 
@@ -99,6 +105,46 @@ class ClipboardAccessibilityService : AccessibilityService() {
         val contentDescription = sequenceOf(node.contentDescription?.toString()).filterNotNull()
         val actionLabels = node.actionList.asSequence().mapNotNull { it.label?.toString() }
         return nodeText + contentDescription + actionLabels
+    }
+
+    private fun packageName(event: AccessibilityEvent): String? = event.packageName?.toString()
+
+    private fun logPotentialMissIfDebug(reason: String, event: AccessibilityEvent) {
+        if (!BuildConfig.DEBUG) return
+
+        val candidates = eventDebugCandidates(event)
+        if (candidates.isEmpty()) return
+
+        Log.d(
+            TAG,
+            "Potential copy miss: reason=$reason type=${eventTypeName(event.eventType)} " +
+                "pkg=${packageName(event) ?: "unknown"} candidates=$candidates"
+        )
+    }
+
+    private fun eventTypeName(eventType: Int): String {
+        return when (eventType) {
+            AccessibilityEvent.TYPE_VIEW_CLICKED -> "view_clicked"
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> "window_state_changed"
+            else -> eventType.toString()
+        }
+    }
+
+    private fun eventDebugCandidates(event: AccessibilityEvent): List<String> {
+        val signals = mutableListOf<String>()
+        signals += event.text.map { it.toString() }
+        event.contentDescription?.toString()?.let(signals::add)
+
+        val source = event.source
+        if (source != null) {
+            try {
+                signals += nodeSignals(source).toList()
+            } finally {
+                source.recycle()
+            }
+        }
+
+        return heuristics.debugCopyCandidates(signals.asSequence())
     }
 
     companion object {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardGhostActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardGhostActivity.kt
@@ -11,6 +11,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.activity.ComponentActivity
+import androidx.core.content.ContextCompat
 
 class ClipboardGhostActivity : ComponentActivity() {
 
@@ -77,7 +78,7 @@ class ClipboardGhostActivity : ComponentActivity() {
             action = ClipRelayService.ACTION_PUSH_TEXT
             putExtra(ClipRelayService.EXTRA_TEXT, text)
         }
-        startService(pushIntent)
+        ContextCompat.startForegroundService(this, pushIntent)
         Log.d(TAG, "Forwarded clipboard text to service (${text.length} chars)")
     }
 
@@ -90,7 +91,7 @@ class ClipboardGhostActivity : ComponentActivity() {
         val clearIntent = Intent(this, ClipRelayService::class.java).apply {
             action = ClipRelayService.ACTION_GHOST_FINISHED
         }
-        startService(clearIntent)
+        ContextCompat.startForegroundService(this, clearIntent)
 
         finish()
         if (android.os.Build.VERSION.SDK_INT >= 34) {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardGhostActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardGhostActivity.kt
@@ -77,6 +77,10 @@ class ClipboardGhostActivity : ComponentActivity() {
         val pushIntent = Intent(this, ClipRelayService::class.java).apply {
             action = ClipRelayService.ACTION_PUSH_TEXT
             putExtra(ClipRelayService.EXTRA_TEXT, text)
+            putExtra(
+                ClipRelayService.EXTRA_CLIPBOARD_TRIGGER_SOURCE,
+                intent.getStringExtra(ClipRelayService.EXTRA_CLIPBOARD_TRIGGER_SOURCE)
+            )
         }
         ContextCompat.startForegroundService(this, pushIntent)
         Log.d(TAG, "Forwarded clipboard text to service (${text.length} chars)")

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardGhostActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardGhostActivity.kt
@@ -72,15 +72,25 @@ class ClipboardGhostActivity : ComponentActivity() {
             Log.d(TAG, "Clipboard text empty")
             return
         }
+        val clipboardTimestampMs = clipboardManager.primaryClipDescription?.timestamp
 
         // Forward to service via the same path as the share sheet
         val pushIntent = Intent(this, ClipRelayService::class.java).apply {
             action = ClipRelayService.ACTION_PUSH_TEXT
             putExtra(ClipRelayService.EXTRA_TEXT, text)
+            clipboardTimestampMs?.let {
+                putExtra(ClipRelayService.EXTRA_CLIPBOARD_TIMESTAMP_MS, it)
+            }
             putExtra(
                 ClipRelayService.EXTRA_CLIPBOARD_TRIGGER_SOURCE,
                 intent.getStringExtra(ClipRelayService.EXTRA_CLIPBOARD_TRIGGER_SOURCE)
             )
+            if (intent.hasExtra(ClipRelayService.EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS)) {
+                putExtra(
+                    ClipRelayService.EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS,
+                    intent.getLongExtra(ClipRelayService.EXTRA_MIN_CLIPBOARD_TIMESTAMP_MS, 0L)
+                )
+            }
         }
         ContextCompat.startForegroundService(this, pushIntent)
         Log.d(TAG, "Forwarded clipboard text to service (${text.length} chars)")

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardSendGate.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardSendGate.kt
@@ -7,6 +7,7 @@ internal class ClipboardSendGate(
     private var lastSentHash: String? = null
     private var lastSentAtMs: Long = 0L
 
+    @Synchronized
     fun shouldSend(hash: String): Boolean {
         val now = nowMs()
         if (hash == lastSentHash && now - lastSentAtMs < suppressionWindowMs) {
@@ -17,6 +18,7 @@ internal class ClipboardSendGate(
         return true
     }
 
+    @Synchronized
     fun reset() {
         lastSentHash = null
         lastSentAtMs = 0L

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardSendGate.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardSendGate.kt
@@ -1,0 +1,28 @@
+package org.cliprelay.service
+
+internal class ClipboardSendGate(
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+    private val suppressionWindowMs: Long = DEFAULT_SUPPRESSION_WINDOW_MS
+) {
+    private var lastSentHash: String? = null
+    private var lastSentAtMs: Long = 0L
+
+    fun shouldSend(hash: String): Boolean {
+        val now = nowMs()
+        if (hash == lastSentHash && now - lastSentAtMs < suppressionWindowMs) {
+            return false
+        }
+        lastSentHash = hash
+        lastSentAtMs = now
+        return true
+    }
+
+    fun reset() {
+        lastSentHash = null
+        lastSentAtMs = 0L
+    }
+
+    companion object {
+        const val DEFAULT_SUPPRESSION_WINDOW_MS = 1_500L
+    }
+}

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardSendGate.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardSendGate.kt
@@ -1,7 +1,9 @@
 package org.cliprelay.service
 
+import android.os.SystemClock
+
 internal class ClipboardSendGate(
-    private val nowMs: () -> Long = { System.currentTimeMillis() },
+    private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
     private val suppressionWindowMs: Long = DEFAULT_SUPPRESSION_WINDOW_MS
 ) {
     private var lastSentHash: String? = null

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardSendGate.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardSendGate.kt
@@ -1,5 +1,8 @@
 package org.cliprelay.service
 
+// Copyright (c) 2026 Christian T. All Rights Reserved.
+// Reference-only source code. See the repository LICENSE for terms.
+
 import android.os.SystemClock
 
 internal class ClipboardSendGate(

--- a/android/app/src/main/java/org/cliprelay/settings/ClipboardSettingsStore.kt
+++ b/android/app/src/main/java/org/cliprelay/settings/ClipboardSettingsStore.kt
@@ -9,6 +9,7 @@ class ClipboardSettingsStore(context: Context) {
         private const val PREFS_NAME = "cliprelay_settings"
         private const val KEY_AUTO_CLEAR_SYNCED_CLIPBOARD = "auto_clear_synced_clipboard"
         const val KEY_AUTO_COPY_ENABLED = "auto_copy_enabled"
+        private const val KEY_AGGRESSIVE_AUTO_COPY_ENABLED = "aggressive_auto_copy_enabled"
         const val KEY_AUTO_COPY_ONBOARDING_SHOWN = "auto_copy_onboarding_shown"
 
         const val AUTO_CLEAR_DELAY_MS = 60_000L
@@ -30,6 +31,14 @@ class ClipboardSettingsStore(context: Context) {
 
     fun setAutoCopyEnabled(enabled: Boolean) {
         prefs.edit().putBoolean(KEY_AUTO_COPY_ENABLED, enabled).apply()
+    }
+
+    fun isAggressiveAutoCopyEnabled(): Boolean {
+        return prefs.getBoolean(KEY_AGGRESSIVE_AUTO_COPY_ENABLED, false)
+    }
+
+    fun setAggressiveAutoCopyEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_AGGRESSIVE_AUTO_COPY_ENABLED, enabled).apply()
     }
 
     fun isAutoCopyOnboardingShown(): Boolean {

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -86,6 +86,7 @@ fun ClipRelayScreen(
     clipboardTransferFlow: Flow<Boolean> = emptyFlow(),
     autoClearEnabled: Boolean,
     autoCopyEnabled: Boolean,
+    aggressiveAutoCopyEnabled: Boolean = false,
     autoCopyAccessibilityEnabled: Boolean = false,
     imageSyncEnabled: Boolean = false,
     onPairClick: () -> Unit,
@@ -93,6 +94,7 @@ fun ClipRelayScreen(
     onBurstShown: () -> Unit,
     onAutoClearSettingChanged: (Boolean) -> Unit,
     onAutoCopySettingChanged: (Boolean) -> Unit,
+    onAggressiveAutoCopySettingChanged: (Boolean) -> Unit,
     onImageSyncSettingChanged: (Boolean) -> Unit = {},
     onAutoCopyFixClick: () -> Unit = {},
     onHelpClick: () -> Unit = {},
@@ -170,12 +172,14 @@ fun ClipRelayScreen(
                 clipboardTransferFlow = clipboardTransferFlow,
                 autoClearEnabled = autoClearEnabled,
                 autoCopyEnabled = autoCopyEnabled,
+                aggressiveAutoCopyEnabled = aggressiveAutoCopyEnabled,
                 autoCopyAccessibilityEnabled = autoCopyAccessibilityEnabled,
                 imageSyncEnabled = imageSyncEnabled,
                 onPairClick = onPairClick,
                 onUnpairClick = onUnpairClick,
                 onAutoClearSettingChanged = onAutoClearSettingChanged,
                 onAutoCopySettingChanged = onAutoCopySettingChanged,
+                onAggressiveAutoCopySettingChanged = onAggressiveAutoCopySettingChanged,
                 onImageSyncSettingChanged = onImageSyncSettingChanged,
                 onAutoCopyFixClick = onAutoCopyFixClick
             )
@@ -287,12 +291,14 @@ private fun MainCard(
     clipboardTransferFlow: Flow<Boolean>,
     autoClearEnabled: Boolean,
     autoCopyEnabled: Boolean,
+    aggressiveAutoCopyEnabled: Boolean = false,
     autoCopyAccessibilityEnabled: Boolean = false,
     imageSyncEnabled: Boolean = false,
     onPairClick: () -> Unit,
     onUnpairClick: () -> Unit,
     onAutoClearSettingChanged: (Boolean) -> Unit,
     onAutoCopySettingChanged: (Boolean) -> Unit,
+    onAggressiveAutoCopySettingChanged: (Boolean) -> Unit,
     onImageSyncSettingChanged: (Boolean) -> Unit = {},
     onAutoCopyFixClick: () -> Unit = {}
 ) {
@@ -562,6 +568,12 @@ private fun MainCard(
                 onEnabledChange = onAutoCopySettingChanged,
                 onFixClick = onAutoCopyFixClick
             )
+            Spacer(modifier = Modifier.height(8.dp))
+            AggressiveAutoCopySettingRow(
+                enabled = aggressiveAutoCopyEnabled,
+                autoCopyEnabled = autoCopyEnabled,
+                onEnabledChange = onAggressiveAutoCopySettingChanged
+            )
         }
     }
 }
@@ -704,6 +716,76 @@ private fun AutoCopySettingRow(
                 uncheckedThumbColor = Color(0xFF7A7A7A),
                 uncheckedTrackColor = Color(0x15000000),
                 uncheckedBorderColor = Color(0x40000000)
+            )
+        )
+    }
+}
+
+@Composable
+private fun AggressiveAutoCopySettingRow(
+    enabled: Boolean,
+    autoCopyEnabled: Boolean,
+    onEnabledChange: (Boolean) -> Unit
+) {
+    val rowEnabled = autoCopyEnabled
+    val toggleBg = if (enabled) Color(0x1400FFD5) else Color(0x08000000)
+    val toggleBorder = if (enabled) Color(0x2B00FFD5) else Color(0x14000000)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(toggleBg)
+            .border(1.dp, toggleBorder, RoundedCornerShape(18.dp))
+            .toggleable(
+                value = enabled,
+                enabled = rowEnabled,
+                role = Role.Switch,
+                onValueChange = onEnabledChange
+            )
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.aggressive_auto_copy_setting_title),
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = if (rowEnabled) Color(0xCC000000) else Color(0x66000000)
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = if (!rowEnabled) {
+                    stringResource(R.string.aggressive_auto_copy_setting_disabled)
+                } else if (enabled) {
+                    stringResource(R.string.aggressive_auto_copy_setting_subtitle_on)
+                } else {
+                    stringResource(R.string.aggressive_auto_copy_setting_subtitle_off)
+                },
+                fontSize = 12.sp,
+                color = if (rowEnabled) Color(0x80000000) else Color(0x66000000),
+                lineHeight = 16.sp
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Switch(
+            checked = enabled,
+            enabled = rowEnabled,
+            onCheckedChange = onEnabledChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Teal,
+                checkedTrackColor = Aqua.copy(alpha = 0.45f),
+                checkedBorderColor = Aqua.copy(alpha = 0.60f),
+                uncheckedThumbColor = Color(0xFF7A7A7A),
+                uncheckedTrackColor = Color(0x15000000),
+                uncheckedBorderColor = Color(0x40000000),
+                disabledCheckedThumbColor = Color(0x807A7A7A),
+                disabledCheckedTrackColor = Color(0x1200FFD5),
+                disabledUncheckedThumbColor = Color(0x807A7A7A),
+                disabledUncheckedTrackColor = Color(0x10000000)
             )
         )
     }

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -117,14 +117,24 @@ class MainActivity : AppCompatActivity() {
         }
         val autoClearEnabled = clipboardSettingsStore.isAutoClearSyncedClipboardEnabled()
         val autoCopyEnabled = clipboardSettingsStore.isAutoCopyEnabled()
+        val aggressiveAutoCopyEnabled = clipboardSettingsStore.isAggressiveAutoCopyEnabled()
         val imageSyncEnabled = pairingStore.isRichMediaEnabled()
-        viewModel.initState(isPaired, deviceName, deviceTag, autoClearEnabled, autoCopyEnabled, imageSyncEnabled)
+        viewModel.initState(
+            isPaired = isPaired,
+            deviceName = deviceName,
+            deviceTag = deviceTag,
+            autoClearEnabled = autoClearEnabled,
+            autoCopyEnabled = autoCopyEnabled,
+            aggressiveAutoCopyEnabled = aggressiveAutoCopyEnabled,
+            imageSyncEnabled = imageSyncEnabled
+        )
 
         setContent {
             val state by viewModel.state.collectAsState()
             val showBurst by viewModel.showBurst.collectAsState()
             val autoClearEnabled by viewModel.autoClearEnabled.collectAsState()
             val autoCopyEnabled by viewModel.autoCopyEnabled.collectAsState()
+            val aggressiveAutoCopyEnabled by viewModel.aggressiveAutoCopyEnabled.collectAsState()
             val autoCopyAccessibilityEnabled by viewModel.autoCopyAccessibilityEnabled.collectAsState()
             val imageSyncEnabled by viewModel.imageSyncEnabled.collectAsState()
             val showVersionMismatch by viewModel.showVersionMismatch.collectAsState()
@@ -156,6 +166,7 @@ class MainActivity : AppCompatActivity() {
                 clipboardTransferFlow = viewModel.clipboardTransfer,
                 autoClearEnabled = autoClearEnabled,
                 autoCopyEnabled = autoCopyEnabled,
+                aggressiveAutoCopyEnabled = aggressiveAutoCopyEnabled,
                 autoCopyAccessibilityEnabled = autoCopyAccessibilityEnabled,
                 imageSyncEnabled = imageSyncEnabled,
                 onPairClick = {
@@ -183,6 +194,10 @@ class MainActivity : AppCompatActivity() {
                         viewModel.onAutoCopySettingChanged(enabled)
                         clipboardSettingsStore.setAutoCopyEnabled(enabled)
                     }
+                },
+                onAggressiveAutoCopySettingChanged = { enabled ->
+                    viewModel.onAggressiveAutoCopySettingChanged(enabled)
+                    clipboardSettingsStore.setAggressiveAutoCopyEnabled(enabled)
                 },
                 onImageSyncSettingChanged = { enabled ->
                     viewModel.onImageSyncSettingChanged(enabled)

--- a/android/app/src/main/java/org/cliprelay/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainViewModel.kt
@@ -28,6 +28,9 @@ class MainViewModel : ViewModel() {
     private val _autoCopyEnabled = MutableStateFlow(false)
     val autoCopyEnabled: StateFlow<Boolean> = _autoCopyEnabled.asStateFlow()
 
+    private val _aggressiveAutoCopyEnabled = MutableStateFlow(false)
+    val aggressiveAutoCopyEnabled: StateFlow<Boolean> = _aggressiveAutoCopyEnabled.asStateFlow()
+
     private val _imageSyncEnabled = MutableStateFlow(false)
     val imageSyncEnabled: StateFlow<Boolean> = _imageSyncEnabled.asStateFlow()
 
@@ -41,10 +44,19 @@ class MainViewModel : ViewModel() {
     private val _clipboardTransfer = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
     val clipboardTransfer: SharedFlow<Boolean> = _clipboardTransfer
 
-    fun initState(isPaired: Boolean, deviceName: String? = null, deviceTag: String? = null, autoClearEnabled: Boolean = false, autoCopyEnabled: Boolean = false, imageSyncEnabled: Boolean = false) {
+    fun initState(
+        isPaired: Boolean,
+        deviceName: String? = null,
+        deviceTag: String? = null,
+        autoClearEnabled: Boolean = false,
+        autoCopyEnabled: Boolean = false,
+        aggressiveAutoCopyEnabled: Boolean = false,
+        imageSyncEnabled: Boolean = false
+    ) {
         _state.value = if (isPaired) AppState.Searching(deviceName, deviceTag) else AppState.Unpaired
         _autoClearEnabled.value = autoClearEnabled
         _autoCopyEnabled.value = autoCopyEnabled
+        _aggressiveAutoCopyEnabled.value = aggressiveAutoCopyEnabled
         _imageSyncEnabled.value = imageSyncEnabled
     }
 
@@ -83,6 +95,10 @@ class MainViewModel : ViewModel() {
 
     fun onAutoCopySettingChanged(enabled: Boolean) {
         _autoCopyEnabled.value = enabled
+    }
+
+    fun onAggressiveAutoCopySettingChanged(enabled: Boolean) {
+        _aggressiveAutoCopyEnabled.value = enabled
     }
 
     fun onImageSyncSettingChanged(enabled: Boolean) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -24,6 +24,10 @@
     <string name="auto_copy_setting_title">Auto-copy to Mac (experimental)</string>
     <string name="auto_copy_setting_subtitle_on">Automatically send copied text to Mac</string>
     <string name="auto_copy_setting_subtitle_off">Automatically send copied text to Mac. Requires Accessibility permission.</string>
+    <string name="aggressive_auto_copy_setting_title">Aggressive auto-copy detection</string>
+    <string name="aggressive_auto_copy_setting_subtitle_on">Broader detection for apps like Reddit and browsers. Fewer misses, but may false-trigger.</string>
+    <string name="aggressive_auto_copy_setting_subtitle_off">Use a broader fallback when apps hide copy actions inside popup menus.</string>
+    <string name="aggressive_auto_copy_setting_disabled">Turn on Auto-copy to Mac first.</string>
     <string name="onboarding_title">Sharing your clipboard</string>
     <string name="onboarding_always_available">Always available</string>
     <string name="onboarding_share_sheet_title">Share menu</string>
@@ -37,14 +41,14 @@
     <string name="onboarding_auto_caveat_notification">Shows a system notification each time</string>
     <string name="onboarding_auto_caveat_reliability">May not detect all copy actions</string>
     <string name="onboarding_got_it">Got it</string>
-    <string name="accessibility_service_description">Detects when you copy text so it can be automatically sent to your paired Mac. Only monitors tap actions — does not read screen content.</string>
+    <string name="accessibility_service_description">Detects copy actions so copied text can be sent to your paired Mac. Only inspects accessibility labels related to copy actions and does not upload screen content.</string>
     <string name="tile_label">Send to Mac</string>
     <string name="tile_not_paired">Not paired</string>
     <string name="auto_copy_needs_accessibility">Not working — tap to enable Accessibility permission</string>
     <string name="image_sync_setting_title">Image sync (experimental)</string>
     <string name="image_sync_setting_subtitle">Sync clipboard images. Requires devices to be on the same Wi-Fi.</string>
     <string name="accessibility_disclosure_title">Accessibility Permission</string>
-    <string name="accessibility_disclosure_body">ClipRelay uses Android\'s Accessibility Service to detect when you copy text, so it can automatically send your clipboard to your paired Mac.\n\nThis permission allows ClipRelay to monitor tap actions only. It does not read, collect, or store any screen content or personal data.</string>
+    <string name="accessibility_disclosure_body">ClipRelay uses Android\'s Accessibility Service to detect when you copy text, so it can automatically send your clipboard to your paired Mac.\n\nClipRelay only inspects accessibility labels related to copy actions and does not upload screen content or personal data. An optional aggressive mode can broaden detection for apps with unusual popup menus, which may increase false positives.</string>
     <string name="accessibility_disclosure_allow">Allow</string>
     <string name="accessibility_disclosure_deny">Deny</string>
 </resources>

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
-    android:accessibilityEventTypes="typeViewClicked|typeWindowStateChanged"
+    android:accessibilityEventTypes="typeViewClicked|typeWindowStateChanged|typeWindowContentChanged|typeNotificationStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:notificationTimeout="200"
+    android:accessibilityFlags="flagIncludeNotImportantViews|flagRetrieveInteractiveWindows|flagReportViewIds"
+    android:notificationTimeout="100"
     android:canRetrieveWindowContent="true" />

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
-    android:accessibilityEventTypes="typeViewClicked|typeWindowStateChanged"
+    android:accessibilityEventTypes="typeViewClicked|typeWindowStateChanged|typeWindowsChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:notificationTimeout="200"
     android:canRetrieveWindowContent="true" />

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
-    android:accessibilityEventTypes="typeViewClicked|typeWindowStateChanged|typeWindowContentChanged|typeNotificationStateChanged"
+    android:accessibilityEventTypes="typeViewClicked|typeWindowStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagIncludeNotImportantViews|flagRetrieveInteractiveWindows|flagReportViewIds"
-    android:notificationTimeout="100"
+    android:notificationTimeout="200"
     android:canRetrieveWindowContent="true" />

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -1,0 +1,61 @@
+package org.cliprelay.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClipboardAccessibilityHeuristicsTest {
+
+    @Test
+    fun `contains copy text matches common extended labels`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertTrue(heuristics.containsCopyText(sequenceOf("Copy link")))
+        assertTrue(heuristics.containsCopyText(sequenceOf("COPY CODE")))
+    }
+
+    @Test
+    fun `contains copy text ignores copyright strings`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertFalse(heuristics.containsCopyText(sequenceOf("Copyright 2026 ClipRelay")))
+    }
+
+    @Test
+    fun `contains copy confirmation text matches copied toast`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertTrue(heuristics.containsCopyConfirmationText(sequenceOf("Copied to clipboard")))
+    }
+
+    @Test
+    fun `toolbar close within grace window triggers fallback`() {
+        var now = 1_000L
+        val heuristics = ClipboardAccessibilityHeuristics(nowMs = { now }, toolbarGracePeriodMs = 500L)
+
+        assertFalse(heuristics.onCopyAffordanceChanged(true))
+
+        now += 300L
+        assertTrue(heuristics.onCopyAffordanceChanged(false))
+    }
+
+    @Test
+    fun `toolbar close after grace window does not trigger fallback`() {
+        var now = 1_000L
+        val heuristics = ClipboardAccessibilityHeuristics(nowMs = { now }, toolbarGracePeriodMs = 500L)
+
+        assertFalse(heuristics.onCopyAffordanceChanged(true))
+
+        now += 700L
+        assertFalse(heuristics.onCopyAffordanceChanged(false))
+    }
+
+    @Test
+    fun `direct detection resets toolbar fallback state`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertFalse(heuristics.onCopyAffordanceChanged(true))
+        heuristics.resetAfterDirectDetection()
+        assertFalse(heuristics.onCopyAffordanceChanged(false))
+    }
+}

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -15,27 +15,11 @@ class ClipboardAccessibilityHeuristicsTest {
     }
 
     @Test
-    fun `window text uses broader matching for known toolbar apps`() {
+    fun `window text uses broader matching for command style labels`() {
         val heuristics = ClipboardAccessibilityHeuristics()
 
-        assertTrue(
-            heuristics.containsCopyWindowText(
-                "com.reddit.frontpage",
-                sequenceOf("Copy permalink")
-            )
-        )
-        assertTrue(
-            heuristics.containsCopyWindowText(
-                "com.android.chrome",
-                sequenceOf("Copy address")
-            )
-        )
-        assertFalse(
-            heuristics.containsCopyWindowText(
-                "com.example.notes",
-                sequenceOf("Copy address")
-            )
-        )
+        assertTrue(heuristics.containsCopyWindowText(sequenceOf("Copy permalink")))
+        assertTrue(heuristics.containsCopyWindowText(sequenceOf("Copy address")))
     }
 
     @Test
@@ -75,33 +59,69 @@ class ClipboardAccessibilityHeuristicsTest {
 
     @Test
     fun `toolbar close within grace window triggers fallback`() {
-        var now = 1_000L
-        val heuristics = ClipboardAccessibilityHeuristics(nowMs = { now }, toolbarGracePeriodMs = 500L)
+        var nowElapsed = 1_000L
+        var nowWallClock = 50_000L
+        val heuristics = ClipboardAccessibilityHeuristics(
+            elapsedRealtimeMs = { nowElapsed },
+            wallClockMs = { nowWallClock },
+            toolbarGracePeriodMs = 500L
+        )
 
-        assertFalse(heuristics.onCopyAffordanceChanged(true))
+        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
 
-        now += 300L
-        assertTrue(heuristics.onCopyAffordanceChanged(false))
+        nowElapsed += 300L
+        nowWallClock += 300L
+        assertTrue(heuristics.onCopyAffordanceChanged(false) == 50_000L)
     }
 
     @Test
     fun `toolbar close after grace window does not trigger fallback`() {
-        var now = 1_000L
-        val heuristics = ClipboardAccessibilityHeuristics(nowMs = { now }, toolbarGracePeriodMs = 500L)
+        var nowElapsed = 1_000L
+        var nowWallClock = 50_000L
+        val heuristics = ClipboardAccessibilityHeuristics(
+            elapsedRealtimeMs = { nowElapsed },
+            wallClockMs = { nowWallClock },
+            toolbarGracePeriodMs = 500L
+        )
 
-        assertFalse(heuristics.onCopyAffordanceChanged(true))
+        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
 
-        now += 700L
-        assertFalse(heuristics.onCopyAffordanceChanged(false))
+        nowElapsed += 700L
+        nowWallClock += 700L
+        assertFalse(heuristics.onCopyAffordanceChanged(false) != null)
     }
 
     @Test
     fun `direct detection resets toolbar fallback state`() {
         val heuristics = ClipboardAccessibilityHeuristics()
 
-        assertFalse(heuristics.onCopyAffordanceChanged(true))
+        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
         heuristics.resetAfterDirectDetection()
-        assertFalse(heuristics.onCopyAffordanceChanged(false))
+        assertFalse(heuristics.onCopyAffordanceChanged(false) != null)
+    }
+
+    @Test
+    fun `expired close resets state before next affordance`() {
+        var nowElapsed = 1_000L
+        var nowWallClock = 50_000L
+        val heuristics = ClipboardAccessibilityHeuristics(
+            elapsedRealtimeMs = { nowElapsed },
+            wallClockMs = { nowWallClock },
+            toolbarGracePeriodMs = 500L
+        )
+
+        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
+        nowElapsed += 700L
+        nowWallClock += 700L
+        assertFalse(heuristics.onCopyAffordanceChanged(false) != null)
+
+        nowElapsed += 100L
+        nowWallClock = 90_000L
+        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
+
+        nowElapsed += 200L
+        nowWallClock += 200L
+        assertTrue(heuristics.onCopyAffordanceChanged(false) == 90_000L)
     }
 
     @Test

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -12,8 +12,30 @@ class ClipboardAccessibilityHeuristicsTest {
 
         assertTrue(heuristics.containsCopyText(sequenceOf("Copy link")))
         assertTrue(heuristics.containsCopyText(sequenceOf("COPY CODE")))
-        assertTrue(heuristics.containsCopyText(sequenceOf("Copy permalink")))
-        assertTrue(heuristics.containsCopyText(sequenceOf("Copy post link")))
+    }
+
+    @Test
+    fun `window text uses broader matching for known toolbar apps`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertTrue(
+            heuristics.containsCopyWindowText(
+                "com.reddit.frontpage",
+                sequenceOf("Copy permalink")
+            )
+        )
+        assertTrue(
+            heuristics.containsCopyWindowText(
+                "com.android.chrome",
+                sequenceOf("Copy address")
+            )
+        )
+        assertFalse(
+            heuristics.containsCopyWindowText(
+                "com.example.notes",
+                sequenceOf("Copy address")
+            )
+        )
     }
 
     @Test
@@ -32,8 +54,23 @@ class ClipboardAccessibilityHeuristicsTest {
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy address")))
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy password")))
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy permalink")))
+        assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy post link")))
         assertFalse(heuristics.containsCopyCommandText(sequenceOf("Don't copy")))
         assertFalse(heuristics.containsCopyCommandText(sequenceOf("Copy to folder")))
+    }
+
+    @Test
+    fun `debug copy candidates only returns copy like labels`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        val candidates = heuristics.debugCopyCandidates(
+            sequenceOf("Copy permalink", "Share link", "Copy to folder", "copycat")
+        )
+
+        assertTrue(candidates.contains("copy permalink"))
+        assertTrue(candidates.contains("copy to folder"))
+        assertFalse(candidates.contains("share link"))
+        assertFalse(candidates.contains("copycat"))
     }
 
     @Test

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -12,6 +12,8 @@ class ClipboardAccessibilityHeuristicsTest {
 
         assertTrue(heuristics.containsCopyText(sequenceOf("Copy link")))
         assertTrue(heuristics.containsCopyText(sequenceOf("COPY CODE")))
+        assertTrue(heuristics.containsCopyText(sequenceOf("Copy permalink")))
+        assertTrue(heuristics.containsCopyText(sequenceOf("Copy post link")))
     }
 
     @Test
@@ -29,6 +31,7 @@ class ClipboardAccessibilityHeuristicsTest {
 
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy address")))
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy password")))
+        assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy permalink")))
         assertFalse(heuristics.containsCopyCommandText(sequenceOf("Don't copy")))
         assertFalse(heuristics.containsCopyCommandText(sequenceOf("Copy to folder")))
     }

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -24,6 +24,15 @@ class ClipboardAccessibilityHeuristicsTest {
     }
 
     @Test
+    fun `contains copy command text matches copy actions with app specific suffixes`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy address")))
+        assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy password")))
+        assertFalse(heuristics.containsCopyCommandText(sequenceOf("Don't copy")))
+    }
+
+    @Test
     fun `toolbar close within grace window triggers fallback`() {
         var now = 1_000L
         val heuristics = ClipboardAccessibilityHeuristics(nowMs = { now }, toolbarGracePeriodMs = 500L)

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -1,6 +1,8 @@
 package org.cliprelay.service
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -67,11 +69,11 @@ class ClipboardAccessibilityHeuristicsTest {
             toolbarGracePeriodMs = 500L
         )
 
-        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
+        assertNull(heuristics.onCopyAffordanceChanged(true))
 
         nowElapsed += 300L
         nowWallClock += 300L
-        assertTrue(heuristics.onCopyAffordanceChanged(false) == 50_000L)
+        assertEquals(50_000L, heuristics.onCopyAffordanceChanged(false))
     }
 
     @Test
@@ -84,20 +86,20 @@ class ClipboardAccessibilityHeuristicsTest {
             toolbarGracePeriodMs = 500L
         )
 
-        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
+        assertNull(heuristics.onCopyAffordanceChanged(true))
 
         nowElapsed += 700L
         nowWallClock += 700L
-        assertFalse(heuristics.onCopyAffordanceChanged(false) != null)
+        assertNull(heuristics.onCopyAffordanceChanged(false))
     }
 
     @Test
     fun `direct detection resets toolbar fallback state`() {
         val heuristics = ClipboardAccessibilityHeuristics()
 
-        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
+        assertNull(heuristics.onCopyAffordanceChanged(true))
         heuristics.resetAfterDirectDetection()
-        assertFalse(heuristics.onCopyAffordanceChanged(false) != null)
+        assertNull(heuristics.onCopyAffordanceChanged(false))
     }
 
     @Test
@@ -110,18 +112,18 @@ class ClipboardAccessibilityHeuristicsTest {
             toolbarGracePeriodMs = 500L
         )
 
-        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
+        assertNull(heuristics.onCopyAffordanceChanged(true))
         nowElapsed += 700L
         nowWallClock += 700L
-        assertFalse(heuristics.onCopyAffordanceChanged(false) != null)
+        assertNull(heuristics.onCopyAffordanceChanged(false))
 
         nowElapsed += 100L
         nowWallClock = 90_000L
-        assertFalse(heuristics.onCopyAffordanceChanged(true) != null)
+        assertNull(heuristics.onCopyAffordanceChanged(true))
 
         nowElapsed += 200L
         nowWallClock += 200L
-        assertTrue(heuristics.onCopyAffordanceChanged(false) == 90_000L)
+        assertEquals(90_000L, heuristics.onCopyAffordanceChanged(false))
     }
 
     @Test
@@ -130,5 +132,15 @@ class ClipboardAccessibilityHeuristicsTest {
 
         assertTrue(heuristics.containsCopyText(sequenceOf("  Copy   to   clipboard  ")))
         assertTrue(heuristics.containsCopyText(sequenceOf("Copy link!")))
+        assertTrue(heuristics.containsCopyText(sequenceOf("📋 Copy")))
+        assertTrue(heuristics.containsCopyText(sequenceOf("🔗 Copy link")))
+    }
+
+    @Test
+    fun `contains copy command text matches icon prefixed commands`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertTrue(heuristics.containsCopyCommandText(sequenceOf("📋 Copy address")))
+        assertTrue(heuristics.containsCopyCommandText(sequenceOf("🔗 Copy permalink")))
     }
 }

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -30,6 +30,7 @@ class ClipboardAccessibilityHeuristicsTest {
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy address")))
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("Copy password")))
         assertFalse(heuristics.containsCopyCommandText(sequenceOf("Don't copy")))
+        assertFalse(heuristics.containsCopyCommandText(sequenceOf("Copy to folder")))
     }
 
     @Test

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import android.view.accessibility.AccessibilityEvent
 
 class ClipboardAccessibilityHeuristicsTest {
 
@@ -103,6 +104,67 @@ class ClipboardAccessibilityHeuristicsTest {
     }
 
     @Test
+    fun `window removal can trigger fallback while affordance remains otherwise visible`() {
+        var nowElapsed = 1_000L
+        var nowWallClock = 50_000L
+        val heuristics = ClipboardAccessibilityHeuristics(
+            elapsedRealtimeMs = { nowElapsed },
+            wallClockMs = { nowWallClock },
+            toolbarGracePeriodMs = 500L
+        )
+
+        assertNull(heuristics.onCopyAffordanceChanged(true))
+
+        nowElapsed += 200L
+        nowWallClock += 200L
+        assertEquals(
+            50_000L,
+            heuristics.onWindowsRemoved(AccessibilityEvent.WINDOWS_CHANGE_REMOVED)
+        )
+    }
+
+    @Test
+    fun `aggressive children mutation can trigger popup fallback after short delay`() {
+        var nowElapsed = 1_000L
+        var nowWallClock = 50_000L
+        val heuristics = ClipboardAccessibilityHeuristics(
+            elapsedRealtimeMs = { nowElapsed },
+            wallClockMs = { nowWallClock },
+            toolbarGracePeriodMs = 500L,
+            aggressiveMutationDelayMs = 150L
+        )
+
+        assertNull(heuristics.onCopyAffordanceChanged(true))
+
+        nowElapsed += 200L
+        nowWallClock += 200L
+        assertEquals(
+            50_000L,
+            heuristics.onAggressiveWindowMutation(AccessibilityEvent.WINDOWS_CHANGE_CHILDREN)
+        )
+    }
+
+    @Test
+    fun `aggressive children mutation ignores immediate popup layout churn`() {
+        var nowElapsed = 1_000L
+        var nowWallClock = 50_000L
+        val heuristics = ClipboardAccessibilityHeuristics(
+            elapsedRealtimeMs = { nowElapsed },
+            wallClockMs = { nowWallClock },
+            toolbarGracePeriodMs = 500L,
+            aggressiveMutationDelayMs = 150L
+        )
+
+        assertNull(heuristics.onCopyAffordanceChanged(true))
+
+        nowElapsed += 50L
+        nowWallClock += 50L
+        assertNull(
+            heuristics.onAggressiveWindowMutation(AccessibilityEvent.WINDOWS_CHANGE_CHILDREN)
+        )
+    }
+
+    @Test
     fun `expired close resets state before next affordance`() {
         var nowElapsed = 1_000L
         var nowWallClock = 50_000L
@@ -142,5 +204,15 @@ class ClipboardAccessibilityHeuristicsTest {
 
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("📋 Copy address")))
         assertTrue(heuristics.containsCopyCommandText(sequenceOf("🔗 Copy permalink")))
+    }
+
+    @Test
+    fun `conservative delayed probe stays package scoped`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertTrue(heuristics.shouldUseConservativeDelayedProbe("com.reddit.frontpage"))
+        assertTrue(heuristics.shouldUseConservativeDelayedProbe("com.reddit.frontpage.debug"))
+        assertFalse(heuristics.shouldUseConservativeDelayedProbe("com.android.chrome"))
+        assertFalse(heuristics.shouldUseConservativeDelayedProbe(null))
     }
 }

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -207,16 +207,28 @@ class ClipboardAccessibilityHeuristicsTest {
     }
 
     @Test
-    fun `window probe strategy stays package scoped outside aggressive mode`() {
+    fun `window probe strategy only broadens when aggressive mode is enabled`() {
         val heuristics = ClipboardAccessibilityHeuristics()
 
         assertEquals(
-            WindowProbeStrategy.BALANCED,
+            WindowProbeStrategy.NONE,
             heuristics.windowProbeStrategy("com.reddit.frontpage", aggressiveMode = false)
         )
         assertEquals(
-            WindowProbeStrategy.BALANCED,
+            WindowProbeStrategy.NONE,
             heuristics.windowProbeStrategy("com.reddit.frontpage.debug", aggressiveMode = false)
+        )
+        assertEquals(
+            WindowProbeStrategy.NONE,
+            heuristics.windowProbeStrategy("info.plateaukao.einkbro", aggressiveMode = false)
+        )
+        assertEquals(
+            WindowProbeStrategy.NONE,
+            heuristics.windowProbeStrategy("info.plateaukao.einkbubble", aggressiveMode = false)
+        )
+        assertEquals(
+            WindowProbeStrategy.NONE,
+            heuristics.windowProbeStrategy("info.plateaukao.einkbubble.beta", aggressiveMode = false)
         )
         assertEquals(
             WindowProbeStrategy.NONE,

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -207,12 +207,28 @@ class ClipboardAccessibilityHeuristicsTest {
     }
 
     @Test
-    fun `conservative delayed probe stays package scoped`() {
+    fun `window probe strategy stays package scoped outside aggressive mode`() {
         val heuristics = ClipboardAccessibilityHeuristics()
 
-        assertTrue(heuristics.shouldUseConservativeDelayedProbe("com.reddit.frontpage"))
-        assertTrue(heuristics.shouldUseConservativeDelayedProbe("com.reddit.frontpage.debug"))
-        assertFalse(heuristics.shouldUseConservativeDelayedProbe("com.android.chrome"))
-        assertFalse(heuristics.shouldUseConservativeDelayedProbe(null))
+        assertEquals(
+            WindowProbeStrategy.BALANCED,
+            heuristics.windowProbeStrategy("com.reddit.frontpage", aggressiveMode = false)
+        )
+        assertEquals(
+            WindowProbeStrategy.BALANCED,
+            heuristics.windowProbeStrategy("com.reddit.frontpage.debug", aggressiveMode = false)
+        )
+        assertEquals(
+            WindowProbeStrategy.NONE,
+            heuristics.windowProbeStrategy("com.android.chrome", aggressiveMode = false)
+        )
+        assertEquals(
+            WindowProbeStrategy.NONE,
+            heuristics.windowProbeStrategy(null, aggressiveMode = false)
+        )
+        assertEquals(
+            WindowProbeStrategy.AGGRESSIVE,
+            heuristics.windowProbeStrategy("com.android.chrome", aggressiveMode = true)
+        )
     }
 }

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityHeuristicsTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class ClipboardAccessibilityHeuristicsTest {
 
     @Test
-    fun `contains copy text matches common extended labels`() {
+    fun `contains copy text matches common exact labels`() {
         val heuristics = ClipboardAccessibilityHeuristics()
 
         assertTrue(heuristics.containsCopyText(sequenceOf("Copy link")))
@@ -15,17 +15,12 @@ class ClipboardAccessibilityHeuristicsTest {
     }
 
     @Test
-    fun `contains copy text ignores copyright strings`() {
+    fun `contains copy text ignores substring false positives`() {
         val heuristics = ClipboardAccessibilityHeuristics()
 
         assertFalse(heuristics.containsCopyText(sequenceOf("Copyright 2026 ClipRelay")))
-    }
-
-    @Test
-    fun `contains copy confirmation text matches copied toast`() {
-        val heuristics = ClipboardAccessibilityHeuristics()
-
-        assertTrue(heuristics.containsCopyConfirmationText(sequenceOf("Copied to clipboard")))
+        assertFalse(heuristics.containsCopyText(sequenceOf("copycat")))
+        assertFalse(heuristics.containsCopyText(sequenceOf("Stop copying")))
     }
 
     @Test
@@ -57,5 +52,13 @@ class ClipboardAccessibilityHeuristicsTest {
         assertFalse(heuristics.onCopyAffordanceChanged(true))
         heuristics.resetAfterDirectDetection()
         assertFalse(heuristics.onCopyAffordanceChanged(false))
+    }
+
+    @Test
+    fun `contains copy text normalizes whitespace and punctuation`() {
+        val heuristics = ClipboardAccessibilityHeuristics()
+
+        assertTrue(heuristics.containsCopyText(sequenceOf("  Copy   to   clipboard  ")))
+        assertTrue(heuristics.containsCopyText(sequenceOf("Copy link!")))
     }
 }

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityServiceTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityServiceTest.kt
@@ -9,25 +9,36 @@ class ClipboardAccessibilityServiceTest {
     @Test
     fun `toolbar close read requires a fresh clipboard timestamp`() {
         assertFalse(
-            ClipboardAccessibilityService.toolbarCloseShouldTriggerRead(
+            ClipboardAccessibilityService.shouldPreflightToolbarRead(
+                strategy = WindowProbeStrategy.NONE,
+                clipboardTimestampMs = null,
+                minClipboardTimestampMs = 10_000L
+            )
+        )
+        assertTrue(
+            ClipboardAccessibilityService.shouldPreflightToolbarRead(
+                strategy = WindowProbeStrategy.AGGRESSIVE,
                 clipboardTimestampMs = null,
                 minClipboardTimestampMs = 10_000L
             )
         )
         assertFalse(
-            ClipboardAccessibilityService.toolbarCloseShouldTriggerRead(
+            ClipboardAccessibilityService.shouldPreflightToolbarRead(
+                strategy = WindowProbeStrategy.AGGRESSIVE,
                 clipboardTimestampMs = 8_900L,
                 minClipboardTimestampMs = 10_000L
             )
         )
         assertTrue(
-            ClipboardAccessibilityService.toolbarCloseShouldTriggerRead(
+            ClipboardAccessibilityService.shouldPreflightToolbarRead(
+                strategy = WindowProbeStrategy.NONE,
                 clipboardTimestampMs = 9_100L,
                 minClipboardTimestampMs = 10_000L
             )
         )
         assertTrue(
-            ClipboardAccessibilityService.toolbarCloseShouldTriggerRead(
+            ClipboardAccessibilityService.shouldPreflightToolbarRead(
+                strategy = WindowProbeStrategy.NONE,
                 clipboardTimestampMs = 10_200L,
                 minClipboardTimestampMs = 10_000L
             )

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityServiceTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityServiceTest.kt
@@ -44,4 +44,36 @@ class ClipboardAccessibilityServiceTest {
             )
         )
     }
+
+    @Test
+    fun `scheduled probe respects current auto copy settings`() {
+        assertFalse(
+            ClipboardAccessibilityService.shouldAllowScheduledProbe(
+                strategy = WindowProbeStrategy.NONE,
+                autoCopyEnabled = false,
+                aggressiveModeEnabled = true
+            )
+        )
+        assertTrue(
+            ClipboardAccessibilityService.shouldAllowScheduledProbe(
+                strategy = WindowProbeStrategy.NONE,
+                autoCopyEnabled = true,
+                aggressiveModeEnabled = false
+            )
+        )
+        assertFalse(
+            ClipboardAccessibilityService.shouldAllowScheduledProbe(
+                strategy = WindowProbeStrategy.AGGRESSIVE,
+                autoCopyEnabled = true,
+                aggressiveModeEnabled = false
+            )
+        )
+        assertTrue(
+            ClipboardAccessibilityService.shouldAllowScheduledProbe(
+                strategy = WindowProbeStrategy.AGGRESSIVE,
+                autoCopyEnabled = true,
+                aggressiveModeEnabled = true
+            )
+        )
+    }
 }

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityServiceTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityServiceTest.kt
@@ -1,0 +1,36 @@
+package org.cliprelay.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClipboardAccessibilityServiceTest {
+
+    @Test
+    fun `delayed probe requires a fresh clipboard timestamp`() {
+        assertFalse(
+            ClipboardAccessibilityService.delayedProbeHasFreshClipboardTimestamp(
+                clipboardTimestampMs = null,
+                minClipboardTimestampMs = 10_000L
+            )
+        )
+        assertFalse(
+            ClipboardAccessibilityService.delayedProbeHasFreshClipboardTimestamp(
+                clipboardTimestampMs = 9_600L,
+                minClipboardTimestampMs = 10_000L
+            )
+        )
+        assertTrue(
+            ClipboardAccessibilityService.delayedProbeHasFreshClipboardTimestamp(
+                clipboardTimestampMs = 9_800L,
+                minClipboardTimestampMs = 10_000L
+            )
+        )
+        assertTrue(
+            ClipboardAccessibilityService.delayedProbeHasFreshClipboardTimestamp(
+                clipboardTimestampMs = 10_200L,
+                minClipboardTimestampMs = 10_000L
+            )
+        )
+    }
+}

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityServiceTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardAccessibilityServiceTest.kt
@@ -7,27 +7,27 @@ import org.junit.Test
 class ClipboardAccessibilityServiceTest {
 
     @Test
-    fun `delayed probe requires a fresh clipboard timestamp`() {
+    fun `toolbar close read requires a fresh clipboard timestamp`() {
         assertFalse(
-            ClipboardAccessibilityService.delayedProbeHasFreshClipboardTimestamp(
+            ClipboardAccessibilityService.toolbarCloseShouldTriggerRead(
                 clipboardTimestampMs = null,
                 minClipboardTimestampMs = 10_000L
             )
         )
         assertFalse(
-            ClipboardAccessibilityService.delayedProbeHasFreshClipboardTimestamp(
-                clipboardTimestampMs = 9_600L,
+            ClipboardAccessibilityService.toolbarCloseShouldTriggerRead(
+                clipboardTimestampMs = 8_900L,
                 minClipboardTimestampMs = 10_000L
             )
         )
         assertTrue(
-            ClipboardAccessibilityService.delayedProbeHasFreshClipboardTimestamp(
-                clipboardTimestampMs = 9_800L,
+            ClipboardAccessibilityService.toolbarCloseShouldTriggerRead(
+                clipboardTimestampMs = 9_100L,
                 minClipboardTimestampMs = 10_000L
             )
         )
         assertTrue(
-            ClipboardAccessibilityService.delayedProbeHasFreshClipboardTimestamp(
+            ClipboardAccessibilityService.toolbarCloseShouldTriggerRead(
                 clipboardTimestampMs = 10_200L,
                 minClipboardTimestampMs = 10_000L
             )

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardSendGateTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardSendGateTest.kt
@@ -7,6 +7,33 @@ import org.junit.Test
 class ClipboardSendGateTest {
 
     @Test
+    fun `toolbar close timestamp allows small platform skew`() {
+        val service = ClipRelayService()
+
+        assertTrue(
+            service.toolbarCloseHasFreshClipboardTimestamp(
+                triggerSource = ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                clipboardTimestampMs = 9_500L,
+                minClipboardTimestampMs = 10_000L
+            )
+        )
+        assertFalse(
+            service.toolbarCloseHasFreshClipboardTimestamp(
+                triggerSource = ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                clipboardTimestampMs = 8_500L,
+                minClipboardTimestampMs = 10_000L
+            )
+        )
+        assertTrue(
+            service.toolbarCloseHasFreshClipboardTimestamp(
+                triggerSource = ClipRelayService.CLIPBOARD_TRIGGER_DIRECT,
+                clipboardTimestampMs = null,
+                minClipboardTimestampMs = null
+            )
+        )
+    }
+
+    @Test
     fun `toolbar close replay only skips when timestamp matches previous send`() {
         val service = ClipRelayService()
 

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardSendGateTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardSendGateTest.kt
@@ -1,0 +1,44 @@
+package org.cliprelay.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClipboardSendGateTest {
+
+    @Test
+    fun `first send is allowed`() {
+        val gate = ClipboardSendGate()
+
+        assertTrue(gate.shouldSend("abc"))
+    }
+
+    @Test
+    fun `duplicate send inside suppression window is blocked`() {
+        var now = 1_000L
+        val gate = ClipboardSendGate(nowMs = { now }, suppressionWindowMs = 500L)
+
+        assertTrue(gate.shouldSend("abc"))
+        now += 300L
+        assertFalse(gate.shouldSend("abc"))
+    }
+
+    @Test
+    fun `duplicate send after suppression window is allowed`() {
+        var now = 1_000L
+        val gate = ClipboardSendGate(nowMs = { now }, suppressionWindowMs = 500L)
+
+        assertTrue(gate.shouldSend("abc"))
+        now += 700L
+        assertTrue(gate.shouldSend("abc"))
+    }
+
+    @Test
+    fun `reset clears duplicate suppression`() {
+        val gate = ClipboardSendGate(nowMs = { 1_000L }, suppressionWindowMs = 500L)
+
+        assertTrue(gate.shouldSend("abc"))
+        gate.reset()
+        assertTrue(gate.shouldSend("abc"))
+    }
+}

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardSendGateTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardSendGateTest.kt
@@ -34,6 +34,16 @@ class ClipboardSendGateTest {
     }
 
     @Test
+    fun `different hash inside suppression window is allowed`() {
+        var now = 1_000L
+        val gate = ClipboardSendGate(nowMs = { now }, suppressionWindowMs = 500L)
+
+        assertTrue(gate.shouldSend("abc"))
+        now += 100L
+        assertTrue(gate.shouldSend("def"))
+    }
+
+    @Test
     fun `reset clears duplicate suppression`() {
         val gate = ClipboardSendGate(nowMs = { 1_000L }, suppressionWindowMs = 500L)
 

--- a/android/app/src/test/java/org/cliprelay/service/ClipboardSendGateTest.kt
+++ b/android/app/src/test/java/org/cliprelay/service/ClipboardSendGateTest.kt
@@ -7,6 +7,39 @@ import org.junit.Test
 class ClipboardSendGateTest {
 
     @Test
+    fun `toolbar close replay only skips when timestamp matches previous send`() {
+        val service = ClipRelayService()
+
+        assertTrue(
+            service.shouldSkipToolbarCloseReplay(
+                triggerSource = ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                textHash = "abc",
+                clipboardTimestampMs = 123L,
+                lastSentTextHash = "abc",
+                lastSentClipboardTimestampMs = 123L
+            )
+        )
+        assertFalse(
+            service.shouldSkipToolbarCloseReplay(
+                triggerSource = ClipRelayService.CLIPBOARD_TRIGGER_TOOLBAR_CLOSE,
+                textHash = "abc",
+                clipboardTimestampMs = 456L,
+                lastSentTextHash = "abc",
+                lastSentClipboardTimestampMs = 123L
+            )
+        )
+        assertFalse(
+            service.shouldSkipToolbarCloseReplay(
+                triggerSource = ClipRelayService.CLIPBOARD_TRIGGER_DIRECT,
+                textHash = "abc",
+                clipboardTimestampMs = 123L,
+                lastSentTextHash = "abc",
+                lastSentClipboardTimestampMs = 123L
+            )
+        )
+    }
+
+    @Test
     fun `first send is allowed`() {
         val gate = ClipboardSendGate()
 


### PR DESCRIPTION
## Summary

This PR improves Android auto-copy reliability for popup-driven copy flows, while keeping the default path bounded and leaving broader fallback behavior behind the aggressive toggle.

## What changed

- tightened the accessibility-driven auto-copy flow across `ClipboardAccessibilityService`, `ClipboardAccessibilityHeuristics`, and `ClipRelayService`
- added stricter freshness/replay handling for toolbar and popup-triggered sends
- hardened ghost-activity lifecycle handling so clipboard reads do not get stuck in-flight
- added an explicit aggressive auto-copy toggle in the Android UI/settings
- expanded regression coverage for the new heuristic and dedupe paths

## Details

- kept detection on low-frequency accessibility events and improved popup/menu handling for copy actions
- matched copy labels more reliably through actionable menu rows / nearby ancestors
- added delayed-probe and toolbar-close preflight checks before launching the clipboard-read path
- moved same-text suppression to a short send gate plus timestamp-aware replay suppression
- switched debounce timing to monotonic time
- updated onboarding/disclosure text to explain the aggressive-mode tradeoff

## Testing

- `cd android && ./gradlew testDebugUnitTest`
- `./scripts/test-all.sh`
- `./scripts/build-all.sh`
- manual validation on my Android phone and MacBook, including Reddit copy flows and aggressive-mode behavior
