### PR TITLE
Make the macOS menubar sync indicator clearer on inbound clipboard updates

### DIFF
--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -278,14 +278,14 @@ extension AppDelegate: ConnectionControllerDelegate {
     }
 
     func didReceiveClipboard(text: String) {
+        statusBarController.flashSyncIndicator(style: .inbound)
         clipboardWriter.writeText(text)
         notificationManager.postClipboardReceived(text: text)
-        statusBarController.flashSyncIndicator()
     }
 
     func didReceiveImage(data: Data, contentType: String) {
+        statusBarController.flashSyncIndicator(style: .inbound)
         clipboardWriter.writeImage(data, contentType: contentType)
-        statusBarController.flashSyncIndicator()
     }
 
     func didCompletePairing(deviceName: String?) {
@@ -341,7 +341,7 @@ extension AppDelegate: ConnectionControllerDelegate {
     }
 
     func didSyncClipboard(hash: String) {
-        statusBarController.flashSyncIndicator()
+        statusBarController.flashSyncIndicator(style: .outbound)
     }
 
     func didChangeImageSyncSetting(enabled: Bool) {

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -278,14 +278,14 @@ extension AppDelegate: ConnectionControllerDelegate {
     }
 
     func didReceiveClipboard(text: String) {
-        statusBarController.flashSyncIndicator(style: .inbound)
         clipboardWriter.writeText(text)
         notificationManager.postClipboardReceived(text: text)
+        statusBarController.flashSyncIndicator(style: .inbound)
     }
 
     func didReceiveImage(data: Data, contentType: String) {
-        statusBarController.flashSyncIndicator(style: .inbound)
         clipboardWriter.writeImage(data, contentType: contentType)
+        statusBarController.flashSyncIndicator(style: .inbound)
     }
 
     func didCompletePairing(deviceName: String?) {

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -6,6 +6,11 @@ import QuartzCore
 import Sparkle
 
 final class StatusBarController {
+    enum SyncIndicatorStyle {
+        case outbound
+        case inbound
+    }
+
     var onPairNewDeviceRequested: (() -> Void)?
     var onForgetDeviceRequested: ((String) -> Void)?
     var onToggleLaunchAtLogin: (() -> Void)?
@@ -84,14 +89,15 @@ final class StatusBarController {
 
 
     /// Briefly pulses the status bar icon to indicate a clipboard sync.
-    func flashSyncIndicator() {
+    func flashSyncIndicator(style: SyncIndicatorStyle = .outbound) {
         guard let button = statusItem.button, let base = baseStatusBarImage else { return }
 
         // Cancel any in-progress pulse
         syncPulseTimer?.invalidate()
+        button.layer?.removeAnimation(forKey: "syncPulse")
 
         // Show bright highlight icon
-        let highlight = base.colorized(with: .systemYellow)
+        let highlight = base.colorized(with: highlightColor(for: style))
         highlight.isTemplate = false
         button.image = highlight
 
@@ -99,16 +105,54 @@ final class StatusBarController {
         button.wantsLayer = true
         if let layer = button.layer {
             let pulse = CAKeyframeAnimation(keyPath: "transform.scale")
-            pulse.values = [1.0, 1.3, 1.0]
-            pulse.keyTimes = [0, 0.4, 1.0]
-            pulse.duration = 0.35
+            pulse.values = pulseValues(for: style)
+            pulse.keyTimes = [0, 0.35, 1.0]
+            pulse.duration = pulseDuration(for: style)
             pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             layer.add(pulse, forKey: "syncPulse")
         }
 
         // Restore normal icon after the animation completes
-        syncPulseTimer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: false) { [weak self] _ in
+        let timer = Timer(timeInterval: restoreDelay(for: style), repeats: false) { [weak self] _ in
             self?.updateStatusBarIcon()
+        }
+        syncPulseTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func highlightColor(for style: SyncIndicatorStyle) -> NSColor {
+        switch style {
+        case .outbound:
+            return .systemYellow
+        case .inbound:
+            return .systemOrange
+        }
+    }
+
+    private func pulseValues(for style: SyncIndicatorStyle) -> [CGFloat] {
+        switch style {
+        case .outbound:
+            return [1.0, 1.3, 1.0]
+        case .inbound:
+            return [1.0, 1.45, 1.15, 1.0]
+        }
+    }
+
+    private func pulseDuration(for style: SyncIndicatorStyle) -> TimeInterval {
+        switch style {
+        case .outbound:
+            return 0.35
+        case .inbound:
+            return 0.65
+        }
+    }
+
+    private func restoreDelay(for style: SyncIndicatorStyle) -> TimeInterval {
+        switch style {
+        case .outbound:
+            return 0.4
+        case .inbound:
+            return 0.85
         }
     }
 

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -11,6 +11,13 @@ final class StatusBarController {
         case inbound
     }
 
+    struct SyncIndicatorSpec {
+        let values: [CGFloat]
+        let keyTimes: [NSNumber]
+        let duration: TimeInterval
+        let restoreDelay: TimeInterval
+    }
+
     var onPairNewDeviceRequested: (() -> Void)?
     var onForgetDeviceRequested: ((String) -> Void)?
     var onToggleLaunchAtLogin: (() -> Void)?
@@ -89,8 +96,9 @@ final class StatusBarController {
 
 
     /// Briefly pulses the status bar icon to indicate a clipboard sync.
-    func flashSyncIndicator(style: SyncIndicatorStyle = .outbound) {
+    func flashSyncIndicator(style: SyncIndicatorStyle) {
         guard let button = statusItem.button, let base = baseStatusBarImage else { return }
+        let spec = Self.syncIndicatorSpec(for: style)
 
         // Cancel any in-progress pulse
         syncPulseTimer?.invalidate()
@@ -105,15 +113,15 @@ final class StatusBarController {
         button.wantsLayer = true
         if let layer = button.layer {
             let pulse = CAKeyframeAnimation(keyPath: "transform.scale")
-            pulse.values = pulseValues(for: style)
-            pulse.keyTimes = [0, 0.35, 1.0]
-            pulse.duration = pulseDuration(for: style)
+            pulse.values = spec.values
+            pulse.keyTimes = spec.keyTimes
+            pulse.duration = spec.duration
             pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             layer.add(pulse, forKey: "syncPulse")
         }
 
         // Restore normal icon after the animation completes
-        let timer = Timer(timeInterval: restoreDelay(for: style), repeats: false) { [weak self] _ in
+        let timer = Timer(timeInterval: spec.restoreDelay, repeats: false) { [weak self] _ in
             self?.updateStatusBarIcon()
         }
         syncPulseTimer = timer
@@ -129,30 +137,22 @@ final class StatusBarController {
         }
     }
 
-    private func pulseValues(for style: SyncIndicatorStyle) -> [CGFloat] {
+    static func syncIndicatorSpec(for style: SyncIndicatorStyle) -> SyncIndicatorSpec {
         switch style {
         case .outbound:
-            return [1.0, 1.3, 1.0]
+            return SyncIndicatorSpec(
+                values: [1.0, 1.3, 1.0],
+                keyTimes: [0.0, 0.35, 1.0],
+                duration: 0.35,
+                restoreDelay: 0.4
+            )
         case .inbound:
-            return [1.0, 1.45, 1.15, 1.0]
-        }
-    }
-
-    private func pulseDuration(for style: SyncIndicatorStyle) -> TimeInterval {
-        switch style {
-        case .outbound:
-            return 0.35
-        case .inbound:
-            return 0.65
-        }
-    }
-
-    private func restoreDelay(for style: SyncIndicatorStyle) -> TimeInterval {
-        switch style {
-        case .outbound:
-            return 0.4
-        case .inbound:
-            return 0.85
+            return SyncIndicatorSpec(
+                values: [1.0, 1.45, 1.15, 1.0],
+                keyTimes: [0.0, 0.25, 0.6, 1.0],
+                duration: 0.65,
+                restoreDelay: 0.85
+            )
         }
     }
 

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/StatusBarControllerTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/StatusBarControllerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import ClipRelay
+
+final class StatusBarControllerTests: XCTestCase {
+    func testOutboundSyncIndicatorSpecMatchesExpectedKeyframeCount() {
+        let spec = StatusBarController.syncIndicatorSpec(for: .outbound)
+
+        XCTAssertEqual(spec.values.count, spec.keyTimes.count)
+        XCTAssertEqual(spec.duration, 0.35, accuracy: 0.001)
+        XCTAssertEqual(spec.restoreDelay, 0.4, accuracy: 0.001)
+    }
+
+    func testInboundSyncIndicatorSpecMatchesExpectedKeyframeCount() {
+        let spec = StatusBarController.syncIndicatorSpec(for: .inbound)
+
+        XCTAssertEqual(spec.values.count, spec.keyTimes.count)
+        XCTAssertEqual(spec.duration, 0.65, accuracy: 0.001)
+        XCTAssertEqual(spec.restoreDelay, 0.85, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

This PR improves the macOS menubar sync indicator so clipboard content received from Android is easier to notice.

The code changes here are macOS-only.

## Why

The Android reliability work makes more popup-driven copy flows sync successfully, but some of those paths are less instantaneous than the direct click path. The previous inbound indicator was easy to miss, so this PR makes receive feedback more obvious on macOS.

## What changed

- added distinct inbound vs outbound sync indicator styles
- made the inbound pulse longer and more visible than the outbound pulse
- kept outbound sync feedback lighter
- added focused tests for the sync-indicator animation spec

## Details

- `StatusBarController` now uses style-specific animation specs for inbound and outbound pulses
- inbound clipboard receives trigger the stronger menubar indicator path
- outbound sends keep the shorter pulse
- tests now pin the keyframe-count/timing invariants for both styles

## Testing

- `swift test`
- `./scripts/test-all.sh`
- `./scripts/build-all.sh`
- manual validation on my Android phone and MacBook to confirm inbound receive indication is more noticeable
