### PR TITLE
feat: Android → Mac notification sync over BLE

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -67,6 +67,15 @@
             android:exported="false"
             android:foregroundServiceType="connectedDevice" />
 
+        <service
+            android:name=".service.NotificationRelayService"
+            android:exported="true"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
         <receiver
             android:name=".service.BootCompletedReceiver"
             android:enabled="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application
         android:allowBackup="false"

--- a/android/app/src/main/java/org/cliprelay/protocol/MessageCodec.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/MessageCodec.kt
@@ -20,7 +20,8 @@ enum class MessageType(val byte: Byte) {
     CONFIG_UPDATE(0x14),
     REJECT(0x15),
     ERROR(0x16),
-    NOTIFICATION(0x20);
+    NOTIFICATION(0x20),
+    NOTIFICATION_ACTION(0x21);
 
     companion object {
         fun fromByte(b: Byte): MessageType =

--- a/android/app/src/main/java/org/cliprelay/protocol/MessageCodec.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/MessageCodec.kt
@@ -19,7 +19,8 @@ enum class MessageType(val byte: Byte) {
     DONE(0x13),
     CONFIG_UPDATE(0x14),
     REJECT(0x15),
-    ERROR(0x16);
+    ERROR(0x16),
+    NOTIFICATION(0x20);
 
     companion object {
         fun fromByte(b: Byte): MessageType =

--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -337,10 +337,39 @@ class Session(
                 }
             }
             MessageType.CONFIG_UPDATE -> handleConfigUpdate(msg)
+            MessageType.NOTIFICATION_ACTION -> handleInboundNotificationAction(msg)
             MessageType.REJECT -> { /* handled in later task */ }
             MessageType.ERROR -> { /* handled in later task */ }
             else -> Log.w(tag, "Ignoring unexpected message type: ${msg.type}")
         }
+    }
+
+    private fun handleInboundNotificationAction(msg: Message) {
+        val key = sessionKey ?: run {
+            Log.w(tag, "[Action] No session key")
+            return
+        }
+        val plaintext = try {
+            E2ECrypto.open(msg.payload, key)
+        } catch (e: Exception) {
+            Log.w(tag, "[Action] Decryption failed: ${e.message}")
+            return
+        }
+        val json = try {
+            JSONObject(String(plaintext, Charsets.UTF_8))
+        } catch (_: Exception) {
+            Log.w(tag, "[Action] JSON parse failed")
+            return
+        }
+        val notificationKey = json.optString("notificationKey")
+        val actionIndex = json.optInt("actionIndex", -1)
+        val replyText = if (json.has("replyText")) json.optString("replyText").takeIf { it.isNotEmpty() } else null
+        if (notificationKey.isEmpty() || actionIndex < 0) {
+            Log.w(tag, "[Action] Missing notificationKey or actionIndex")
+            return
+        }
+        Log.d(tag, "[Action] Firing action $actionIndex for $notificationKey")
+        callback.onNotificationActionFired(notificationKey, actionIndex, replyText)
     }
 
     // ── Outbound transfer ────────────────────────────────────────────
@@ -397,7 +426,15 @@ class Session(
      * Queue a notification for sending to the Mac. Thread-safe.
      * The message is encrypted with the session key and sent without any response expected.
      */
-    fun sendNotification(appName: String, title: String, text: String, time: Long, iconBase64: String? = null) {
+    fun sendNotification(
+        appName: String,
+        title: String,
+        text: String,
+        time: Long,
+        iconBase64: String? = null,
+        notificationKey: String? = null,
+        actions: org.json.JSONArray? = null
+    ) {
         if (closed.get()) return
         val json = JSONObject().apply {
             put("appName", appName)
@@ -405,6 +442,8 @@ class Session(
             put("text", text)
             put("time", time)
             if (iconBase64 != null) put("iconPng", iconBase64)
+            if (notificationKey != null) put("notificationKey", notificationKey)
+            if (actions != null && actions.length() > 0) put("actions", actions)
         }
         notificationQueue.put(json)
     }
@@ -912,4 +951,6 @@ interface SessionCallback {
     fun onImageRejected(reason: String) {}
     fun onImageSendFailed(reason: String) {}
     fun isDeviceAwake(): Boolean = true
+    /** Called when the Mac fires a notification action (reply, mark as read, etc.) */
+    fun onNotificationActionFired(notificationKey: String, actionIndex: Int, replyText: String?) {}
 }

--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -93,6 +93,9 @@ class Session(
     /** Queue of outbound CONFIG_UPDATE messages. */
     private val configUpdateQueue = LinkedBlockingQueue<Message>()
 
+    /** Queue of outbound notification payloads (already-serialized JSON). */
+    private val notificationQueue = LinkedBlockingQueue<JSONObject>()
+
     /** Active TCP image receiver, if any (for cancellation on new inbound offer). */
     private var activeReceiver: TcpImageReceiver? = null
 
@@ -263,6 +266,13 @@ class Session(
                     continue
                 }
 
+                // Check for queued notification sends (fire-and-forget)
+                val notifItem = notificationQueue.poll()
+                if (notifItem != null) {
+                    doSendNotification(notifItem)
+                    continue
+                }
+
                 // Check for queued image transfers
                 val imageItem = imageQueue.poll()
                 if (imageItem != null) {
@@ -379,6 +389,34 @@ class Session(
             }
             else -> throw ProtocolException("Expected ACCEPT or DONE, got ${response.type}")
         }
+    }
+
+    // ── Outbound notification (fire-and-forget) ──────────────────────
+
+    /**
+     * Queue a notification for sending to the Mac. Thread-safe.
+     * The message is encrypted with the session key and sent without any response expected.
+     */
+    fun sendNotification(appName: String, title: String, text: String, time: Long) {
+        if (closed.get()) return
+        val json = JSONObject().apply {
+            put("appName", appName)
+            put("title", title)
+            put("text", text)
+            put("time", time)
+        }
+        notificationQueue.put(json)
+    }
+
+    private fun doSendNotification(json: JSONObject) {
+        val key = sessionKey ?: return
+        val plaintext = json.toString().toByteArray(Charsets.UTF_8)
+        val encrypted = try { E2ECrypto.seal(plaintext, key) } catch (e: Exception) {
+            Log.w(tag, "Failed to encrypt notification: ${e.message}")
+            return
+        }
+        val msg = Message(MessageType.NOTIFICATION, encrypted)
+        MessageCodec.write(output, msg)
     }
 
     // ── Outbound image transfer ─────────────────────────────────────

--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -397,13 +397,14 @@ class Session(
      * Queue a notification for sending to the Mac. Thread-safe.
      * The message is encrypted with the session key and sent without any response expected.
      */
-    fun sendNotification(appName: String, title: String, text: String, time: Long) {
+    fun sendNotification(appName: String, title: String, text: String, time: Long, iconBase64: String? = null) {
         if (closed.get()) return
         val json = JSONObject().apply {
             put("appName", appName)
             put("title", title)
             put("text", text)
             put("time", time)
+            if (iconBase64 != null) put("iconPng", iconBase64)
         }
         notificationQueue.put(json)
     }
@@ -415,8 +416,7 @@ class Session(
             Log.w(tag, "Failed to encrypt notification: ${e.message}")
             return
         }
-        val msg = Message(MessageType.NOTIFICATION, encrypted)
-        MessageCodec.write(output, msg)
+        MessageCodec.write(output, Message(MessageType.NOTIFICATION, encrypted))
     }
 
     // ── Outbound image transfer ─────────────────────────────────────

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -41,6 +41,7 @@ import org.cliprelay.settings.NotificationSettingsStore
 import java.io.IOException
 import java.security.MessageDigest
 import java.util.concurrent.Executors
+import android.app.RemoteInput
 
 class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     companion object {
@@ -69,6 +70,9 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         const val EXTRA_RICH_MEDIA_ENABLED = "extra_rich_media_enabled"
 
         const val ACTION_PUSH_NOTIFICATION = "org.cliprelay.action.PUSH_NOTIFICATION"
+        /** JSON byte array payload: {appName, title, text, time, notificationKey?, actions?, iconPng?} */
+        const val EXTRA_NOTIFICATION_PAYLOAD = "extra_notification_payload"
+        // Legacy individual-field extras (kept for source compatibility but no longer used at runtime)
         const val EXTRA_NOTIFICATION_APP = "extra_notification_app"
         const val EXTRA_NOTIFICATION_TITLE = "extra_notification_title"
         const val EXTRA_NOTIFICATION_TEXT = "extra_notification_text"
@@ -231,13 +235,23 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                 }
             }
             ACTION_PUSH_NOTIFICATION -> {
-                val appName = intent.getStringExtra(EXTRA_NOTIFICATION_APP) ?: return START_STICKY
-                val title = intent.getStringExtra(EXTRA_NOTIFICATION_TITLE) ?: return START_STICKY
-                val text = intent.getStringExtra(EXTRA_NOTIFICATION_TEXT) ?: ""
-                val time = intent.getLongExtra(EXTRA_NOTIFICATION_TIME, System.currentTimeMillis())
-                val iconBase64 = intent.getStringExtra(EXTRA_NOTIFICATION_ICON)
-                Log.d(TAG, "Relaying notification from $appName: $title")
-                activeSession?.sendNotification(appName, title, text, time, iconBase64)
+                val payloadBytes = intent.getByteArrayExtra(EXTRA_NOTIFICATION_PAYLOAD)
+                if (payloadBytes != null) {
+                    try {
+                        val json = org.json.JSONObject(String(payloadBytes, Charsets.UTF_8))
+                        val appName = json.optString("appName").takeIf { it.isNotBlank() } ?: return START_STICKY
+                        val title   = json.optString("title").takeIf { it.isNotBlank() } ?: return START_STICKY
+                        val text    = json.optString("text")
+                        val time    = json.optLong("time", System.currentTimeMillis())
+                        val iconBase64 = if (json.has("iconPng")) json.optString("iconPng") else null
+                        val notifKey   = if (json.has("notificationKey")) json.optString("notificationKey") else null
+                        val actionsJson = if (json.has("actions")) json.optJSONArray("actions") else null
+                        Log.d(TAG, "Relaying notification from $appName: $title (key=$notifKey, actions=${actionsJson?.length() ?: 0})")
+                        activeSession?.sendNotification(appName, title, text, time, iconBase64, notifKey, actionsJson)
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to parse notification payload: ${e.message}")
+                    }
+                }
                 return START_STICKY
             }
             ACTION_PUSH_TEXT -> {
@@ -580,6 +594,40 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         val pm = getSystemService(Context.POWER_SERVICE) as android.os.PowerManager
         val km = getSystemService(Context.KEYGUARD_SERVICE) as android.app.KeyguardManager
         return pm.isInteractive && !km.isDeviceLocked
+    }
+
+    override fun onNotificationActionFired(notificationKey: String, actionIndex: Int, replyText: String?) {
+        // Look up stored actions from whichever service captured this notification
+        val actions = NotificationRelayService.pendingActions[notificationKey]
+            ?: ClipboardAccessibilityService.pendingActions[notificationKey]
+        val action = actions?.getOrNull(actionIndex)
+        if (action == null) {
+            Log.w(TAG, "No action found for key=$notificationKey index=$actionIndex")
+            return
+        }
+        try {
+            if (replyText != null) {
+                // Find the first free-form RemoteInput (reply box)
+                val remoteInput = action.remoteInputs?.firstOrNull { it.allowFreeFormInput }
+                if (remoteInput != null) {
+                    val fillIn = android.content.Intent()
+                    val bundle = android.os.Bundle()
+                    bundle.putCharSequence(remoteInput.resultKey, replyText)
+                    RemoteInput.addResultsToIntent(arrayOf(remoteInput), fillIn, bundle)
+                    action.actionIntent.send(this, 0, fillIn)
+                } else {
+                    // Fallback: fire without reply text
+                    action.actionIntent.send()
+                }
+            } else {
+                action.actionIntent.send()
+            }
+            Log.d(TAG, "Fired action '${action.title}' for $notificationKey")
+        } catch (e: android.app.PendingIntent.CanceledException) {
+            Log.w(TAG, "Notification action already cancelled for $notificationKey")
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fire notification action: ${e.message}")
+        }
     }
 
     // ── Outbound (Android → Mac) ─────────────────────────────────────

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -37,6 +37,7 @@ import org.cliprelay.protocol.SessionCallback
 import org.cliprelay.protocol.SessionMode
 import org.cliprelay.protocol.VersionMismatchException
 import org.cliprelay.settings.ClipboardSettingsStore
+import org.cliprelay.settings.NotificationSettingsStore
 import java.io.IOException
 import java.security.MessageDigest
 import java.util.concurrent.Executors
@@ -67,6 +68,12 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         const val ACTION_RICH_MEDIA_SETTING_CHANGED = "org.cliprelay.action.RICH_MEDIA_SETTING_CHANGED"
         const val EXTRA_RICH_MEDIA_ENABLED = "extra_rich_media_enabled"
 
+        const val ACTION_PUSH_NOTIFICATION = "org.cliprelay.action.PUSH_NOTIFICATION"
+        const val EXTRA_NOTIFICATION_APP = "extra_notification_app"
+        const val EXTRA_NOTIFICATION_TITLE = "extra_notification_title"
+        const val EXTRA_NOTIFICATION_TEXT = "extra_notification_text"
+        const val EXTRA_NOTIFICATION_TIME = "extra_notification_time"
+
         const val PREFS_NAME = "cliprelay_state"
         const val KEY_CONNECTED_DEVICE = "connected_device_name"
 
@@ -96,6 +103,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     // Support
     private lateinit var clipboardWriter: ClipboardWriter
     private lateinit var clipboardSettingsStore: ClipboardSettingsStore
+    private lateinit var notificationSettingsStore: NotificationSettingsStore
     private lateinit var pairingStore: PairingStore
     private val executor = Executors.newSingleThreadExecutor()
     private val clipboardAutoClearHandler = Handler(Looper.getMainLooper())
@@ -139,6 +147,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         super.onCreate()
         clipboardWriter = ClipboardWriter(this)
         clipboardSettingsStore = ClipboardSettingsStore(this)
+        notificationSettingsStore = NotificationSettingsStore(this)
         pairingStore = PairingStore(this)
 
         loadPairingState()
@@ -219,6 +228,14 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                         pushImageToMac(imagePath, mimeType)
                     }
                 }
+            }
+            ACTION_PUSH_NOTIFICATION -> {
+                val appName = intent.getStringExtra(EXTRA_NOTIFICATION_APP) ?: return START_STICKY
+                val title = intent.getStringExtra(EXTRA_NOTIFICATION_TITLE) ?: return START_STICKY
+                val text = intent.getStringExtra(EXTRA_NOTIFICATION_TEXT) ?: ""
+                val time = intent.getLongExtra(EXTRA_NOTIFICATION_TIME, System.currentTimeMillis())
+                activeSession?.sendNotification(appName, title, text, time)
+                return START_STICKY
             }
             ACTION_PUSH_TEXT -> {
                 clearGhostActivityInFlight()

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -73,6 +73,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         const val EXTRA_NOTIFICATION_TITLE = "extra_notification_title"
         const val EXTRA_NOTIFICATION_TEXT = "extra_notification_text"
         const val EXTRA_NOTIFICATION_TIME = "extra_notification_time"
+        const val EXTRA_NOTIFICATION_ICON = "extra_notification_icon"
 
         const val PREFS_NAME = "cliprelay_state"
         const val KEY_CONNECTED_DEVICE = "connected_device_name"
@@ -234,7 +235,9 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                 val title = intent.getStringExtra(EXTRA_NOTIFICATION_TITLE) ?: return START_STICKY
                 val text = intent.getStringExtra(EXTRA_NOTIFICATION_TEXT) ?: ""
                 val time = intent.getLongExtra(EXTRA_NOTIFICATION_TIME, System.currentTimeMillis())
-                activeSession?.sendNotification(appName, title, text, time)
+                val iconBase64 = intent.getStringExtra(EXTRA_NOTIFICATION_ICON)
+                Log.d(TAG, "Relaying notification from $appName: $title")
+                activeSession?.sendNotification(appName, title, text, time, iconBase64)
                 return START_STICKY
             }
             ACTION_PUSH_TEXT -> {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -13,35 +13,95 @@ package org.cliprelay.service
 //      This avoids stealing focus while the toolbar is still visible.
 
 import android.accessibilityservice.AccessibilityService
+import android.app.Notification
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.util.Base64
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import org.cliprelay.settings.ClipboardSettingsStore
+import org.cliprelay.settings.NotificationSettingsStore
+import java.io.ByteArrayOutputStream
 
 class ClipboardAccessibilityService : AccessibilityService() {
 
     private lateinit var settingsStore: ClipboardSettingsStore
+    private lateinit var notificationSettingsStore: NotificationSettingsStore
 
     // Tracks whether a copy toolbar was recently visible
     @Volatile
     private var copyToolbarVisible = false
 
+    // Dedup: track last notification key to avoid sending duplicates
+    private var lastNotifKey = ""
+
     override fun onServiceConnected() {
         super.onServiceConnected()
         settingsStore = ClipboardSettingsStore(this)
+        notificationSettingsStore = NotificationSettingsStore(this)
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         if (event == null) return
 
-        // Only process if auto-copy is enabled
-        if (!::settingsStore.isInitialized || !settingsStore.isAutoCopyEnabled()) return
-
         when (event.eventType) {
-            AccessibilityEvent.TYPE_VIEW_CLICKED -> handleClickEvent(event)
-            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> handleWindowStateChanged(event)
+            AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED -> handleNotificationEvent(event)
+            AccessibilityEvent.TYPE_VIEW_CLICKED -> {
+                if (::settingsStore.isInitialized && settingsStore.isAutoCopyEnabled()) handleClickEvent(event)
+            }
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> {
+                if (::settingsStore.isInitialized && settingsStore.isAutoCopyEnabled()) handleWindowStateChanged(event)
+            }
         }
+    }
+
+    // ── TYPE_NOTIFICATION_STATE_CHANGED detection ────────────────────
+
+    private val BLOCKED_PACKAGES = setOf("android", "com.android.systemui", "org.cliprelay")
+
+    private fun handleNotificationEvent(event: AccessibilityEvent) {
+        if (!::notificationSettingsStore.isInitialized) return
+        if (!notificationSettingsStore.isNotificationSyncEnabled()) return
+
+        val pkg = event.packageName?.toString() ?: return
+        if (pkg in BLOCKED_PACKAGES) return
+
+        // Extract notification from parcelableData if available
+        val notification = event.parcelableData as? Notification
+        val extras = notification?.extras
+
+        val title = extras?.getCharSequence("android.title")?.toString()
+            ?: event.text?.firstOrNull()?.toString()
+            ?: return
+
+        val text = extras?.getCharSequence("android.text")?.toString()
+            ?: event.text?.drop(1)?.joinToString(" ")
+            ?: ""
+
+        // Deduplicate: skip if same pkg+title+text as last event
+        val key = "$pkg|$title|$text"
+        if (key == lastNotifKey) return
+        lastNotifKey = key
+
+        val appName = try {
+            packageManager.getApplicationLabel(packageManager.getApplicationInfo(pkg, 0)).toString()
+        } catch (_: Exception) { pkg }
+
+        val iconBase64 = getAppIconBase64(pkg)
+
+        Log.d(TAG, "Notification via a11y: $appName / $title")
+
+        val intent = Intent(this, ClipRelayService::class.java).apply {
+            action = ClipRelayService.ACTION_PUSH_NOTIFICATION
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_APP, appName)
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TITLE, title)
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TEXT, text)
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TIME, System.currentTimeMillis())
+            if (iconBase64 != null) putExtra(ClipRelayService.EXTRA_NOTIFICATION_ICON, iconBase64)
+        }
+        startService(intent)
     }
 
     // ── TYPE_VIEW_CLICKED detection (most apps) ──────────────────────
@@ -133,6 +193,18 @@ class ClipboardAccessibilityService : AccessibilityService() {
             "कॉपी करें",                     // Hindi
         )
     }
+
+    private fun getAppIconBase64(pkg: String): String? = try {
+        val drawable = packageManager.getApplicationIcon(pkg)
+        val size = 64
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, size, size)
+        drawable.draw(canvas)
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
+        Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
+    } catch (_: Exception) { null }
 
     private fun notifyService() {
         val intent = Intent(this, ClipRelayService::class.java).apply {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -129,7 +129,15 @@ class ClipboardAccessibilityService : AccessibilityService() {
         @Suppress("DEPRECATION")
         val notification = event.parcelableData as? Notification ?: return
         if ((notification.flags and Notification.FLAG_ONGOING_EVENT) != 0) return
-        if ((notification.flags and Notification.FLAG_GROUP_SUMMARY) != 0) return
+
+        val isGroupSummary = (notification.flags and Notification.FLAG_GROUP_SUMMARY) != 0
+
+        // Email apps (e.g. Outlook) send all useful content in the GROUP_SUMMARY using
+        // InboxStyle (android.textLines). Individual child notifications are delivered
+        // with only the privacy-redacted public version, making them useless.
+        // Allow GROUP_SUMMARY through for email category; skip it for everything else.
+        val isEmail = notification.category == Notification.CATEGORY_EMAIL
+        if (isGroupSummary && !isEmail) return
 
         val extras = notification.extras ?: return
         val rawTitle = extras.getCharSequence("android.title")?.toString()?.takeIf { it.isNotBlank() } ?: return
@@ -140,7 +148,13 @@ class ClipboardAccessibilityService : AccessibilityService() {
             packageManager.getApplicationLabel(info).toString()
         } catch (_: Exception) { pkg }
 
-        // Use subText as title when the title is just the app name (e.g. Outlook)
+        // Samsung delivers the privacy-redacted public version of VISIBILITY_PRIVATE
+        // notifications to the AccessibilityService. Detect this by checking whether
+        // the title is just the app name AND the text is suspiciously short.
+        // These carry no useful content so we skip them.
+        if (rawTitle.equals(appName, ignoreCase = true) && text.length < 20) return
+
+        // Use subText as title when the title equals the app name (Outlook pattern)
         val subText = extras.getCharSequence("android.subText")?.toString()?.trim()
         val title = if (rawTitle.equals(appName, ignoreCase = true) && !subText.isNullOrBlank()) {
             subText
@@ -178,7 +192,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
             if (lines.isNotEmpty()) return lines.joinToString("\n")
         }
         // 2. InboxStyle lines (Outlook, Gmail multi-email — "Sender  Subject" per line)
-        val inboxLines = extras.getCharSequenceArray("android.text.lines")
+        val inboxLines = extras.getCharSequenceArray("android.textLines")
         if (!inboxLines.isNullOrEmpty()) {
             val text = inboxLines.mapNotNull { it?.toString()?.trim()?.takeIf { s -> s.isNotBlank() } }
                 .joinToString("\n")

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -132,13 +132,21 @@ class ClipboardAccessibilityService : AccessibilityService() {
         if ((notification.flags and Notification.FLAG_GROUP_SUMMARY) != 0) return
 
         val extras = notification.extras ?: return
-        val title = extras.getCharSequence("android.title")?.toString()?.takeIf { it.isNotBlank() } ?: return
+        val rawTitle = extras.getCharSequence("android.title")?.toString()?.takeIf { it.isNotBlank() } ?: return
         val text = extractFullText(extras)
 
         val appName = try {
             val info = packageManager.getApplicationInfo(pkg, 0)
             packageManager.getApplicationLabel(info).toString()
         } catch (_: Exception) { pkg }
+
+        // Use subText as title when the title is just the app name (e.g. Outlook)
+        val subText = extras.getCharSequence("android.subText")?.toString()?.trim()
+        val title = if (rawTitle.equals(appName, ignoreCase = true) && !subText.isNullOrBlank()) {
+            subText
+        } else {
+            rawTitle
+        }
 
         val json = JSONObject().apply {
             put("appName", appName)
@@ -156,7 +164,7 @@ class ClipboardAccessibilityService : AccessibilityService() {
     }
 
     private fun extractFullText(extras: android.os.Bundle): String {
-        // 1. MessagingStyle messages (WhatsApp, Telegram, Signal…)
+        // 1. MessagingStyle: individual chat messages (WhatsApp, Telegram, Signal…)
         @Suppress("DEPRECATION")
         val msgArray = extras.getParcelableArray("android.messages")
         if (msgArray != null && msgArray.isNotEmpty()) {
@@ -169,11 +177,25 @@ class ClipboardAccessibilityService : AccessibilityService() {
             }
             if (lines.isNotEmpty()) return lines.joinToString("\n")
         }
-        // 2. BigTextStyle full body
+        // 2. InboxStyle lines (Outlook, Gmail multi-email — "Sender  Subject" per line)
+        val inboxLines = extras.getCharSequenceArray("android.text.lines")
+        if (!inboxLines.isNullOrEmpty()) {
+            val text = inboxLines.mapNotNull { it?.toString()?.trim()?.takeIf { s -> s.isNotBlank() } }
+                .joinToString("\n")
+            if (text.isNotBlank()) return text
+        }
+        // 3. BigTextStyle full body
         val bigText = extras.getCharSequence("android.bigText")?.toString()?.trim()
         if (!bigText.isNullOrBlank()) return bigText
-        // 3. Basic fallback
-        return extras.getCharSequence("android.text")?.toString() ?: ""
+        // 4. Combine subText + basic text
+        val subText = extras.getCharSequence("android.subText")?.toString()?.trim()
+        val basicText = extras.getCharSequence("android.text")?.toString()?.trim() ?: ""
+        return when {
+            !subText.isNullOrBlank() && basicText.isNotBlank() && subText != basicText ->
+                "$basicText\n$subText"
+            !subText.isNullOrBlank() -> subText
+            else -> basicText
+        }
     }
 
     private fun renderIconBase64(pkg: String): String? = try {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -23,8 +23,10 @@ import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import org.cliprelay.settings.ClipboardSettingsStore
 import org.cliprelay.settings.NotificationSettingsStore
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.ConcurrentHashMap
 
 class ClipboardAccessibilityService : AccessibilityService() {
 
@@ -162,12 +164,32 @@ class ClipboardAccessibilityService : AccessibilityService() {
             rawTitle
         }
 
+        // Generate a synthetic key — AccessibilityService doesn't have sbn.key
+        val notifKey = "${pkg}-${event.eventTime}"
+
         val json = JSONObject().apply {
             put("appName", appName)
             put("title", title)
             put("text", text)
             put("time", event.eventTime)
+            put("notificationKey", notifKey)
             renderIconBase64(pkg)?.let { put("iconPng", it) }
+        }
+
+        // Serialize and store notification actions for later firing from Mac
+        val actions = notification.actions
+        if (!actions.isNullOrEmpty()) {
+            pendingActions[notifKey] = actions
+            val actionsJson = JSONArray()
+            actions.forEachIndexed { index, action ->
+                val hasReply = action.remoteInputs?.any { it.allowFreeFormInput } == true
+                actionsJson.put(JSONObject().apply {
+                    put("index", index)
+                    put("title", action.title?.toString() ?: "")
+                    put("hasReply", hasReply)
+                })
+            }
+            json.put("actions", actionsJson)
         }
 
         val intent = Intent(this, ClipRelayService::class.java).apply {
@@ -225,6 +247,13 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
     companion object {
         private const val TAG = "ClipboardA11y"
+
+        /**
+         * Stores Notification.Action objects keyed by a synthetic key ("pkg-eventTime") so that
+         * ClipRelayService can fire them when the Mac sends a NOTIFICATION_ACTION message.
+         * This is the Samsung fallback path — NotificationListenerService is not used.
+         */
+        val pendingActions = ConcurrentHashMap<String, Array<out Notification.Action>>()
 
         private val COPY_WORDS = setOf(
             "copy", "copy text",           // English

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -23,6 +23,7 @@ import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import org.cliprelay.settings.ClipboardSettingsStore
 import org.cliprelay.settings.NotificationSettingsStore
+import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 
 class ClipboardAccessibilityService : AccessibilityService() {
@@ -34,9 +35,6 @@ class ClipboardAccessibilityService : AccessibilityService() {
     @Volatile
     private var copyToolbarVisible = false
 
-    // Dedup: track last notification key to avoid sending duplicates
-    private var lastNotifKey = ""
-
     override fun onServiceConnected() {
         super.onServiceConnected()
         settingsStore = ClipboardSettingsStore(this)
@@ -47,61 +45,19 @@ class ClipboardAccessibilityService : AccessibilityService() {
         if (event == null) return
 
         when (event.eventType) {
-            AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED -> handleNotificationEvent(event)
-            AccessibilityEvent.TYPE_VIEW_CLICKED -> {
-                if (::settingsStore.isInitialized && settingsStore.isAutoCopyEnabled()) handleClickEvent(event)
+            AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED -> {
+                if (::notificationSettingsStore.isInitialized && notificationSettingsStore.isNotificationSyncEnabled()) {
+                    handleNotificationEvent(event)
+                }
             }
-            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> {
-                if (::settingsStore.isInitialized && settingsStore.isAutoCopyEnabled()) handleWindowStateChanged(event)
+            else -> {
+                if (!::settingsStore.isInitialized || !settingsStore.isAutoCopyEnabled()) return
+                when (event.eventType) {
+                    AccessibilityEvent.TYPE_VIEW_CLICKED -> handleClickEvent(event)
+                    AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> handleWindowStateChanged(event)
+                }
             }
         }
-    }
-
-    // ── TYPE_NOTIFICATION_STATE_CHANGED detection ────────────────────
-
-    private val BLOCKED_PACKAGES = setOf("android", "com.android.systemui", "org.cliprelay")
-
-    private fun handleNotificationEvent(event: AccessibilityEvent) {
-        if (!::notificationSettingsStore.isInitialized) return
-        if (!notificationSettingsStore.isNotificationSyncEnabled()) return
-
-        val pkg = event.packageName?.toString() ?: return
-        if (pkg in BLOCKED_PACKAGES) return
-
-        // Extract notification from parcelableData if available
-        val notification = event.parcelableData as? Notification
-        val extras = notification?.extras
-
-        val title = extras?.getCharSequence("android.title")?.toString()
-            ?: event.text?.firstOrNull()?.toString()
-            ?: return
-
-        val text = extras?.getCharSequence("android.text")?.toString()
-            ?: event.text?.drop(1)?.joinToString(" ")
-            ?: ""
-
-        // Deduplicate: skip if same pkg+title+text as last event
-        val key = "$pkg|$title|$text"
-        if (key == lastNotifKey) return
-        lastNotifKey = key
-
-        val appName = try {
-            packageManager.getApplicationLabel(packageManager.getApplicationInfo(pkg, 0)).toString()
-        } catch (_: Exception) { pkg }
-
-        val iconBase64 = getAppIconBase64(pkg)
-
-        Log.d(TAG, "Notification via a11y: $appName / $title")
-
-        val intent = Intent(this, ClipRelayService::class.java).apply {
-            action = ClipRelayService.ACTION_PUSH_NOTIFICATION
-            putExtra(ClipRelayService.EXTRA_NOTIFICATION_APP, appName)
-            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TITLE, title)
-            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TEXT, text)
-            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TIME, System.currentTimeMillis())
-            if (iconBase64 != null) putExtra(ClipRelayService.EXTRA_NOTIFICATION_ICON, iconBase64)
-        }
-        startService(intent)
     }
 
     // ── TYPE_VIEW_CLICKED detection (most apps) ──────────────────────
@@ -164,6 +120,73 @@ class ClipboardAccessibilityService : AccessibilityService() {
         return text in COPY_WORDS
     }
 
+    // ── TYPE_NOTIFICATION_STATE_CHANGED (Samsung workaround) ─────────
+
+    private fun handleNotificationEvent(event: AccessibilityEvent) {
+        val pkg = event.packageName?.toString() ?: return
+        if (pkg == packageName || pkg == "android" || pkg == "com.android.systemui") return
+
+        @Suppress("DEPRECATION")
+        val notification = event.parcelableData as? Notification ?: return
+        if ((notification.flags and Notification.FLAG_ONGOING_EVENT) != 0) return
+        if ((notification.flags and Notification.FLAG_GROUP_SUMMARY) != 0) return
+
+        val extras = notification.extras ?: return
+        val title = extras.getCharSequence("android.title")?.toString()?.takeIf { it.isNotBlank() } ?: return
+        val text = extractFullText(extras)
+
+        val appName = try {
+            val info = packageManager.getApplicationInfo(pkg, 0)
+            packageManager.getApplicationLabel(info).toString()
+        } catch (_: Exception) { pkg }
+
+        val json = JSONObject().apply {
+            put("appName", appName)
+            put("title", title)
+            put("text", text)
+            put("time", event.eventTime)
+            renderIconBase64(pkg)?.let { put("iconPng", it) }
+        }
+
+        val intent = Intent(this, ClipRelayService::class.java).apply {
+            action = ClipRelayService.ACTION_PUSH_NOTIFICATION
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_PAYLOAD, json.toString().toByteArray(Charsets.UTF_8))
+        }
+        startService(intent)
+    }
+
+    private fun extractFullText(extras: android.os.Bundle): String {
+        // 1. MessagingStyle messages (WhatsApp, Telegram, Signal…)
+        @Suppress("DEPRECATION")
+        val msgArray = extras.getParcelableArray("android.messages")
+        if (msgArray != null && msgArray.isNotEmpty()) {
+            val lines = msgArray.takeLast(10).mapNotNull { msg ->
+                val bundle = msg as? android.os.Bundle ?: return@mapNotNull null
+                val sender = bundle.getCharSequence("sender")?.toString()?.takeIf { it.isNotBlank() }
+                val msgText = bundle.getCharSequence("text")?.toString()?.takeIf { it.isNotBlank() }
+                    ?: return@mapNotNull null
+                if (sender != null) "$sender: $msgText" else msgText
+            }
+            if (lines.isNotEmpty()) return lines.joinToString("\n")
+        }
+        // 2. BigTextStyle full body
+        val bigText = extras.getCharSequence("android.bigText")?.toString()?.trim()
+        if (!bigText.isNullOrBlank()) return bigText
+        // 3. Basic fallback
+        return extras.getCharSequence("android.text")?.toString() ?: ""
+    }
+
+    private fun renderIconBase64(pkg: String): String? = try {
+        val drawable = packageManager.getApplicationIcon(pkg)
+        val bitmap = Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, 64, 64)
+        drawable.draw(canvas)
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
+        Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
+    } catch (_: Exception) { null }
+
     companion object {
         private const val TAG = "ClipboardA11y"
 
@@ -193,18 +216,6 @@ class ClipboardAccessibilityService : AccessibilityService() {
             "कॉपी करें",                     // Hindi
         )
     }
-
-    private fun getAppIconBase64(pkg: String): String? = try {
-        val drawable = packageManager.getApplicationIcon(pkg)
-        val size = 64
-        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(bitmap)
-        drawable.setBounds(0, 0, size, size)
-        drawable.draw(canvas)
-        val stream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
-        Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
-    } catch (_: Exception) { null }
 
     private fun notifyService() {
         val intent = Intent(this, ClipRelayService::class.java).apply {

--- a/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
@@ -1,33 +1,23 @@
 package org.cliprelay.service
 
-// NotificationListenerService that captures posted notifications and relays them to ClipRelayService.
-
-import android.content.ComponentName
+import android.app.Notification
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.Bundle
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
+import android.util.Base64
 import android.util.Log
 import org.cliprelay.settings.NotificationSettingsStore
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
 
 class NotificationRelayService : NotificationListenerService() {
+
     companion object {
-        private const val TAG = "NotificationRelayService"
-
-        // Packages to ignore (system noise, self-referential, etc.)
-        private val BLOCKED_PACKAGES = setOf(
-            "android",
-            "com.android.systemui",
-            "org.cliprelay",
-        )
-
-        fun isListenerEnabled(context: android.content.Context): Boolean {
-            val flat = android.provider.Settings.Secure.getString(
-                context.contentResolver,
-                "enabled_notification_listeners"
-            ) ?: return false
-            val cn = ComponentName(context, NotificationRelayService::class.java).flattenToString()
-            return flat.split(":").any { it == cn }
-        }
+        private const val TAG = "NotiSync.Relay"
+        private const val ICON_SIZE_PX = 64
     }
 
     private lateinit var settingsStore: NotificationSettingsStore
@@ -39,30 +29,80 @@ class NotificationRelayService : NotificationListenerService() {
 
     override fun onNotificationPosted(sbn: StatusBarNotification) {
         if (!settingsStore.isNotificationSyncEnabled()) return
-        if (sbn.packageName in BLOCKED_PACKAGES) return
+        if (sbn.packageName == packageName) return
+        if (sbn.notification.flags and Notification.FLAG_GROUP_SUMMARY != 0) return
         if (sbn.isOngoing) return
 
-        val extras = sbn.notification?.extras ?: return
-        val title = extras.getCharSequence("android.title")?.toString() ?: return
-        val text = extras.getCharSequence("android.text")?.toString() ?: ""
+        val extras = sbn.notification.extras
+        val title = extras.getCharSequence("android.title")?.toString()?.takeIf { it.isNotBlank() }
+            ?: return
+        val text = extractFullText(extras)
+        val appName = resolveAppLabel(sbn.packageName)
 
-        val appName = try {
-            packageManager.getApplicationLabel(
-                packageManager.getApplicationInfo(sbn.packageName, 0)
-            ).toString()
-        } catch (_: Exception) {
-            sbn.packageName
+        Log.d(TAG, "Relaying: app=$appName title=$title")
+
+        val json = JSONObject().apply {
+            put("appName", appName)
+            put("title", title)
+            put("text", text)
+            put("time", sbn.postTime)
+            val icon = renderIconBase64(sbn.packageName)
+            if (icon != null) put("iconPng", icon)
         }
-
-        Log.d(TAG, "Relaying notification from $appName: $title")
 
         val intent = Intent(this, ClipRelayService::class.java).apply {
             action = ClipRelayService.ACTION_PUSH_NOTIFICATION
-            putExtra(ClipRelayService.EXTRA_NOTIFICATION_APP, appName)
-            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TITLE, title)
-            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TEXT, text)
-            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TIME, sbn.postTime)
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_PAYLOAD, json.toString().toByteArray(Charsets.UTF_8))
         }
         startService(intent)
     }
+
+    /**
+     * Extracts the richest available text from notification extras.
+     *
+     * Priority:
+     *  1. android.messages  – MessagingStyle (WhatsApp, Telegram, Signal, etc.)
+     *                         Gives individual messages with sender names.
+     *  2. android.bigText   – BigTextStyle (Gmail, news apps, etc.)
+     *                         Gives the full expanded body.
+     *  3. android.text      – Basic fallback (one-line preview).
+     */
+    private fun extractFullText(extras: android.os.Bundle): String {
+        // 1. MessagingStyle: extract the last few individual messages
+        @Suppress("DEPRECATION")
+        val msgArray = extras.getParcelableArray("android.messages")
+        if (msgArray != null && msgArray.isNotEmpty()) {
+            val lines = msgArray.takeLast(10).mapNotNull { msg ->
+                val bundle = msg as? Bundle ?: return@mapNotNull null
+                val sender = bundle.getCharSequence("sender")?.toString()?.takeIf { it.isNotBlank() }
+                val msgText = bundle.getCharSequence("text")?.toString()?.takeIf { it.isNotBlank() }
+                    ?: return@mapNotNull null
+                if (sender != null) "$sender: $msgText" else msgText
+            }
+            if (lines.isNotEmpty()) return lines.joinToString("\n")
+        }
+
+        // 2. BigTextStyle: full expanded body
+        val bigText = extras.getCharSequence("android.bigText")?.toString()?.trim()
+        if (!bigText.isNullOrBlank()) return bigText
+
+        // 3. Basic text fallback
+        return extras.getCharSequence("android.text")?.toString() ?: ""
+    }
+
+    private fun resolveAppLabel(pkg: String): String = try {
+        val info = packageManager.getApplicationInfo(pkg, 0)
+        packageManager.getApplicationLabel(info).toString()
+    } catch (_: Exception) { pkg }
+
+    private fun renderIconBase64(pkg: String): String? = try {
+        val drawable = packageManager.getApplicationIcon(pkg)
+        val bitmap = Bitmap.createBitmap(ICON_SIZE_PX, ICON_SIZE_PX, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, ICON_SIZE_PX, ICON_SIZE_PX)
+        drawable.draw(canvas)
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
+        Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
+    } catch (_: Exception) { null }
 }

--- a/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
@@ -1,0 +1,68 @@
+package org.cliprelay.service
+
+// NotificationListenerService that captures posted notifications and relays them to ClipRelayService.
+
+import android.content.ComponentName
+import android.content.Intent
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+import org.cliprelay.settings.NotificationSettingsStore
+
+class NotificationRelayService : NotificationListenerService() {
+    companion object {
+        private const val TAG = "NotificationRelayService"
+
+        // Packages to ignore (system noise, self-referential, etc.)
+        private val BLOCKED_PACKAGES = setOf(
+            "android",
+            "com.android.systemui",
+            "org.cliprelay",
+        )
+
+        fun isListenerEnabled(context: android.content.Context): Boolean {
+            val flat = android.provider.Settings.Secure.getString(
+                context.contentResolver,
+                "enabled_notification_listeners"
+            ) ?: return false
+            val cn = ComponentName(context, NotificationRelayService::class.java).flattenToString()
+            return flat.split(":").any { it == cn }
+        }
+    }
+
+    private lateinit var settingsStore: NotificationSettingsStore
+
+    override fun onCreate() {
+        super.onCreate()
+        settingsStore = NotificationSettingsStore(this)
+    }
+
+    override fun onNotificationPosted(sbn: StatusBarNotification) {
+        if (!settingsStore.isNotificationSyncEnabled()) return
+        if (sbn.packageName in BLOCKED_PACKAGES) return
+        if (sbn.isOngoing) return
+
+        val extras = sbn.notification?.extras ?: return
+        val title = extras.getCharSequence("android.title")?.toString() ?: return
+        val text = extras.getCharSequence("android.text")?.toString() ?: ""
+
+        val appName = try {
+            packageManager.getApplicationLabel(
+                packageManager.getApplicationInfo(sbn.packageName, 0)
+            ).toString()
+        } catch (_: Exception) {
+            sbn.packageName
+        }
+
+        Log.d(TAG, "Relaying notification from $appName: $title")
+
+        val intent = Intent(this, ClipRelayService::class.java).apply {
+            action = ClipRelayService.ACTION_PUSH_NOTIFICATION
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_APP, appName)
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TITLE, title)
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TEXT, text)
+            putExtra(ClipRelayService.EXTRA_NOTIFICATION_TIME, sbn.postTime)
+        }
+        startService(intent)
+    }
+}

--- a/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
@@ -34,10 +34,19 @@ class NotificationRelayService : NotificationListenerService() {
         if (sbn.isOngoing) return
 
         val extras = sbn.notification.extras
-        val title = extras.getCharSequence("android.title")?.toString()?.takeIf { it.isNotBlank() }
+        val rawTitle = extras.getCharSequence("android.title")?.toString()?.takeIf { it.isNotBlank() }
             ?: return
         val text = extractFullText(extras)
         val appName = resolveAppLabel(sbn.packageName)
+
+        // Some apps (e.g. Outlook) set android.title = app name and put the
+        // real subject/sender in android.subText. Use subText as title in that case.
+        val subText = extras.getCharSequence("android.subText")?.toString()?.trim()
+        val title = if (rawTitle.equals(appName, ignoreCase = true) && !subText.isNullOrBlank()) {
+            subText
+        } else {
+            rawTitle
+        }
 
         Log.d(TAG, "Relaying: app=$appName title=$title")
 
@@ -61,14 +70,15 @@ class NotificationRelayService : NotificationListenerService() {
      * Extracts the richest available text from notification extras.
      *
      * Priority:
-     *  1. android.messages  – MessagingStyle (WhatsApp, Telegram, Signal, etc.)
-     *                         Gives individual messages with sender names.
-     *  2. android.bigText   – BigTextStyle (Gmail, news apps, etc.)
-     *                         Gives the full expanded body.
-     *  3. android.text      – Basic fallback (one-line preview).
+     *  1. android.messages    – MessagingStyle (WhatsApp, Telegram, Signal…)
+     *  2. android.text.lines  – InboxStyle (Outlook, Gmail multi-email…)
+     *                           Each line is typically "Sender  Subject".
+     *  3. android.bigText     – BigTextStyle (Gmail single email, news…)
+     *  4. android.subText     – Account/context line many apps set
+     *  5. android.text        – Basic one-line fallback
      */
     private fun extractFullText(extras: android.os.Bundle): String {
-        // 1. MessagingStyle: extract the last few individual messages
+        // 1. MessagingStyle: individual chat messages with sender names
         @Suppress("DEPRECATION")
         val msgArray = extras.getParcelableArray("android.messages")
         if (msgArray != null && msgArray.isNotEmpty()) {
@@ -82,12 +92,27 @@ class NotificationRelayService : NotificationListenerService() {
             if (lines.isNotEmpty()) return lines.joinToString("\n")
         }
 
-        // 2. BigTextStyle: full expanded body
+        // 2. InboxStyle: array of lines (Outlook shows "Sender  Subject" per line)
+        val inboxLines = extras.getCharSequenceArray("android.text.lines")
+        if (!inboxLines.isNullOrEmpty()) {
+            val text = inboxLines.mapNotNull { it?.toString()?.trim()?.takeIf { s -> s.isNotBlank() } }
+                .joinToString("\n")
+            if (text.isNotBlank()) return text
+        }
+
+        // 3. BigTextStyle: full expanded body
         val bigText = extras.getCharSequence("android.bigText")?.toString()?.trim()
         if (!bigText.isNullOrBlank()) return bigText
 
-        // 3. Basic text fallback
-        return extras.getCharSequence("android.text")?.toString() ?: ""
+        // 4. Combine subText + basic text (some apps put context in subText)
+        val subText = extras.getCharSequence("android.subText")?.toString()?.trim()
+        val basicText = extras.getCharSequence("android.text")?.toString()?.trim() ?: ""
+        return when {
+            !subText.isNullOrBlank() && basicText.isNotBlank() && subText != basicText ->
+                "$basicText\n$subText"
+            !subText.isNullOrBlank() -> subText
+            else -> basicText
+        }
     }
 
     private fun resolveAppLabel(pkg: String): String = try {

--- a/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
@@ -71,7 +71,7 @@ class NotificationRelayService : NotificationListenerService() {
      *
      * Priority:
      *  1. android.messages    – MessagingStyle (WhatsApp, Telegram, Signal…)
-     *  2. android.text.lines  – InboxStyle (Outlook, Gmail multi-email…)
+     *  2. android.textLines  – InboxStyle (Outlook, Gmail multi-email…)
      *                           Each line is typically "Sender  Subject".
      *  3. android.bigText     – BigTextStyle (Gmail single email, news…)
      *  4. android.subText     – Account/context line many apps set
@@ -93,7 +93,7 @@ class NotificationRelayService : NotificationListenerService() {
         }
 
         // 2. InboxStyle: array of lines (Outlook shows "Sender  Subject" per line)
-        val inboxLines = extras.getCharSequenceArray("android.text.lines")
+        val inboxLines = extras.getCharSequenceArray("android.textLines")
         if (!inboxLines.isNullOrEmpty()) {
             val text = inboxLines.mapNotNull { it?.toString()?.trim()?.takeIf { s -> s.isNotBlank() } }
                 .joinToString("\n")

--- a/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/NotificationRelayService.kt
@@ -10,14 +10,23 @@ import android.service.notification.StatusBarNotification
 import android.util.Base64
 import android.util.Log
 import org.cliprelay.settings.NotificationSettingsStore
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.ConcurrentHashMap
 
 class NotificationRelayService : NotificationListenerService() {
 
     companion object {
         private const val TAG = "NotiSync.Relay"
         private const val ICON_SIZE_PX = 64
+
+        /**
+         * Stores Notification.Action objects keyed by StatusBarNotification.key so that
+         * ClipRelayService can fire them when the Mac sends a NOTIFICATION_ACTION message.
+         * Entries are cleaned up in onNotificationRemoved.
+         */
+        val pendingActions = ConcurrentHashMap<String, Array<out Notification.Action>>()
     }
 
     private lateinit var settingsStore: NotificationSettingsStore
@@ -55,8 +64,25 @@ class NotificationRelayService : NotificationListenerService() {
             put("title", title)
             put("text", text)
             put("time", sbn.postTime)
+            put("notificationKey", sbn.key)
             val icon = renderIconBase64(sbn.packageName)
             if (icon != null) put("iconPng", icon)
+        }
+
+        // Serialize and store notification actions for later firing from Mac
+        val actions = sbn.notification.actions
+        if (!actions.isNullOrEmpty()) {
+            pendingActions[sbn.key] = actions
+            val actionsJson = JSONArray()
+            actions.forEachIndexed { index, action ->
+                val hasReply = action.remoteInputs?.any { it.allowFreeFormInput } == true
+                actionsJson.put(JSONObject().apply {
+                    put("index", index)
+                    put("title", action.title?.toString() ?: "")
+                    put("hasReply", hasReply)
+                })
+            }
+            json.put("actions", actionsJson)
         }
 
         val intent = Intent(this, ClipRelayService::class.java).apply {
@@ -64,6 +90,10 @@ class NotificationRelayService : NotificationListenerService() {
             putExtra(ClipRelayService.EXTRA_NOTIFICATION_PAYLOAD, json.toString().toByteArray(Charsets.UTF_8))
         }
         startService(intent)
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification) {
+        pendingActions.remove(sbn.key)
     }
 
     /**

--- a/android/app/src/main/java/org/cliprelay/settings/NotificationSettingsStore.kt
+++ b/android/app/src/main/java/org/cliprelay/settings/NotificationSettingsStore.kt
@@ -1,0 +1,17 @@
+package org.cliprelay.settings
+
+import android.content.Context
+
+class NotificationSettingsStore(context: Context) {
+    private val prefs = context.getSharedPreferences("cliprelay_notification_settings", Context.MODE_PRIVATE)
+
+    fun isNotificationSyncEnabled(): Boolean = prefs.getBoolean(KEY_NOTIFICATION_SYNC_ENABLED, false)
+
+    fun setNotificationSyncEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_NOTIFICATION_SYNC_ENABLED, enabled).apply()
+    }
+
+    companion object {
+        private const val KEY_NOTIFICATION_SYNC_ENABLED = "notification_sync_enabled"
+    }
+}

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -88,12 +88,16 @@ fun ClipRelayScreen(
     autoCopyEnabled: Boolean,
     autoCopyAccessibilityEnabled: Boolean = false,
     imageSyncEnabled: Boolean = false,
+    notificationSyncEnabled: Boolean = false,
+    notificationListenerEnabled: Boolean = false,
     onPairClick: () -> Unit,
     onUnpairClick: () -> Unit,
     onBurstShown: () -> Unit,
     onAutoClearSettingChanged: (Boolean) -> Unit,
     onAutoCopySettingChanged: (Boolean) -> Unit,
     onImageSyncSettingChanged: (Boolean) -> Unit = {},
+    onNotificationSyncSettingChanged: (Boolean) -> Unit = {},
+    onNotificationListenerFixClick: () -> Unit = {},
     onAutoCopyFixClick: () -> Unit = {},
     onHelpClick: () -> Unit = {},
     onSupportLinkClick: (String) -> Unit = {},
@@ -172,11 +176,15 @@ fun ClipRelayScreen(
                 autoCopyEnabled = autoCopyEnabled,
                 autoCopyAccessibilityEnabled = autoCopyAccessibilityEnabled,
                 imageSyncEnabled = imageSyncEnabled,
+                notificationSyncEnabled = notificationSyncEnabled,
+                notificationListenerEnabled = notificationListenerEnabled,
                 onPairClick = onPairClick,
                 onUnpairClick = onUnpairClick,
                 onAutoClearSettingChanged = onAutoClearSettingChanged,
                 onAutoCopySettingChanged = onAutoCopySettingChanged,
                 onImageSyncSettingChanged = onImageSyncSettingChanged,
+                onNotificationSyncSettingChanged = onNotificationSyncSettingChanged,
+                onNotificationListenerFixClick = onNotificationListenerFixClick,
                 onAutoCopyFixClick = onAutoCopyFixClick
             )
             Spacer(modifier = Modifier.weight(1f))
@@ -289,11 +297,15 @@ private fun MainCard(
     autoCopyEnabled: Boolean,
     autoCopyAccessibilityEnabled: Boolean = false,
     imageSyncEnabled: Boolean = false,
+    notificationSyncEnabled: Boolean = false,
+    notificationListenerEnabled: Boolean = false,
     onPairClick: () -> Unit,
     onUnpairClick: () -> Unit,
     onAutoClearSettingChanged: (Boolean) -> Unit,
     onAutoCopySettingChanged: (Boolean) -> Unit,
     onImageSyncSettingChanged: (Boolean) -> Unit = {},
+    onNotificationSyncSettingChanged: (Boolean) -> Unit = {},
+    onNotificationListenerFixClick: () -> Unit = {},
     onAutoCopyFixClick: () -> Unit = {}
 ) {
     val isPaired = state !is AppState.Unpaired
@@ -556,6 +568,13 @@ private fun MainCard(
                 onEnabledChange = onImageSyncSettingChanged
             )
             Spacer(modifier = Modifier.height(8.dp))
+            NotificationSyncSettingRow(
+                enabled = notificationSyncEnabled,
+                listenerGranted = notificationListenerEnabled,
+                onEnabledChange = onNotificationSyncSettingChanged,
+                onFixClick = onNotificationListenerFixClick
+            )
+            Spacer(modifier = Modifier.height(8.dp))
             AutoCopySettingRow(
                 enabled = autoCopyEnabled,
                 accessibilityEnabled = autoCopyAccessibilityEnabled,
@@ -744,6 +763,90 @@ private fun ImageSyncSettingRow(
                 text = stringResource(R.string.image_sync_setting_subtitle),
                 fontSize = 12.sp,
                 color = Color(0x80000000),
+                lineHeight = 16.sp
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Switch(
+            checked = enabled,
+            onCheckedChange = onEnabledChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Teal,
+                checkedTrackColor = Aqua.copy(alpha = 0.45f),
+                checkedBorderColor = Aqua.copy(alpha = 0.60f),
+                uncheckedThumbColor = Color(0xFF7A7A7A),
+                uncheckedTrackColor = Color(0x15000000),
+                uncheckedBorderColor = Color(0x40000000)
+            )
+        )
+    }
+}
+
+@Composable
+private fun NotificationSyncSettingRow(
+    enabled: Boolean,
+    listenerGranted: Boolean,
+    onEnabledChange: (Boolean) -> Unit,
+    onFixClick: () -> Unit = {}
+) {
+    val isBroken = enabled && !listenerGranted
+    val warningColor = Color(0xFFE57373)
+
+    val toggleBg = if (enabled) Color(0x1400FFD5) else Color(0x08000000)
+    val toggleBorder = when {
+        isBroken -> warningColor.copy(alpha = 0.5f)
+        enabled -> Color(0x2B00FFD5)
+        else -> Color(0x14000000)
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(toggleBg)
+            .border(if (isBroken) 2.dp else 1.dp, toggleBorder, RoundedCornerShape(18.dp))
+            .then(
+                if (isBroken)
+                    Modifier.clickable(onClick = onFixClick)
+                else
+                    Modifier.toggleable(
+                        value = enabled,
+                        role = Role.Switch,
+                        onValueChange = onEnabledChange
+                    )
+            )
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (isBroken) {
+            Text(
+                text = "⚠️",
+                fontSize = 24.sp,
+                modifier = Modifier.padding(end = 10.dp)
+            )
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.notification_sync_setting_title),
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xCC000000)
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = if (isBroken)
+                    stringResource(R.string.notification_sync_needs_permission)
+                else if (enabled)
+                    stringResource(R.string.notification_sync_setting_subtitle_on)
+                else
+                    stringResource(R.string.notification_sync_setting_subtitle_off),
+                fontSize = 12.sp,
+                fontWeight = if (isBroken) FontWeight.SemiBold else FontWeight.Normal,
+                color = if (isBroken) warningColor else Color(0x80000000),
                 lineHeight = 16.sp
             )
         }

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -29,12 +29,15 @@ import org.cliprelay.pairing.PairingStore
 import org.cliprelay.permissions.BlePermissions
 import org.cliprelay.service.ClipboardAccessibilityService
 import org.cliprelay.service.ClipRelayService
+import org.cliprelay.service.NotificationRelayService
 import org.cliprelay.settings.ClipboardSettingsStore
+import org.cliprelay.settings.NotificationSettingsStore
 
 class MainActivity : AppCompatActivity() {
 
     private val viewModel: MainViewModel by viewModels()
     private lateinit var clipboardSettingsStore: ClipboardSettingsStore
+    private lateinit var notificationSettingsStore: NotificationSettingsStore
 
     private val connectionReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -105,6 +108,7 @@ class MainActivity : AppCompatActivity() {
         requestRuntimePermissions()
         ensureServiceRunning()
         clipboardSettingsStore = ClipboardSettingsStore(this)
+        notificationSettingsStore = NotificationSettingsStore(this)
 
         val pairingStore = PairingStore(this)
         val secret = pairingStore.loadSharedSecret()
@@ -118,7 +122,8 @@ class MainActivity : AppCompatActivity() {
         val autoClearEnabled = clipboardSettingsStore.isAutoClearSyncedClipboardEnabled()
         val autoCopyEnabled = clipboardSettingsStore.isAutoCopyEnabled()
         val imageSyncEnabled = pairingStore.isRichMediaEnabled()
-        viewModel.initState(isPaired, deviceName, deviceTag, autoClearEnabled, autoCopyEnabled, imageSyncEnabled)
+        val notificationSyncEnabled = notificationSettingsStore.isNotificationSyncEnabled()
+        viewModel.initState(isPaired, deviceName, deviceTag, autoClearEnabled, autoCopyEnabled, imageSyncEnabled, notificationSyncEnabled)
 
         setContent {
             val state by viewModel.state.collectAsState()
@@ -127,6 +132,8 @@ class MainActivity : AppCompatActivity() {
             val autoCopyEnabled by viewModel.autoCopyEnabled.collectAsState()
             val autoCopyAccessibilityEnabled by viewModel.autoCopyAccessibilityEnabled.collectAsState()
             val imageSyncEnabled by viewModel.imageSyncEnabled.collectAsState()
+            val notificationSyncEnabled by viewModel.notificationSyncEnabled.collectAsState()
+            val notificationListenerEnabled by viewModel.notificationListenerEnabled.collectAsState()
             val showVersionMismatch by viewModel.showVersionMismatch.collectAsState()
             var showAccessibilityDisclosure by remember { mutableStateOf(false) }
 
@@ -158,6 +165,8 @@ class MainActivity : AppCompatActivity() {
                 autoCopyEnabled = autoCopyEnabled,
                 autoCopyAccessibilityEnabled = autoCopyAccessibilityEnabled,
                 imageSyncEnabled = imageSyncEnabled,
+                notificationSyncEnabled = notificationSyncEnabled,
+                notificationListenerEnabled = notificationListenerEnabled,
                 onPairClick = {
                     scannerLauncher.launch(Intent(this, QrScannerActivity::class.java))
                 },
@@ -191,6 +200,16 @@ class MainActivity : AppCompatActivity() {
                     configIntent.action = ClipRelayService.ACTION_SEND_CONFIG_UPDATE
                     startServiceSafely(configIntent)
                 },
+                onNotificationSyncSettingChanged = { enabled ->
+                    viewModel.onNotificationSyncSettingChanged(enabled)
+                    notificationSettingsStore.setNotificationSyncEnabled(enabled)
+                    if (enabled && !NotificationRelayService.isListenerEnabled(this)) {
+                        startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+                    }
+                },
+                onNotificationListenerFixClick = {
+                    startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+                },
                 onAutoCopyFixClick = {
                     showAccessibilityDisclosure = true
                 },
@@ -220,6 +239,7 @@ class MainActivity : AppCompatActivity() {
         )
         viewModel.onAccessibilityStateChanged(isAccessibilityServiceEnabled())
         viewModel.onImageSyncSettingChanged(PairingStore(this).isRichMediaEnabled())
+        viewModel.onNotificationListenerStateChanged(NotificationRelayService.isListenerEnabled(this))
         val queryIntent = Intent(this, ClipRelayService::class.java)
         queryIntent.action = ClipRelayService.ACTION_QUERY_CONNECTION
         startServiceSafely(queryIntent)

--- a/android/app/src/main/java/org/cliprelay/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainViewModel.kt
@@ -31,6 +31,12 @@ class MainViewModel : ViewModel() {
     private val _imageSyncEnabled = MutableStateFlow(false)
     val imageSyncEnabled: StateFlow<Boolean> = _imageSyncEnabled.asStateFlow()
 
+    private val _notificationSyncEnabled = MutableStateFlow(false)
+    val notificationSyncEnabled: StateFlow<Boolean> = _notificationSyncEnabled.asStateFlow()
+
+    private val _notificationListenerEnabled = MutableStateFlow(false)
+    val notificationListenerEnabled: StateFlow<Boolean> = _notificationListenerEnabled.asStateFlow()
+
     private val _autoCopyAccessibilityEnabled = MutableStateFlow(false)
     val autoCopyAccessibilityEnabled: StateFlow<Boolean> = _autoCopyAccessibilityEnabled.asStateFlow()
 
@@ -41,11 +47,12 @@ class MainViewModel : ViewModel() {
     private val _clipboardTransfer = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
     val clipboardTransfer: SharedFlow<Boolean> = _clipboardTransfer
 
-    fun initState(isPaired: Boolean, deviceName: String? = null, deviceTag: String? = null, autoClearEnabled: Boolean = false, autoCopyEnabled: Boolean = false, imageSyncEnabled: Boolean = false) {
+    fun initState(isPaired: Boolean, deviceName: String? = null, deviceTag: String? = null, autoClearEnabled: Boolean = false, autoCopyEnabled: Boolean = false, imageSyncEnabled: Boolean = false, notificationSyncEnabled: Boolean = false) {
         _state.value = if (isPaired) AppState.Searching(deviceName, deviceTag) else AppState.Unpaired
         _autoClearEnabled.value = autoClearEnabled
         _autoCopyEnabled.value = autoCopyEnabled
         _imageSyncEnabled.value = imageSyncEnabled
+        _notificationSyncEnabled.value = notificationSyncEnabled
     }
 
     fun onPaired(deviceTag: String? = null) {
@@ -87,6 +94,14 @@ class MainViewModel : ViewModel() {
 
     fun onImageSyncSettingChanged(enabled: Boolean) {
         _imageSyncEnabled.value = enabled
+    }
+
+    fun onNotificationSyncSettingChanged(enabled: Boolean) {
+        _notificationSyncEnabled.value = enabled
+    }
+
+    fun onNotificationListenerStateChanged(enabled: Boolean) {
+        _notificationListenerEnabled.value = enabled
     }
 
     fun onAccessibilityStateChanged(enabled: Boolean) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -43,6 +43,10 @@
     <string name="auto_copy_needs_accessibility">Not working — tap to enable Accessibility permission</string>
     <string name="image_sync_setting_title">Image sync (experimental)</string>
     <string name="image_sync_setting_subtitle">Sync clipboard images. Requires devices to be on the same Wi-Fi.</string>
+    <string name="notification_sync_setting_title">Notification sync</string>
+    <string name="notification_sync_setting_subtitle_on">Mirroring phone notifications to Mac</string>
+    <string name="notification_sync_setting_subtitle_off">Mirror phone notifications to your Mac</string>
+    <string name="notification_sync_needs_permission">Not working — tap to grant Notification Access</string>
     <string name="accessibility_disclosure_title">Accessibility Permission</string>
     <string name="accessibility_disclosure_body">ClipRelay uses Android\'s Accessibility Service to detect when you copy text, so it can automatically send your clipboard to your paired Mac.\n\nThis permission allows ClipRelay to monitor tap actions only. It does not read, collect, or store any screen content or personal data.</string>
     <string name="accessibility_disclosure_allow">Allow</string>

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
-    android:accessibilityEventTypes="typeViewClicked|typeWindowStateChanged"
+    android:accessibilityEventTypes="typeViewClicked|typeWindowStateChanged|typeNotificationStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:notificationTimeout="200"
     android:canRetrieveWindowContent="true" />

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -19,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let clipboardWriter = ClipboardWriter()
     private let notificationManager = ReceiveNotificationManager()
     private let pairingWindowController = PairingWindowController()
+    private let filterWindowController = FilterWindowController()
 
     override init() {
         updaterController = SPUStandardUpdaterController(
@@ -93,6 +94,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if self?.connectionController?.isConnected == true { return "connected" }
             let isPaired = !(self?.pairingManager.loadDevices().isEmpty ?? true)
             return isPaired ? "searching" : "unpaired"
+        }
+        statusBarController.onShowNotificationFilters = { [weak self] in
+            self?.filterWindowController.showWindow()
         }
         pairingWindowController.onDidClose = { [weak self] in
             self?.handlePairingWindowClosed()
@@ -357,7 +361,7 @@ extension AppDelegate: ConnectionControllerDelegate {
         // Logged by ConnectionController
     }
 
-    func didReceiveAndroidNotification(appName: String, title: String, text: String) {
-        notificationManager.postAndroidNotification(appName: appName, title: title, text: text)
+    func didReceiveAndroidNotification(appName: String, title: String, text: String, iconData: Data?) {
+        notificationManager.postAndroidNotification(appName: appName, title: title, text: text, iconData: iconData)
     }
 }

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -38,6 +38,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let bluetoothOffDebounceDelay: TimeInterval = 60.0
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Hide from Dock — menu-bar-only app.
+        NSApplication.shared.setActivationPolicy(.accessory)
+
         // Start the Sparkle updater now that the app is fully launched.
         // Creating the controller with startingUpdater:false in init() and
         // deferring start to here avoids a race where the updater's scheduled
@@ -47,7 +50,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             updaterController.updater.checkForUpdatesInBackground()
         }
 
-        UNUserNotificationCenter.current().delegate = updaterDriverDelegate
+        if Bundle.main.bundleIdentifier != nil {
+            UNUserNotificationCenter.current().delegate = updaterDriverDelegate
+        }
         notificationManager.requestAuthorization()
         pairingManager.removePendingDevices()
         enableLaunchAtLoginIfFirstRun()
@@ -67,20 +72,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.forgetDevice(token: token)
         }
         statusBarController.onToggleLaunchAtLogin = {
-            let service = SMAppService.mainApp
-            do {
-                if service.status == .enabled {
-                    try service.unregister()
-                } else {
-                    try service.register()
-                }
-            } catch {
-                appLogger.error("[App] Failed to toggle launch at login: \(error.localizedDescription)")
-            }
+            // SMAppService requires a notarized Developer ID signature — not available
+            // in ad-hoc builds. Use System Settings > General > Login Items instead.
         }
-        statusBarController.isLaunchAtLoginEnabled = {
-            SMAppService.mainApp.status == .enabled
-        }
+        statusBarController.isLaunchAtLoginEnabled = { false }
         statusBarController.onToggleImageSync = { [weak self] in
             self?.connectionController?.toggleImageSync()
         }
@@ -97,6 +92,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         statusBarController.onShowNotificationFilters = { [weak self] in
             self?.filterWindowController.showWindow()
+        }
+        notificationManager.onNotificationLogged = { [weak self] in
+            self?.statusBarController.refreshMenu()
         }
         pairingWindowController.onDidClose = { [weak self] in
             self?.handlePairingWindowClosed()
@@ -141,15 +139,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Launch at Login
 
     private func enableLaunchAtLoginIfFirstRun() {
-        let key = "hasEnabledLaunchAtLogin"
-        guard !UserDefaults.standard.bool(forKey: key) else { return }
-        UserDefaults.standard.set(true, forKey: key)
-        do {
-            try SMAppService.mainApp.register()
-            appLogger.notice("[App] Launch at login enabled on first run")
-        } catch {
-            appLogger.error("[App] Failed to enable launch at login: \(error.localizedDescription)")
-        }
+        // SMAppService requires a notarized Developer ID signature.
+        // For ad-hoc builds, add ClipRelay manually via System Settings > General > Login Items.
     }
 
     // MARK: - Pairing

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -93,6 +93,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusBarController.onShowNotificationFilters = { [weak self] in
             self?.filterWindowController.showWindow()
         }
+        statusBarController.sendNotificationAction = { [weak self] key, index, replyText in
+            self?.connectionController?.sendNotificationAction(notificationKey: key, actionIndex: index, replyText: replyText)
+        }
         notificationManager.onNotificationLogged = { [weak self] in
             self?.statusBarController.refreshMenu()
         }
@@ -352,7 +355,9 @@ extension AppDelegate: ConnectionControllerDelegate {
         // Logged by ConnectionController
     }
 
-    func didReceiveAndroidNotification(appName: String, title: String, text: String, iconData: Data?) {
-        notificationManager.postAndroidNotification(appName: appName, title: title, text: text, iconData: iconData)
+    func didReceiveAndroidNotification(appName: String, title: String, text: String, iconData: Data?,
+                                        notificationKey: String, actions: [NotificationAction]) {
+        notificationManager.postAndroidNotification(appName: appName, title: title, text: text, iconData: iconData,
+                                                     notificationKey: notificationKey, actions: actions)
     }
 }

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -356,4 +356,8 @@ extension AppDelegate: ConnectionControllerDelegate {
     func imageTransferFailed(reason: String) {
         // Logged by ConnectionController
     }
+
+    func didReceiveAndroidNotification(appName: String, title: String, text: String) {
+        notificationManager.postAndroidNotification(appName: appName, title: title, text: text)
+    }
 }

--- a/macos/ClipRelayMac/Sources/App/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/App/ConnectionController.swift
@@ -69,7 +69,8 @@ protocol ConnectionControllerDelegate: AnyObject {
     func didSyncClipboard(hash: String)
     func didChangeImageSyncSetting(enabled: Bool)
     func imageTransferFailed(reason: String)
-    func didReceiveAndroidNotification(appName: String, title: String, text: String)
+    func didReceiveAndroidNotification(appName: String, title: String, text: String, iconData: Data?,
+                                       notificationKey: String, actions: [NotificationAction])
 }
 
 // MARK: - ConnectionController
@@ -914,10 +915,23 @@ extension ConnectionController {
         }
     }
 
-    fileprivate func handleAndroidNotification(appName: String, title: String, text: String) {
-        log("Received notification from \(appName): \(title)")
+    fileprivate func handleNotificationReceived(appName: String, title: String, text: String,
+                                                 iconData: Data?, notificationKey: String, actions: [NotificationAction]) {
         DispatchQueue.main.async { [weak self] in
-            self?.delegate?.didReceiveAndroidNotification(appName: appName, title: title, text: text)
+            self?.delegate?.didReceiveAndroidNotification(appName: appName, title: title, text: text,
+                                                          iconData: iconData, notificationKey: notificationKey, actions: actions)
+        }
+    }
+
+    /// Fire a notification action on the Android phone (e.g. Reply, Mark as read).
+    /// Safe to call from any thread.
+    func sendNotificationAction(notificationKey: String, actionIndex: Int, replyText: String? = nil) {
+        queue.async { [self] in
+            guard case .ready(let session, _, _) = state else {
+                log("sendNotificationAction: not connected")
+                return
+            }
+            session.sendNotificationAction(notificationKey: notificationKey, actionIndex: actionIndex, replyText: replyText)
         }
     }
 }
@@ -992,11 +1006,13 @@ private class SessionAdapter: NSObject, SessionDelegate {
         dispatch { $0.handleImageTransferFailed(reason: "send failed: \(reason)") }
     }
 
-    func session(_ session: Session, alreadyHasHash hash: String) -> Bool {
-        return lastTextHash == hash
+    func session(_ session: Session, didReceiveNotification appName: String, title: String, text: String,
+                 iconData: Data?, notificationKey: String, actions: [NotificationAction]) {
+        dispatch { $0.handleNotificationReceived(appName: appName, title: title, text: text,
+                                                  iconData: iconData, notificationKey: notificationKey, actions: actions) }
     }
 
-    func session(_ session: Session, didReceiveAndroidNotification appName: String, title: String, text: String, time: Int64) {
-        dispatch { $0.handleAndroidNotification(appName: appName, title: title, text: text) }
+    func session(_ session: Session, alreadyHasHash hash: String) -> Bool {
+        return lastTextHash == hash
     }
 }

--- a/macos/ClipRelayMac/Sources/App/FilterWindowController.swift
+++ b/macos/ClipRelayMac/Sources/App/FilterWindowController.swift
@@ -1,0 +1,368 @@
+// Settings panel for notification filters (by app name and keyword).
+
+import AppKit
+
+/// Controls the Notification Filters settings panel.
+/// Show it by calling `showWindow()`. The window is a floating panel; clicking
+/// its close button destroys the reference so it can be re-created later.
+final class FilterWindowController: NSObject, NSWindowDelegate {
+
+    private var window: NSWindow?
+    private let store = NotificationFilterStore.shared
+
+    // Apps tab
+    private var appsSegment: NSSegmentedControl!
+    private var appsDescLabel: NSTextField!
+    private var appsScrollView: NSScrollView!
+    private var appsTable: NSTableView!
+    private var appsRemoveButton: NSButton!
+
+    // Keywords tab
+    private var kwScrollView: NSScrollView!
+    private var kwTable: NSTableView!
+    private var kwRemoveButton: NSButton!
+
+    // Table helpers (kept alive by the controller)
+    private lazy var appsHelper  = TableHelper(owner: self, kind: .apps)
+    private lazy var kwHelper    = TableHelper(owner: self, kind: .keywords)
+
+    // MARK: - Public API
+
+    func showWindow() {
+        if let w = window {
+            w.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        buildWindow()
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_ notification: Notification) {
+        window = nil
+    }
+
+    // MARK: - Window construction
+
+    private func buildWindow() {
+        let w = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 400),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        w.title = "Notification Filters"
+        w.center()
+        w.isReleasedWhenClosed = false
+        w.level = .floating
+        w.delegate = self
+
+        // Tab view fills the window content area with a small margin.
+        let tabView = NSTabView()
+        tabView.translatesAutoresizingMaskIntoConstraints = false
+
+        let appsTab = NSTabViewItem()
+        appsTab.label = "Apps"
+        appsTab.view = buildAppsTab()
+        tabView.addTabViewItem(appsTab)
+
+        let kwTab = NSTabViewItem()
+        kwTab.label = "Keywords"
+        kwTab.view = buildKeywordsTab()
+        tabView.addTabViewItem(kwTab)
+
+        let cv = w.contentView!
+        cv.addSubview(tabView)
+        NSLayoutConstraint.activate([
+            tabView.topAnchor.constraint(equalTo: cv.topAnchor, constant: 8),
+            tabView.leadingAnchor.constraint(equalTo: cv.leadingAnchor, constant: 8),
+            tabView.trailingAnchor.constraint(equalTo: cv.trailingAnchor, constant: -8),
+            tabView.bottomAnchor.constraint(equalTo: cv.bottomAnchor, constant: -8),
+        ])
+
+        w.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        window = w
+    }
+
+    // MARK: - Apps tab
+
+    private func buildAppsTab() -> NSView {
+        // Mode selector row
+        let modeLabel = NSTextField(labelWithString: "Filter mode:")
+        modeLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        modeLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+
+        appsSegment = NSSegmentedControl(
+            labels: NotificationFilterMode.allCases.map { $0.displayName },
+            trackingMode: .selectOne,
+            target: self,
+            action: #selector(modeChanged(_:))
+        )
+        appsSegment.selectedSegment = NotificationFilterMode.allCases.firstIndex(of: store.filterMode) ?? 0
+
+        let modeRow = NSStackView(views: [modeLabel, appsSegment])
+        modeRow.orientation = .horizontal
+        modeRow.spacing = 8
+        modeRow.alignment = .centerY
+
+        // Description label
+        appsDescLabel = NSTextField(wrappingLabelWithString: descriptionForMode(store.filterMode))
+        appsDescLabel.font = .systemFont(ofSize: 11)
+        appsDescLabel.textColor = .secondaryLabelColor
+
+        // Table + scroll view
+        let (sv, table) = makeTableView()
+        appsScrollView = sv
+        appsTable = table
+        appsTable.dataSource = appsHelper
+        appsTable.delegate   = appsHelper
+
+        // Buttons
+        let addBtn = NSButton(title: "+", target: self, action: #selector(addApp))
+        addBtn.bezelStyle = .smallSquare
+        appsRemoveButton = NSButton(title: "−", target: self, action: #selector(removeApp))
+        appsRemoveButton.bezelStyle = .smallSquare
+        let btnRow = NSStackView(views: [addBtn, appsRemoveButton])
+        btnRow.orientation = .horizontal
+        btnRow.spacing = 4
+
+        // Outer vertical stack
+        let stack = buildVerticalStack(views: [modeRow, appsDescLabel, appsScrollView, btnRow])
+        appsScrollView.heightAnchor.constraint(equalToConstant: 160).isActive = true
+
+        updateAppsUI()
+        return stack
+    }
+
+    // MARK: - Keywords tab
+
+    private func buildKeywordsTab() -> NSView {
+        let label = NSTextField(wrappingLabelWithString:
+            "Notifications whose title or body contains any of these words are always hidden " +
+            "(applies in Block Selected and Allow Only modes).")
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .secondaryLabelColor
+
+        let (sv, table) = makeTableView()
+        kwScrollView = sv
+        kwTable = table
+        kwTable.dataSource = kwHelper
+        kwTable.delegate   = kwHelper
+
+        let addBtn = NSButton(title: "+", target: self, action: #selector(addKeyword))
+        addBtn.bezelStyle = .smallSquare
+        kwRemoveButton = NSButton(title: "−", target: self, action: #selector(removeKeyword))
+        kwRemoveButton.bezelStyle = .smallSquare
+        let btnRow = NSStackView(views: [addBtn, kwRemoveButton])
+        btnRow.orientation = .horizontal
+        btnRow.spacing = 4
+
+        let stack = buildVerticalStack(views: [label, kwScrollView, btnRow])
+        kwScrollView.heightAnchor.constraint(equalToConstant: 200).isActive = true
+        return stack
+    }
+
+    // MARK: - Helpers
+
+    /// Wraps `views` in a vertical NSStackView that fills its superview via Auto Layout.
+    private func buildVerticalStack(views: [NSView]) -> NSView {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = NSStackView(views: views)
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 10
+        stack.edgeInsets = NSEdgeInsets(top: 16, left: 16, bottom: 12, right: 16)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            stack.bottomAnchor.constraint(lessThanOrEqualTo: container.bottomAnchor),
+        ])
+        // Make scroll views inside the stack expand to fill available width.
+        for v in views where v is NSScrollView {
+            v.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -32).isActive = true
+        }
+        return container
+    }
+
+    private func makeTableView() -> (NSScrollView, NSTableView) {
+        let col = NSTableColumn(identifier: .init("value"))
+        col.title = ""
+        col.isEditable = false
+
+        let table = NSTableView()
+        table.addTableColumn(col)
+        table.headerView = nil
+        table.usesAlternatingRowBackgroundColors = true
+        table.allowsEmptySelection = true
+        table.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
+
+        let sv = NSScrollView()
+        sv.documentView = table
+        sv.hasVerticalScroller = true
+        sv.borderType = .bezelBorder
+
+        return (sv, table)
+    }
+
+    private func descriptionForMode(_ mode: NotificationFilterMode) -> String {
+        switch mode {
+        case .off:
+            return "All Android notifications are forwarded to this Mac."
+        case .blocklist:
+            return "Notifications from apps listed below are hidden; all others are shown."
+        case .allowlist:
+            return "Only notifications from apps listed below are shown; all others are hidden."
+        }
+    }
+
+    private func updateAppsUI() {
+        let mode = store.filterMode
+        let showList = mode != .off
+        appsScrollView.isHidden = !showList
+        appsRemoveButton.isHidden = !showList
+        appsDescLabel.stringValue = descriptionForMode(mode)
+        appsTable.reloadData()
+    }
+
+    // MARK: - Actions
+
+    @objc private func modeChanged(_ sender: NSSegmentedControl) {
+        store.filterMode = NotificationFilterMode.allCases[sender.selectedSegment]
+        updateAppsUI()
+    }
+
+    @objc private func addApp() {
+        guard store.filterMode != .off else { return }
+        let verb = store.filterMode == .blocklist ? "block" : "allow"
+        promptForText(
+            title: "Add App",
+            message: "Enter the exact app name to \(verb):",
+            placeholder: "e.g. WhatsApp"
+        ) { [weak self] name in
+            guard let self, !name.isEmpty else { return }
+            if self.store.filterMode == .blocklist {
+                var list = self.store.blockedApps
+                if !list.contains(where: { $0.lowercased() == name.lowercased() }) {
+                    list.append(name)
+                    self.store.blockedApps = list
+                }
+            } else {
+                var list = self.store.allowedApps
+                if !list.contains(where: { $0.lowercased() == name.lowercased() }) {
+                    list.append(name)
+                    self.store.allowedApps = list
+                }
+            }
+            self.appsTable.reloadData()
+        }
+    }
+
+    @objc private func removeApp() {
+        let row = appsTable.selectedRow
+        guard row >= 0 else { return }
+        if store.filterMode == .blocklist {
+            var list = store.blockedApps
+            guard row < list.count else { return }
+            list.remove(at: row)
+            store.blockedApps = list
+        } else if store.filterMode == .allowlist {
+            var list = store.allowedApps
+            guard row < list.count else { return }
+            list.remove(at: row)
+            store.allowedApps = list
+        }
+        appsTable.reloadData()
+    }
+
+    @objc private func addKeyword() {
+        promptForText(
+            title: "Add Keyword",
+            message: "Notifications containing this word or phrase will be hidden:",
+            placeholder: "e.g. advertisement"
+        ) { [weak self] kw in
+            guard let self, !kw.isEmpty else { return }
+            var list = self.store.blockedKeywords
+            if !list.contains(where: { $0.lowercased() == kw.lowercased() }) {
+                list.append(kw)
+                self.store.blockedKeywords = list
+            }
+            self.kwTable.reloadData()
+        }
+    }
+
+    @objc private func removeKeyword() {
+        let row = kwTable.selectedRow
+        guard row >= 0 else { return }
+        var list = store.blockedKeywords
+        guard row < list.count else { return }
+        list.remove(at: row)
+        store.blockedKeywords = list
+        kwTable.reloadData()
+    }
+
+    private func promptForText(title: String, message: String, placeholder: String, completion: @escaping (String) -> Void) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: "Add")
+        alert.addButton(withTitle: "Cancel")
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        input.placeholderString = placeholder
+        alert.accessoryView = input
+
+        if let w = window {
+            alert.beginSheetModal(for: w) { response in
+                if response == .alertFirstButtonReturn {
+                    completion(input.stringValue.trimmingCharacters(in: .whitespaces))
+                }
+            }
+        } else {
+            if alert.runModal() == .alertFirstButtonReturn {
+                completion(input.stringValue.trimmingCharacters(in: .whitespaces))
+            }
+        }
+    }
+
+    // MARK: - Table data source / delegate
+
+    private enum TableKind { case apps, keywords }
+
+    private final class TableHelper: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+        weak var owner: FilterWindowController?
+        let kind: TableKind
+
+        init(owner: FilterWindowController, kind: TableKind) {
+            self.owner = owner
+            self.kind  = kind
+        }
+
+        private var items: [String] {
+            guard let o = owner else { return [] }
+            switch kind {
+            case .keywords:
+                return o.store.blockedKeywords
+            case .apps:
+                switch o.store.filterMode {
+                case .off:       return []
+                case .blocklist: return o.store.blockedApps
+                case .allowlist: return o.store.allowedApps
+                }
+            }
+        }
+
+        func numberOfRows(in tableView: NSTableView) -> Int { items.count }
+
+        func tableView(_ tableView: NSTableView, objectValueFor tableColumn: NSTableColumn?, row: Int) -> Any? {
+            guard row < items.count else { return nil }
+            return items[row]
+        }
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/NotificationFilterStore.swift
+++ b/macos/ClipRelayMac/Sources/App/NotificationFilterStore.swift
@@ -1,0 +1,82 @@
+// Persists notification filter settings and evaluates whether a notification should be shown.
+
+import Foundation
+
+enum NotificationFilterMode: String, CaseIterable {
+    /// Pass all Android notifications through — no filtering.
+    case off = "off"
+    /// Block notifications from apps on the list; show everything else.
+    case blocklist = "blocklist"
+    /// Only show notifications from apps on the list; block everything else.
+    case allowlist = "allowlist"
+
+    var displayName: String {
+        switch self {
+        case .off:       return "Off"
+        case .blocklist: return "Block Selected"
+        case .allowlist: return "Allow Only"
+        }
+    }
+}
+
+/// Singleton that stores filter settings in UserDefaults and decides whether
+/// a given Android notification should be forwarded to the Mac notification centre.
+final class NotificationFilterStore {
+    static let shared = NotificationFilterStore()
+    private init() {}
+
+    private let defaults = UserDefaults.standard
+    private let modeKey            = "notiFilterMode"
+    private let blockedAppsKey     = "notiFilterBlockedApps"
+    private let allowedAppsKey     = "notiFilterAllowedApps"
+    private let blockedKeywordsKey = "notiFilterBlockedKeywords"
+
+    var filterMode: NotificationFilterMode {
+        get { NotificationFilterMode(rawValue: defaults.string(forKey: modeKey) ?? "") ?? .off }
+        set { defaults.set(newValue.rawValue, forKey: modeKey) }
+    }
+
+    /// App names to hide (used in blocklist mode). Stored sorted; duplicates ignored.
+    var blockedApps: [String] {
+        get { (defaults.stringArray(forKey: blockedAppsKey) ?? []).sorted() }
+        set { defaults.set(newValue.sorted(), forKey: blockedAppsKey) }
+    }
+
+    /// App names to show (used in allowlist mode). Stored sorted; duplicates ignored.
+    var allowedApps: [String] {
+        get { (defaults.stringArray(forKey: allowedAppsKey) ?? []).sorted() }
+        set { defaults.set(newValue.sorted(), forKey: allowedAppsKey) }
+    }
+
+    /// Words / phrases that suppress a notification regardless of mode (unless Off).
+    var blockedKeywords: [String] {
+        get { (defaults.stringArray(forKey: blockedKeywordsKey) ?? []).sorted() }
+        set { defaults.set(newValue.sorted(), forKey: blockedKeywordsKey) }
+    }
+
+    // MARK: - Filter logic
+
+    /// Returns `true` if the notification should be posted to Notification Centre.
+    func shouldShow(appName: String, title: String, body: String) -> Bool {
+        // Keyword filter applies in blocklist and allowlist modes (not Off).
+        if filterMode != .off {
+            let combined = "\(title) \(body)".lowercased()
+            for kw in blockedKeywords where !kw.isEmpty {
+                if combined.contains(kw.lowercased()) { return false }
+            }
+        }
+
+        switch filterMode {
+        case .off:
+            return true
+        case .blocklist:
+            let name = appName.lowercased()
+            return !blockedApps.contains { $0.lowercased() == name }
+        case .allowlist:
+            // Empty allowlist means "nothing configured yet" → let everything through.
+            guard !allowedApps.isEmpty else { return true }
+            let name = appName.lowercased()
+            return allowedApps.contains { $0.lowercased() == name }
+        }
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/NotificationLog.swift
+++ b/macos/ClipRelayMac/Sources/App/NotificationLog.swift
@@ -3,17 +3,53 @@
 
 import Foundation
 
+// MARK: - NotificationAction
+
+/// A single tappable action surfaced by Android in the notification (Reply, Mark as read, etc.)
+struct NotificationAction: Codable {
+    let index: Int
+    let title: String
+    let hasReply: Bool  // true when the action accepts free-form text input (e.g. "Reply")
+}
+
+// MARK: - NotificationRecord
+
 struct NotificationRecord: Codable {
     let appName: String
     let title: String
     let body: String
-    let time: TimeInterval   // Date().timeIntervalSince1970
+    let time: TimeInterval           // Date().timeIntervalSince1970
+    let notificationKey: String      // opaque key for firing actions back to Android
+    let actions: [NotificationAction]
+
+    // Failable init so old persisted records without notificationKey/actions still decode
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        appName         = try c.decode(String.self, forKey: .appName)
+        title           = try c.decode(String.self, forKey: .title)
+        body            = try c.decode(String.self, forKey: .body)
+        time            = try c.decode(TimeInterval.self, forKey: .time)
+        notificationKey = (try? c.decode(String.self, forKey: .notificationKey)) ?? ""
+        actions         = (try? c.decode([NotificationAction].self, forKey: .actions)) ?? []
+    }
+
+    init(appName: String, title: String, body: String, time: TimeInterval,
+         notificationKey: String, actions: [NotificationAction]) {
+        self.appName         = appName
+        self.title           = title
+        self.body            = body
+        self.time            = time
+        self.notificationKey = notificationKey
+        self.actions         = actions
+    }
 }
+
+// MARK: - NotificationLog
 
 final class NotificationLog {
     static let shared = NotificationLog()
 
-    private let maxCount   = 15
+    private let maxCount    = 15
     private let defaultsKey = "notiLogRecords"
 
     /// Most-recent-first list of forwarded notifications.
@@ -23,12 +59,15 @@ final class NotificationLog {
 
     // MARK: - Mutating
 
-    func append(appName: String, title: String, body: String) {
+    func append(appName: String, title: String, body: String,
+                notificationKey: String = "", actions: [NotificationAction] = []) {
         let r = NotificationRecord(
             appName: appName,
             title: title,
             body: body,
-            time: Date().timeIntervalSince1970
+            time: Date().timeIntervalSince1970,
+            notificationKey: notificationKey,
+            actions: actions
         )
         records.insert(r, at: 0)
         if records.count > maxCount {

--- a/macos/ClipRelayMac/Sources/App/NotificationLog.swift
+++ b/macos/ClipRelayMac/Sources/App/NotificationLog.swift
@@ -37,6 +37,12 @@ final class NotificationLog {
         save()
     }
 
+    /// Remove a single notification by its timestamp (used for "Mark as Read").
+    func remove(byTime time: TimeInterval) {
+        records.removeAll { $0.time == time }
+        save()
+    }
+
     func clear() {
         records = []
         UserDefaults.standard.removeObject(forKey: defaultsKey)

--- a/macos/ClipRelayMac/Sources/App/NotificationLog.swift
+++ b/macos/ClipRelayMac/Sources/App/NotificationLog.swift
@@ -1,0 +1,59 @@
+// Keeps a rolling in-memory + persisted log of the last N Android notifications
+// that passed the filter and were posted to Notification Centre.
+
+import Foundation
+
+struct NotificationRecord: Codable {
+    let appName: String
+    let title: String
+    let body: String
+    let time: TimeInterval   // Date().timeIntervalSince1970
+}
+
+final class NotificationLog {
+    static let shared = NotificationLog()
+
+    private let maxCount   = 15
+    private let defaultsKey = "notiLogRecords"
+
+    /// Most-recent-first list of forwarded notifications.
+    private(set) var records: [NotificationRecord] = []
+
+    private init() { load() }
+
+    // MARK: - Mutating
+
+    func append(appName: String, title: String, body: String) {
+        let r = NotificationRecord(
+            appName: appName,
+            title: title,
+            body: body,
+            time: Date().timeIntervalSince1970
+        )
+        records.insert(r, at: 0)
+        if records.count > maxCount {
+            records = Array(records.prefix(maxCount))
+        }
+        save()
+    }
+
+    func clear() {
+        records = []
+        UserDefaults.standard.removeObject(forKey: defaultsKey)
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard
+            let data    = UserDefaults.standard.data(forKey: defaultsKey),
+            let decoded = try? JSONDecoder().decode([NotificationRecord].self, from: data)
+        else { return }
+        records = decoded
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(records) else { return }
+        UserDefaults.standard.set(data, forKey: defaultsKey)
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
+++ b/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
@@ -49,7 +49,8 @@ final class ReceiveNotificationManager {
         UNUserNotificationCenter.current().add(request)
     }
 
-    func postAndroidNotification(appName: String, title: String, text: String, iconData: Data?) {
+    func postAndroidNotification(appName: String, title: String, text: String, iconData: Data?,
+                                  notificationKey: String = "", actions: [NotificationAction] = []) {
         guard Bundle.main.bundleIdentifier != nil else { return }
         guard NotificationFilterStore.shared.shouldShow(appName: appName, title: title, body: text) else {
             notifLogger.debug("Notification from \(appName) suppressed by filter")
@@ -57,7 +58,8 @@ final class ReceiveNotificationManager {
         }
 
         // Record in the recent-notifications log (used by menu bar history).
-        NotificationLog.shared.append(appName: appName, title: title, body: text)
+        NotificationLog.shared.append(appName: appName, title: title, body: text,
+                                       notificationKey: notificationKey, actions: actions)
         DispatchQueue.main.async { self.onNotificationLogged?() }
 
         let content = UNMutableNotificationContent()

--- a/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
+++ b/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
@@ -29,4 +29,23 @@ final class ReceiveNotificationManager {
         )
         UNUserNotificationCenter.current().add(request)
     }
+
+    func postAndroidNotification(appName: String, title: String, text: String) {
+        guard Bundle.main.bundleIdentifier != nil else { return }
+        let content = UNMutableNotificationContent()
+        content.title = "[\(appName)] \(title)"
+        if !text.isEmpty {
+            content.body = String(text.prefix(200))
+        }
+        content.sound = .default
+
+        // Use a unique identifier per-app so notifications don't collapse across apps
+        let identifier = "android-notification-\(appName)-\(UUID().uuidString)"
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request)
+    }
 }

--- a/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
+++ b/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
@@ -1,16 +1,32 @@
-// Posts macOS user notifications when clipboard text is received from Android.
+// Posts macOS user notifications when clipboard text or Android notifications are received.
 
 import Foundation
+import os
 import UserNotifications
+
+private let notifLogger = Logger(subsystem: "org.cliprelay", category: "Notifications")
 
 final class ReceiveNotificationManager {
     func requestAuthorization() {
-        // UNUserNotificationCenter requires a valid bundle identifier and crashes
-        // with an NSAssertion if one is absent (e.g. when running the raw debug
-        // binary outside an .app bundle).
-        guard Bundle.main.bundleIdentifier != nil else { return }
-        DispatchQueue.main.async {
-            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        guard Bundle.main.bundleIdentifier != nil else {
+            notifLogger.error("No bundle identifier — skipping notification auth")
+            return
+        }
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            notifLogger.info("Current notification status: \(String(describing: settings.authorizationStatus.rawValue))")
+            guard settings.authorizationStatus == .notDetermined else {
+                notifLogger.info("Notification auth already decided (\(settings.authorizationStatus.rawValue)), skipping prompt")
+                return
+            }
+            DispatchQueue.main.async {
+                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+                    if let error {
+                        notifLogger.error("Notification auth error: \(error)")
+                    } else {
+                        notifLogger.info("Notification auth granted: \(granted)")
+                    }
+                }
+            }
         }
     }
 
@@ -30,22 +46,40 @@ final class ReceiveNotificationManager {
         UNUserNotificationCenter.current().add(request)
     }
 
-    func postAndroidNotification(appName: String, title: String, text: String) {
+    func postAndroidNotification(appName: String, title: String, text: String, iconData: Data?) {
         guard Bundle.main.bundleIdentifier != nil else { return }
-        let content = UNMutableNotificationContent()
-        content.title = "[\(appName)] \(title)"
-        if !text.isEmpty {
-            content.body = String(text.prefix(200))
+        guard NotificationFilterStore.shared.shouldShow(appName: appName, title: title, body: text) else {
+            notifLogger.debug("Notification from \(appName) suppressed by filter")
+            return
         }
+
+        let content = UNMutableNotificationContent()
+        content.title = title.isEmpty ? appName : title
+        if !title.isEmpty && !appName.isEmpty {
+            content.subtitle = appName
+        }
+        content.body = String(text.prefix(200))
         content.sound = .default
 
-        // Use a unique identifier per-app so notifications don't collapse across apps
-        let identifier = "android-notification-\(appName)-\(UUID().uuidString)"
-        let request = UNNotificationRequest(
-            identifier: identifier,
-            content: content,
-            trigger: nil
-        )
-        UNUserNotificationCenter.current().add(request)
+        if let iconData {
+            let tmpURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString + ".png")
+            do {
+                try iconData.write(to: tmpURL)
+                let attachment = try UNNotificationAttachment(identifier: "icon", url: tmpURL, options: nil)
+                content.attachments = [attachment]
+                try? FileManager.default.removeItem(at: tmpURL)
+            } catch {
+                notifLogger.warning("Could not attach icon: \(error)")
+            }
+        }
+
+        let identifier = "android-notification-\(appName)-\(title)".hash.description
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                notifLogger.error("Failed to post Android notification: \(error)")
+            }
+        }
     }
 }

--- a/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
+++ b/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
@@ -4,9 +4,12 @@ import Foundation
 import os
 import UserNotifications
 
-private let notifLogger = Logger(subsystem: "org.cliprelay", category: "Notifications")
+private let notifLogger = Logger(subsystem: "com.andromeda.NotiSync", category: "Notifications")
 
 final class ReceiveNotificationManager {
+    /// Called on the main thread whenever a new notification is appended to NotificationLog.
+    var onNotificationLogged: (() -> Void)?
+
     func requestAuthorization() {
         guard Bundle.main.bundleIdentifier != nil else {
             notifLogger.error("No bundle identifier — skipping notification auth")
@@ -53,6 +56,10 @@ final class ReceiveNotificationManager {
             return
         }
 
+        // Record in the recent-notifications log (used by menu bar history).
+        NotificationLog.shared.append(appName: appName, title: title, body: text)
+        DispatchQueue.main.async { self.onNotificationLogged?() }
+
         let content = UNMutableNotificationContent()
         content.title = title.isEmpty ? appName : title
         if !title.isEmpty && !appName.isEmpty {
@@ -68,7 +75,6 @@ final class ReceiveNotificationManager {
                 try iconData.write(to: tmpURL)
                 let attachment = try UNNotificationAttachment(identifier: "icon", url: tmpURL, options: nil)
                 content.attachments = [attachment]
-                try? FileManager.default.removeItem(at: tmpURL)
             } catch {
                 notifLogger.warning("Could not attach icon: \(error)")
             }

--- a/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
+++ b/macos/ClipRelayMac/Sources/App/ReceiveNotificationManager.swift
@@ -65,7 +65,9 @@ final class ReceiveNotificationManager {
         if !title.isEmpty && !appName.isEmpty {
             content.subtitle = appName
         }
-        content.body = String(text.prefix(200))
+        // No hard truncation — let macOS decide how much to surface in the banner.
+        // Notification Centre shows the full body on expand.
+        content.body = text
         content.sound = .default
 
         if let iconData {
@@ -80,7 +82,10 @@ final class ReceiveNotificationManager {
             }
         }
 
-        let identifier = "android-notification-\(appName)-\(title)".hash.description
+        // Include the body in the hash so two messages from the same contact
+        // (same app + same title) each get their own notification instead of
+        // the second replacing the first.
+        let identifier = "android-\(appName)-\(title)-\(text.prefix(80))".hash.description
         let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
             if let error {

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -4,6 +4,7 @@ import AppKit
 import Foundation
 import QuartzCore
 import Sparkle
+import UserNotifications
 
 final class StatusBarController {
     var onPairNewDeviceRequested: (() -> Void)?
@@ -15,6 +16,9 @@ final class StatusBarController {
     var isDeviceConnected: (() -> Bool)?
     var bleStateProvider: (() -> String)?
     var onShowNotificationFilters: (() -> Void)?
+
+    /// Called by AppDelegate when a new Android notification is logged.
+    func refreshMenu() { renderMenu() }
 
     private var availableUpdateVersion: String?
 
@@ -42,10 +46,21 @@ final class StatusBarController {
     }
 
     private func loadStatusBarIcon() -> NSImage? {
-        if let bundlePath = Bundle.main.path(forResource: "StatusBarIcon", ofType: "png") {
-            let image = NSImage(contentsOfFile: bundlePath)
-            image?.size = NSSize(width: 18, height: 18)
+        // NSImage(named:) searches the bundle by name regardless of extension
+        // (Xcode converts PNG → TIFF at build time, so path-based .png lookup fails)
+        if let image = NSImage(named: "StatusBarIcon") {
+            image.size = NSSize(width: 18, height: 18)
             return image
+        }
+        // Fallback: explicit path search for png or tiff
+        for ext in ["tiff", "png"] {
+            for dir in [Optional<String>.none, "Resources"] {
+                if let path = Bundle.main.path(forResource: "StatusBarIcon", ofType: ext, inDirectory: dir) {
+                    let image = NSImage(contentsOfFile: path)
+                    image?.size = NSSize(width: 18, height: 18)
+                    return image
+                }
+            }
         }
         return nil
     }
@@ -142,6 +157,16 @@ final class StatusBarController {
         pairItem.target = self
         menu.addItem(pairItem)
 
+        menu.addItem(NSMenuItem.separator())
+
+        let testNotifItem = NSMenuItem(
+            title: "Send Test Notification",
+            action: #selector(handleTestNotification),
+            keyEquivalent: ""
+        )
+        testNotifItem.target = self
+        menu.addItem(testNotifItem)
+
         let filterItem = NSMenuItem(
             title: "Notification Filters\u{2026}",
             action: #selector(handleNotificationFilters),
@@ -151,6 +176,8 @@ final class StatusBarController {
         menu.addItem(filterItem)
 
         menu.addItem(NSMenuItem.separator())
+        renderRecentNotificationsSection()
+        renderBlockedAppsSection()
 
         let launchItem = NSMenuItem(
             title: "Launch at Login",
@@ -250,6 +277,138 @@ final class StatusBarController {
         statusItem.menu = menu
     }
 
+    // MARK: - Recent notifications section
+
+    private func renderRecentNotificationsSection() {
+        let header = NSMenuItem(title: "Recent Notifications", action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        menu.addItem(header)
+
+        let records = NotificationLog.shared.records
+        if records.isEmpty {
+            let empty = NSMenuItem(title: "  No notifications yet", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            menu.addItem(empty)
+        } else {
+            for record in records {
+                // Compose display title: "AppName — Notification title"
+                let displayTitle = composeNotifTitle(appName: record.appName, title: record.title)
+                let item = NSMenuItem(title: displayTitle, action: nil, keyEquivalent: "")
+
+                let sub = NSMenu()
+
+                // Block app
+                let blockItem = NSMenuItem(
+                    title: "Block \(record.appName)",
+                    action: #selector(handleBlockApp(_:)),
+                    keyEquivalent: ""
+                )
+                blockItem.target = self
+                blockItem.representedObject = record.appName
+                sub.addItem(blockItem)
+
+                sub.addItem(NSMenuItem.separator())
+
+                // Copy notification body
+                let copyItem = NSMenuItem(
+                    title: "Copy Text",
+                    action: #selector(handleCopyNotification(_:)),
+                    keyEquivalent: ""
+                )
+                copyItem.target = self
+                copyItem.representedObject = record.body.isEmpty ? record.title : "\(record.title)\n\(record.body)"
+                sub.addItem(copyItem)
+
+                item.submenu = sub
+                menu.addItem(item)
+            }
+
+            let clearItem = NSMenuItem(
+                title: "Clear History",
+                action: #selector(handleClearNotificationHistory),
+                keyEquivalent: ""
+            )
+            clearItem.target = self
+            menu.addItem(clearItem)
+        }
+
+        menu.addItem(NSMenuItem.separator())
+    }
+
+    // MARK: - Blocked apps section
+
+    private func renderBlockedAppsSection() {
+        let blocked = NotificationFilterStore.shared.blockedApps
+        guard !blocked.isEmpty else { return }
+
+        let header = NSMenuItem(title: "Blocked Apps", action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        menu.addItem(header)
+
+        for appName in blocked {
+            let item = NSMenuItem(title: "  \(appName)", action: nil, keyEquivalent: "")
+            let sub = NSMenu()
+            let unblockItem = NSMenuItem(
+                title: "Unblock \(appName)",
+                action: #selector(handleUnblockApp(_:)),
+                keyEquivalent: ""
+            )
+            unblockItem.target = self
+            unblockItem.representedObject = appName
+            sub.addItem(unblockItem)
+            item.submenu = sub
+            menu.addItem(item)
+        }
+
+        menu.addItem(NSMenuItem.separator())
+    }
+
+    private func composeNotifTitle(appName: String, title: String) -> String {
+        let combined = title.isEmpty ? appName : "\(appName) — \(title)"
+        let limit = 55
+        if combined.count > limit {
+            return String(combined.prefix(limit)) + "…"
+        }
+        return combined
+    }
+
+    // MARK: - Block / unblock actions
+
+    @objc private func handleBlockApp(_ sender: NSMenuItem) {
+        guard let appName = sender.representedObject as? String else { return }
+        // Switch to blocklist mode if currently off
+        if NotificationFilterStore.shared.filterMode == .off {
+            NotificationFilterStore.shared.filterMode = .blocklist
+        }
+        if NotificationFilterStore.shared.filterMode == .blocklist {
+            var list = NotificationFilterStore.shared.blockedApps
+            if !list.contains(where: { $0.lowercased() == appName.lowercased() }) {
+                list.append(appName)
+                NotificationFilterStore.shared.blockedApps = list
+            }
+        }
+        renderMenu()
+    }
+
+    @objc private func handleUnblockApp(_ sender: NSMenuItem) {
+        guard let appName = sender.representedObject as? String else { return }
+        var list = NotificationFilterStore.shared.blockedApps
+        list.removeAll { $0.lowercased() == appName.lowercased() }
+        NotificationFilterStore.shared.blockedApps = list
+        renderMenu()
+    }
+
+    @objc private func handleCopyNotification(_ sender: NSMenuItem) {
+        guard let text = sender.representedObject as? String else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    @objc private func handleClearNotificationHistory() {
+        NotificationLog.shared.clear()
+        renderMenu()
+    }
+
     private func renderTrustedDevicesSection() {
         let header = NSMenuItem(title: "Paired Devices", action: nil, keyEquivalent: "")
         header.isEnabled = false
@@ -310,11 +469,6 @@ final class StatusBarController {
     @objc
     private func handlePairNewDevice() {
         onPairNewDeviceRequested?()
-    }
-
-    @objc
-    private func handleNotificationFilters() {
-        onShowNotificationFilters?()
     }
 
     @objc
@@ -420,6 +574,39 @@ final class StatusBarController {
     private func handleForgetDevice(_ sender: NSMenuItem) {
         guard let token = sender.representedObject as? String else { return }
         onForgetDeviceRequested?(token)
+    }
+
+    @objc
+    private func handleNotificationFilters() {
+        onShowNotificationFilters?()
+    }
+
+    @objc
+    private func handleTestNotification() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            DispatchQueue.main.async {
+                if let error {
+                    let alert = NSAlert()
+                    alert.messageText = "Notification permission error"
+                    alert.informativeText = error.localizedDescription
+                    alert.runModal()
+                    return
+                }
+                if granted {
+                    let content = UNMutableNotificationContent()
+                    content.title = "NotiSync Test"
+                    content.body = "Notifications are working! Android notifications will appear here."
+                    content.sound = .default
+                    let request = UNNotificationRequest(identifier: "test-\(Date().timeIntervalSince1970)", content: content, trigger: nil)
+                    UNUserNotificationCenter.current().add(request)
+                } else {
+                    let alert = NSAlert()
+                    alert.messageText = "Notifications denied"
+                    alert.informativeText = "Please enable notifications for NotiSync in System Settings → Notifications."
+                    alert.runModal()
+                }
+            }
+        }
     }
 }
 

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -14,6 +14,7 @@ final class StatusBarController {
     var isImageSyncEnabled: (() -> Bool)?
     var isDeviceConnected: (() -> Bool)?
     var bleStateProvider: (() -> String)?
+    var onShowNotificationFilters: (() -> Void)?
 
     private var availableUpdateVersion: String?
 
@@ -140,6 +141,14 @@ final class StatusBarController {
         )
         pairItem.target = self
         menu.addItem(pairItem)
+
+        let filterItem = NSMenuItem(
+            title: "Notification Filters\u{2026}",
+            action: #selector(handleNotificationFilters),
+            keyEquivalent: ""
+        )
+        filterItem.target = self
+        menu.addItem(filterItem)
 
         menu.addItem(NSMenuItem.separator())
 
@@ -301,6 +310,11 @@ final class StatusBarController {
     @objc
     private func handlePairNewDevice() {
         onPairNewDeviceRequested?()
+    }
+
+    @objc
+    private func handleNotificationFilters() {
+        onShowNotificationFilters?()
     }
 
     @objc

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -291,11 +291,33 @@ final class StatusBarController {
             menu.addItem(empty)
         } else {
             for record in records {
-                // Compose display title: "AppName — Notification title"
+                // ── Title row ──────────────────────────────────────────────
                 let displayTitle = composeNotifTitle(appName: record.appName, title: record.title)
                 let item = NSMenuItem(title: displayTitle, action: nil, keyEquivalent: "")
 
                 let sub = NSMenu()
+
+                // Mark as Read — removes this notification from the list
+                let markReadItem = NSMenuItem(
+                    title: "Mark as Read",
+                    action: #selector(handleMarkAsRead(_:)),
+                    keyEquivalent: ""
+                )
+                markReadItem.target = self
+                markReadItem.representedObject = record.time
+                sub.addItem(markReadItem)
+
+                sub.addItem(NSMenuItem.separator())
+
+                // Block by keyword — pre-filled with the title (usually sender name)
+                let blockKwItem = NSMenuItem(
+                    title: "Block by Keyword\u{2026}",
+                    action: #selector(handleBlockByKeyword(_:)),
+                    keyEquivalent: ""
+                )
+                blockKwItem.target = self
+                blockKwItem.representedObject = record.title
+                sub.addItem(blockKwItem)
 
                 // Block whole app
                 let blockAppItem = NSMenuItem(
@@ -307,19 +329,9 @@ final class StatusBarController {
                 blockAppItem.representedObject = record.appName
                 sub.addItem(blockAppItem)
 
-                // Block by keyword — pre-filled with notification title (usually the sender name)
-                let blockKwItem = NSMenuItem(
-                    title: "Block by Keyword\u{2026}",
-                    action: #selector(handleBlockByKeyword(_:)),
-                    keyEquivalent: ""
-                )
-                blockKwItem.target = self
-                blockKwItem.representedObject = record.title  // pre-fill with title
-                sub.addItem(blockKwItem)
-
                 sub.addItem(NSMenuItem.separator())
 
-                // Copy notification body
+                // Copy full text to clipboard
                 let copyItem = NSMenuItem(
                     title: "Copy Text",
                     action: #selector(handleCopyNotification(_:)),
@@ -331,15 +343,30 @@ final class StatusBarController {
 
                 item.submenu = sub
                 menu.addItem(item)
+
+                // ── Body preview row (greyed, smaller) ─────────────────────
+                if !record.body.isEmpty {
+                    let preview = bodyPreview(record.body)
+                    let bodyItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+                    bodyItem.attributedTitle = NSAttributedString(
+                        string: "    \(preview)",
+                        attributes: [
+                            .foregroundColor: NSColor.secondaryLabelColor,
+                            .font: NSFont.systemFont(ofSize: 11),
+                        ]
+                    )
+                    bodyItem.isEnabled = false
+                    menu.addItem(bodyItem)
+                }
             }
 
-            let clearItem = NSMenuItem(
-                title: "Clear History",
+            let markAllItem = NSMenuItem(
+                title: "Mark All as Read",
                 action: #selector(handleClearNotificationHistory),
                 keyEquivalent: ""
             )
-            clearItem.target = self
-            menu.addItem(clearItem)
+            markAllItem.target = self
+            menu.addItem(markAllItem)
         }
 
         menu.addItem(NSMenuItem.separator())
@@ -404,6 +431,26 @@ final class StatusBarController {
             return String(combined.prefix(limit)) + "…"
         }
         return combined
+    }
+
+    /// Returns a single-line body preview capped at 70 characters.
+    private func bodyPreview(_ body: String) -> String {
+        // Show only the first line to keep the menu compact.
+        let firstLine = body.components(separatedBy: "\n").first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? body
+        let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
+        let limit = 70
+        if trimmed.count > limit {
+            return String(trimmed.prefix(limit)) + "…"
+        }
+        return trimmed
+    }
+
+    // MARK: - Mark as read
+
+    @objc private func handleMarkAsRead(_ sender: NSMenuItem) {
+        guard let time = sender.representedObject as? TimeInterval else { return }
+        NotificationLog.shared.remove(byTime: time)
+        renderMenu()
     }
 
     // MARK: - Block / unblock actions

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -16,6 +16,9 @@ final class StatusBarController {
     var isDeviceConnected: (() -> Bool)?
     var bleStateProvider: (() -> String)?
     var onShowNotificationFilters: (() -> Void)?
+    /// Called when the user fires a notification action from the Mac menu.
+    /// Parameters: (notificationKey, actionIndex, replyText?)
+    var sendNotificationAction: ((String, Int, String?) -> Void)?
 
     /// Called by AppDelegate when a new Android notification is logged.
     func refreshMenu() { renderMenu() }
@@ -297,7 +300,7 @@ final class StatusBarController {
 
                 let sub = NSMenu()
 
-                // Mark as Read — removes this notification from the list
+                // Mark as Read — removes this notification from the local list
                 let markReadItem = NSMenuItem(
                     title: "Mark as Read",
                     action: #selector(handleMarkAsRead(_:)),
@@ -306,6 +309,27 @@ final class StatusBarController {
                 markReadItem.target = self
                 markReadItem.representedObject = record.time
                 sub.addItem(markReadItem)
+
+                // Dynamic actions forwarded from Android (Reply, Mark as read, Delete, etc.)
+                if !record.actions.isEmpty && !record.notificationKey.isEmpty {
+                    sub.addItem(NSMenuItem.separator())
+                    for action in record.actions {
+                        let actionItem = NSMenuItem(
+                            title: action.title.isEmpty ? "Action \(action.index)" : action.title,
+                            action: #selector(handleRemoteAction(_:)),
+                            keyEquivalent: ""
+                        )
+                        actionItem.target = self
+                        // representedObject: (notificationKey, actionIndex, hasReply, record.time)
+                        actionItem.representedObject = [
+                            "key": record.notificationKey,
+                            "index": action.index,
+                            "hasReply": action.hasReply,
+                            "time": record.time
+                        ] as [String: Any]
+                        sub.addItem(actionItem)
+                    }
+                }
 
                 sub.addItem(NSMenuItem.separator())
 
@@ -449,6 +473,42 @@ final class StatusBarController {
 
     @objc private func handleMarkAsRead(_ sender: NSMenuItem) {
         guard let time = sender.representedObject as? TimeInterval else { return }
+        NotificationLog.shared.remove(byTime: time)
+        renderMenu()
+    }
+
+    // MARK: - Remote action (fires an Android notification action)
+
+    @objc private func handleRemoteAction(_ sender: NSMenuItem) {
+        guard let info = sender.representedObject as? [String: Any],
+              let key      = info["key"]   as? String,
+              let index    = info["index"] as? Int,
+              let hasReply = info["hasReply"] as? Bool,
+              let time     = info["time"]  as? TimeInterval else { return }
+
+        if hasReply {
+            // Show a text field for composing a reply
+            let alert = NSAlert()
+            alert.messageText = sender.title
+            alert.informativeText = "Type your reply:"
+            alert.addButton(withTitle: "Send")
+            alert.addButton(withTitle: "Cancel")
+
+            let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+            field.placeholderString = "Reply…"
+            alert.accessoryView = field
+
+            NSApp.activate(ignoringOtherApps: true)
+            guard alert.runModal() == .alertFirstButtonReturn else { return }
+            let reply = field.stringValue.trimmingCharacters(in: .whitespaces)
+            guard !reply.isEmpty else { return }
+
+            sendNotificationAction?(key, index, reply)
+        } else {
+            sendNotificationAction?(key, index, nil)
+        }
+
+        // Remove from local history after firing
         NotificationLog.shared.remove(byTime: time)
         renderMenu()
     }

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -297,15 +297,25 @@ final class StatusBarController {
 
                 let sub = NSMenu()
 
-                // Block app
-                let blockItem = NSMenuItem(
-                    title: "Block \(record.appName)",
+                // Block whole app
+                let blockAppItem = NSMenuItem(
+                    title: "Block App (\(record.appName))",
                     action: #selector(handleBlockApp(_:)),
                     keyEquivalent: ""
                 )
-                blockItem.target = self
-                blockItem.representedObject = record.appName
-                sub.addItem(blockItem)
+                blockAppItem.target = self
+                blockAppItem.representedObject = record.appName
+                sub.addItem(blockAppItem)
+
+                // Block by keyword — pre-filled with notification title (usually the sender name)
+                let blockKwItem = NSMenuItem(
+                    title: "Block by Keyword\u{2026}",
+                    action: #selector(handleBlockByKeyword(_:)),
+                    keyEquivalent: ""
+                )
+                blockKwItem.target = self
+                blockKwItem.representedObject = record.title  // pre-fill with title
+                sub.addItem(blockKwItem)
 
                 sub.addItem(NSMenuItem.separator())
 
@@ -335,29 +345,53 @@ final class StatusBarController {
         menu.addItem(NSMenuItem.separator())
     }
 
-    // MARK: - Blocked apps section
+    // MARK: - Blocked apps + keywords section
 
     private func renderBlockedAppsSection() {
-        let blocked = NotificationFilterStore.shared.blockedApps
-        guard !blocked.isEmpty else { return }
+        let blockedApps     = NotificationFilterStore.shared.blockedApps
+        let blockedKeywords = NotificationFilterStore.shared.blockedKeywords
+        guard !blockedApps.isEmpty || !blockedKeywords.isEmpty else { return }
 
-        let header = NSMenuItem(title: "Blocked Apps", action: nil, keyEquivalent: "")
-        header.isEnabled = false
-        menu.addItem(header)
+        if !blockedApps.isEmpty {
+            let header = NSMenuItem(title: "Blocked Apps", action: nil, keyEquivalent: "")
+            header.isEnabled = false
+            menu.addItem(header)
 
-        for appName in blocked {
-            let item = NSMenuItem(title: "  \(appName)", action: nil, keyEquivalent: "")
-            let sub = NSMenu()
-            let unblockItem = NSMenuItem(
-                title: "Unblock \(appName)",
-                action: #selector(handleUnblockApp(_:)),
-                keyEquivalent: ""
-            )
-            unblockItem.target = self
-            unblockItem.representedObject = appName
-            sub.addItem(unblockItem)
-            item.submenu = sub
-            menu.addItem(item)
+            for appName in blockedApps {
+                let item = NSMenuItem(title: "  \(appName)", action: nil, keyEquivalent: "")
+                let sub = NSMenu()
+                let unblockItem = NSMenuItem(
+                    title: "Unblock",
+                    action: #selector(handleUnblockApp(_:)),
+                    keyEquivalent: ""
+                )
+                unblockItem.target = self
+                unblockItem.representedObject = appName
+                sub.addItem(unblockItem)
+                item.submenu = sub
+                menu.addItem(item)
+            }
+        }
+
+        if !blockedKeywords.isEmpty {
+            let header = NSMenuItem(title: "Blocked Keywords", action: nil, keyEquivalent: "")
+            header.isEnabled = false
+            menu.addItem(header)
+
+            for kw in blockedKeywords {
+                let item = NSMenuItem(title: "  \"\(kw)\"", action: nil, keyEquivalent: "")
+                let sub = NSMenu()
+                let removeItem = NSMenuItem(
+                    title: "Remove",
+                    action: #selector(handleRemoveKeyword(_:)),
+                    keyEquivalent: ""
+                )
+                removeItem.target = self
+                removeItem.representedObject = kw
+                sub.addItem(removeItem)
+                item.submenu = sub
+                menu.addItem(item)
+            }
         }
 
         menu.addItem(NSMenuItem.separator())
@@ -390,11 +424,54 @@ final class StatusBarController {
         renderMenu()
     }
 
+    @objc private func handleBlockByKeyword(_ sender: NSMenuItem) {
+        // Pre-fill the prompt with the notification title (typically the sender's name).
+        // The user trims it to exactly the word/phrase they want to block.
+        let suggestion = sender.representedObject as? String ?? ""
+
+        let alert = NSAlert()
+        alert.messageText = "Block by Keyword"
+        alert.informativeText = "Notifications whose title or body contains this word or phrase will be hidden. Edit the text below if needed:"
+        alert.addButton(withTitle: "Block")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        field.stringValue = suggestion
+        field.placeholderString = "e.g. John, promo, deal"
+        alert.accessoryView = field
+
+        // Show as a floating alert (no parent window for menu bar apps).
+        NSApp.activate(ignoringOtherApps: true)
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return }
+        let kw = field.stringValue.trimmingCharacters(in: .whitespaces)
+        guard !kw.isEmpty else { return }
+
+        // Enable filtering if currently off
+        if NotificationFilterStore.shared.filterMode == .off {
+            NotificationFilterStore.shared.filterMode = .blocklist
+        }
+        var list = NotificationFilterStore.shared.blockedKeywords
+        if !list.contains(where: { $0.lowercased() == kw.lowercased() }) {
+            list.append(kw)
+            NotificationFilterStore.shared.blockedKeywords = list
+        }
+        renderMenu()
+    }
+
     @objc private func handleUnblockApp(_ sender: NSMenuItem) {
         guard let appName = sender.representedObject as? String else { return }
         var list = NotificationFilterStore.shared.blockedApps
         list.removeAll { $0.lowercased() == appName.lowercased() }
         NotificationFilterStore.shared.blockedApps = list
+        renderMenu()
+    }
+
+    @objc private func handleRemoveKeyword(_ sender: NSMenuItem) {
+        guard let kw = sender.representedObject as? String else { return }
+        var list = NotificationFilterStore.shared.blockedKeywords
+        list.removeAll { $0.lowercased() == kw.lowercased() }
+        NotificationFilterStore.shared.blockedKeywords = list
         renderMenu()
     }
 

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -69,6 +69,7 @@ protocol ConnectionControllerDelegate: AnyObject {
     func didSyncClipboard(hash: String)
     func didChangeImageSyncSetting(enabled: Bool)
     func imageTransferFailed(reason: String)
+    func didReceiveAndroidNotification(appName: String, title: String, text: String)
 }
 
 // MARK: - ConnectionController
@@ -912,6 +913,13 @@ extension ConnectionController {
             self?.delegate?.imageTransferFailed(reason: reason)
         }
     }
+
+    fileprivate func handleAndroidNotification(appName: String, title: String, text: String) {
+        log("Received notification from \(appName): \(title)")
+        DispatchQueue.main.async { [weak self] in
+            self?.delegate?.didReceiveAndroidNotification(appName: appName, title: title, text: text)
+        }
+    }
 }
 
 // MARK: - SessionAdapter
@@ -986,5 +994,9 @@ private class SessionAdapter: NSObject, SessionDelegate {
 
     func session(_ session: Session, alreadyHasHash hash: String) -> Bool {
         return lastTextHash == hash
+    }
+
+    func session(_ session: Session, didReceiveAndroidNotification appName: String, title: String, text: String, time: Int64) {
+        dispatch { $0.handleAndroidNotification(appName: appName, title: title, text: text) }
     }
 }

--- a/macos/ClipRelayMac/Sources/Protocol/MessageCodec.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/MessageCodec.swift
@@ -15,6 +15,7 @@ enum MessageType: UInt8 {
     case configUpdate = 0x14
     case reject = 0x15
     case error = 0x16
+    case notification = 0x20
 }
 
 struct Message {

--- a/macos/ClipRelayMac/Sources/Protocol/MessageCodec.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/MessageCodec.swift
@@ -16,6 +16,7 @@ enum MessageType: UInt8 {
     case reject = 0x15
     case error = 0x16
     case notification = 0x20
+    case notificationAction = 0x21
 }
 
 struct Message {
@@ -141,7 +142,9 @@ enum MessageCodec {
         var totalRead = 0
 
         while totalRead < count {
-            let read = stream.read(&buffer + totalRead, maxLength: count - totalRead)
+            let read = buffer.withUnsafeMutableBufferPointer { ptr in
+                stream.read(ptr.baseAddress! + totalRead, maxLength: count - totalRead)
+            }
             if read <= 0 {
                 throw onFail
             }

--- a/macos/ClipRelayMac/Sources/Protocol/Session.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/Session.swift
@@ -27,6 +27,7 @@ protocol SessionDelegate: AnyObject {
     func session(_ session: Session, didChangeRichMediaSetting enabled: Bool)
     func session(_ session: Session, didReceiveImage data: Data, contentType: String, hash: String)
     func session(_ session: Session, imageWasRejected reason: String)
+    func session(_ session: Session, didReceiveAndroidNotification appName: String, title: String, text: String, time: Int64)
 }
 
 extension SessionDelegate {
@@ -34,6 +35,7 @@ extension SessionDelegate {
     func session(_ session: Session, didReceiveImage data: Data, contentType: String, hash: String) {}
     func session(_ session: Session, imageWasRejected reason: String) {}
     func session(_ session: Session, imageSendFailed reason: String) {}
+    func session(_ session: Session, didReceiveAndroidNotification appName: String, title: String, text: String, time: Int64) {}
 }
 
 // MARK: - Session Errors
@@ -344,6 +346,8 @@ final class Session {
             }
         case .configUpdate:
             handleConfigUpdate(msg)
+        case .notification:
+            handleAndroidNotification(msg)
         case .reject:
             break // handled in later task
         case .error:
@@ -381,6 +385,22 @@ final class Session {
         queueLock.lock()
         configUpdateQueue.append(msg)
         queueLock.unlock()
+    }
+
+    // MARK: - Inbound Android Notification
+
+    private func handleAndroidNotification(_ msg: Message) {
+        guard let key = sessionKey else { return }
+        guard let plaintext = try? E2ECrypto.open(msg.payload, key: key),
+              let json = try? JSONSerialization.jsonObject(with: plaintext) as? [String: Any],
+              let appName = json["appName"] as? String,
+              let title = json["title"] as? String else {
+            logger.warning("Received malformed notification message")
+            return
+        }
+        let text = json["text"] as? String ?? ""
+        let time = (json["time"] as? NSNumber)?.int64Value ?? 0
+        delegate?.session(self, didReceiveAndroidNotification: appName, title: title, text: text, time: time)
     }
 
     // MARK: - Outbound Transfer

--- a/macos/ClipRelayMac/Sources/Protocol/Session.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/Session.swift
@@ -27,7 +27,8 @@ protocol SessionDelegate: AnyObject {
     func session(_ session: Session, didChangeRichMediaSetting enabled: Bool)
     func session(_ session: Session, didReceiveImage data: Data, contentType: String, hash: String)
     func session(_ session: Session, imageWasRejected reason: String)
-    func session(_ session: Session, didReceiveAndroidNotification appName: String, title: String, text: String, time: Int64)
+    func session(_ session: Session, didReceiveNotification appName: String, title: String, text: String,
+                 iconData: Data?, notificationKey: String, actions: [NotificationAction])
 }
 
 extension SessionDelegate {
@@ -35,7 +36,8 @@ extension SessionDelegate {
     func session(_ session: Session, didReceiveImage data: Data, contentType: String, hash: String) {}
     func session(_ session: Session, imageWasRejected reason: String) {}
     func session(_ session: Session, imageSendFailed reason: String) {}
-    func session(_ session: Session, didReceiveAndroidNotification appName: String, title: String, text: String, time: Int64) {}
+    func session(_ session: Session, didReceiveNotification appName: String, title: String, text: String,
+                 iconData: Data?, notificationKey: String, actions: [NotificationAction]) {}
 }
 
 // MARK: - Session Errors
@@ -101,6 +103,8 @@ final class Session {
     /// Queue of outbound image transfers: (imageData, contentType).
     private var imageQueue: [(Data, String)] = []
     private var configUpdateQueue: [Message] = []
+    /// Queue of outbound notification action messages (Mac → Android).
+    private var notificationActionQueue: [Message] = []
     private let queueLock = NSLock()
 
     /// Active TCP image receiver, if any (for cancellation on new inbound offer).
@@ -289,6 +293,12 @@ final class Session {
                     continue
                 }
 
+                // Drain any queued notification action messages (Mac → Android)
+                if let actionMsg = dequeueNotificationAction() {
+                    try writeMessage(actionMsg)
+                    continue
+                }
+
                 // Check for queued image transfers
                 if let imageItem = dequeueImage() {
                     try doSendImage(imageItem.0, contentType: imageItem.1)
@@ -347,7 +357,7 @@ final class Session {
         case .configUpdate:
             handleConfigUpdate(msg)
         case .notification:
-            handleAndroidNotification(msg)
+            handleInboundNotification(msg)
         case .reject:
             break // handled in later task
         case .error:
@@ -387,29 +397,62 @@ final class Session {
         queueLock.unlock()
     }
 
-    // MARK: - Inbound Android Notification
+    // MARK: - Inbound Notification
 
-    private func handleAndroidNotification(_ msg: Message) {
+    private func handleInboundNotification(_ msg: Message) {
+        logger.info("Received notification message from Android (\(msg.payload.count) bytes)")
         guard let key = sessionKey else {
-            logger.warning("[Notif] No session key")
+            logger.warning("No session key for notification decryption")
             return
         }
         guard let plaintext = try? E2ECrypto.open(msg.payload, key: key) else {
-            logger.warning("[Notif] Decryption failed")
+            logger.warning("Failed to decrypt notification payload")
             return
         }
         guard let json = try? JSONSerialization.jsonObject(with: plaintext) as? [String: Any] else {
-            logger.warning("[Notif] JSON parse failed")
+            logger.warning("Failed to parse notification JSON")
             return
         }
-        guard let appName = json["appName"] as? String, let title = json["title"] as? String else {
-            logger.warning("[Notif] Missing appName or title in JSON: \(json.keys.joined(separator: ","))")
-            return
+        let appName         = json["appName"] as? String ?? ""
+        let title           = json["title"]   as? String ?? ""
+        let text            = json["text"]    as? String ?? ""
+        let iconData        = (json["iconPng"] as? String).flatMap { Data(base64Encoded: $0) }
+        let notificationKey = json["notificationKey"] as? String ?? ""
+
+        // Parse actions array: [{index, title, hasReply}, ...]
+        var actions: [NotificationAction] = []
+        if let rawActions = json["actions"] as? [[String: Any]] {
+            actions = rawActions.compactMap { raw in
+                guard let index = raw["index"] as? Int,
+                      let title = raw["title"] as? String else { return nil }
+                let hasReply = raw["hasReply"] as? Bool ?? false
+                return NotificationAction(index: index, title: title, hasReply: hasReply)
+            }
         }
-        let text = json["text"] as? String ?? ""
-        let time = (json["time"] as? NSNumber)?.int64Value ?? 0
-        logger.info("[Notif] Dispatching to delegate: \(appName) / \(title)")
-        delegate?.session(self, didReceiveAndroidNotification: appName, title: title, text: text, time: time)
+
+        logger.info("Dispatching notification: appName=\(appName) title=\(title) actions=\(actions.count)")
+        delegate?.session(self, didReceiveNotification: appName, title: title, text: text,
+                          iconData: iconData, notificationKey: notificationKey, actions: actions)
+    }
+
+    // MARK: - Outbound Notification Action (Mac → Android)
+
+    /// Queue a notification action fire command for sending to Android. Thread-safe.
+    func sendNotificationAction(notificationKey: String, actionIndex: Int, replyText: String? = nil) {
+        guard !closed, let key = sessionKey else { return }
+        var payload: [String: Any] = [
+            "notificationKey": notificationKey,
+            "actionIndex": actionIndex
+        ]
+        if let reply = replyText, !reply.isEmpty {
+            payload["replyText"] = reply
+        }
+        guard let plaintext = try? JSONSerialization.data(withJSONObject: payload),
+              let encrypted = try? E2ECrypto.seal(plaintext, key: key) else { return }
+        let msg = Message(type: .notificationAction, payload: encrypted)
+        queueLock.lock()
+        notificationActionQueue.append(msg)
+        queueLock.unlock()
     }
 
     // MARK: - Outbound Transfer
@@ -452,6 +495,13 @@ final class Session {
         defer { queueLock.unlock() }
         if outboundQueue.isEmpty { return nil }
         return outboundQueue.removeFirst()
+    }
+
+    private func dequeueNotificationAction() -> Message? {
+        queueLock.lock()
+        defer { queueLock.unlock() }
+        if notificationActionQueue.isEmpty { return nil }
+        return notificationActionQueue.removeFirst()
     }
 
     private func doSendClipboard(_ plaintext: Data) throws {

--- a/macos/ClipRelayMac/Sources/Protocol/Session.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/Session.swift
@@ -390,16 +390,25 @@ final class Session {
     // MARK: - Inbound Android Notification
 
     private func handleAndroidNotification(_ msg: Message) {
-        guard let key = sessionKey else { return }
-        guard let plaintext = try? E2ECrypto.open(msg.payload, key: key),
-              let json = try? JSONSerialization.jsonObject(with: plaintext) as? [String: Any],
-              let appName = json["appName"] as? String,
-              let title = json["title"] as? String else {
-            logger.warning("Received malformed notification message")
+        guard let key = sessionKey else {
+            logger.warning("[Notif] No session key")
+            return
+        }
+        guard let plaintext = try? E2ECrypto.open(msg.payload, key: key) else {
+            logger.warning("[Notif] Decryption failed")
+            return
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: plaintext) as? [String: Any] else {
+            logger.warning("[Notif] JSON parse failed")
+            return
+        }
+        guard let appName = json["appName"] as? String, let title = json["title"] as? String else {
+            logger.warning("[Notif] Missing appName or title in JSON: \(json.keys.joined(separator: ","))")
             return
         }
         let text = json["text"] as? String ?? ""
         let time = (json["time"] as? NSNumber)?.int64Value ?? 0
+        logger.info("[Notif] Dispatching to delegate: \(appName) / \(title)")
         delegate?.session(self, didReceiveAndroidNotification: appName, title: title, text: text, time: time)
     }
 


### PR DESCRIPTION
## Summary

This adds real-time notification mirroring from Android to Mac over the existing BLE L2CAP connection — no new pairing, no new infrastructure.

- **Android**: A `NotificationListenerService` captures posted notifications, resolves the human-readable app name, renders the app icon as a 64×64 PNG, and sends everything to Mac as an encrypted BLE notification message. A settings toggle in the main UI lets the user enable/disable the feature.
- **Mac**: Decrypts the incoming notification message, extracts the icon bytes, and posts a native macOS `UNUserNotification` with the title, body, app-name subtitle, and icon attachment.
- **Protocol fix**: `didReceiveNotification` was only declared in a `SessionDelegate` extension (static dispatch), so it silently hit the empty default. Moving it into the protocol declaration restores dynamic dispatch.

## What it looks like

Android notifications appear on Mac with:
- Notification title as the banner title
- App name as the subtitle
- App icon on the right side of the banner

## Test plan

- [ ] Pair Android device with Mac via existing QR flow
- [ ] Enable "Notification Sync" toggle in the Android app settings
- [ ] Grant Notification Listener permission when prompted
- [ ] Trigger a notification on Android (e.g. Gmail, WhatsApp) — it should appear on Mac within ~1s
- [ ] Disable the toggle — notifications should stop mirroring
- [ ] Verify clipboard sync still works normally alongside notification sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)