### PR TITLE
fix(macos): Forget Device requires two presses to remove a paired device

### DIFF
--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -180,8 +180,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Device Management
 
     private func forgetDevice(token: String) {
-        connectionController.forgetDevice(token: token)
-        refreshTrustedPeersMenu()
+        connectionController.forgetDevice(token: token) { [weak self] in
+            self?.refreshTrustedPeersMenu()
+        }
     }
 
     // MARK: - Bluetooth Alert

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -478,9 +478,14 @@ extension ConnectionController {
 
     // MARK: Device Management
 
-    func forgetDevice(token: String) {
+    func forgetDevice(token: String, completion: (() -> Void)? = nil) {
         queue.async { [self] in
             pairingManager.removeDevice(secret: token)
+            defer {
+                if let completion {
+                    DispatchQueue.main.async(execute: completion)
+                }
+            }
             switch state {
             case .ready(_, let t, _) where t == token:
                 transitionToIdle(reason: "device forgotten", reconnect: false)


### PR DESCRIPTION
## Problem
Pressing **Forget Device** in the Mac menu bar app appeared to do nothing — the device only disappeared after pressing it a second time.

## Root cause
`AppDelegate.forgetDevice` called `ConnectionController.forgetDevice(token:)`, which removes the device asynchronously on the BLE dispatch queue, but then refreshed the menu immediately on the main thread. The refresh reloaded the device list from the Keychain **before** the removal had executed, so the menu re-rendered with the stale list. The first press did remove the device; the second press merely refreshed the menu.

## Fix
`ConnectionController.forgetDevice` now accepts a completion callback invoked on the main thread after the removal (and any state transition) completes. `AppDelegate` refreshes the trusted-devices menu from that callback.

## Testing
- macOS build + all 140 Swift unit tests pass
- BLE hardware smoke test against a Pixel 10 Pro XL completed a full pair → forget cycle
- Android build/tests skipped (macOS-only change)