### PR TITLE
Support multiple paired devices on both platforms (multi-Mac + multi-phone)

### DIFF
--- a/android/app/src/debug/java/org/cliprelay/debug/DebugSmokeReceiver.kt
+++ b/android/app/src/debug/java/org/cliprelay/debug/DebugSmokeReceiver.kt
@@ -30,7 +30,7 @@ class DebugSmokeReceiver : BroadcastReceiver() {
                 val deviceName = intent.getStringExtra(EXTRA_DEVICE_NAME)
 
                 runCatching {
-                    if (!PairingStore(context).saveSharedSecret(normalizedToken)) {
+                    if (!PairingStore(context).addPairedMac(normalizedToken, deviceName)) {
                         setResultCode(3)
                         return
                     }

--- a/android/app/src/main/java/org/cliprelay/ble/Advertiser.kt
+++ b/android/app/src/main/java/org/cliprelay/ble/Advertiser.kt
@@ -41,6 +41,9 @@ class Advertiser(private val context: Context, private val serviceUuid: ParcelUu
         }
     }
 
+    // Written from session/service threads, read on the main-looper advertising
+    // path — @Volatile guarantees the freshly-set tag is visible to the next cycle.
+    @Volatile
     var deviceTag: ByteArray? = null
     var psm: Int = 0
 

--- a/android/app/src/main/java/org/cliprelay/pairing/PairingStore.kt
+++ b/android/app/src/main/java/org/cliprelay/pairing/PairingStore.kt
@@ -12,15 +12,17 @@ import org.cliprelay.protocol.SettingsProvider
 import org.json.JSONArray
 import org.json.JSONObject
 
+/** Device-tag hex for a shared secret: the stable non-secret identifier. */
+internal fun deviceTagHex(secretHex: String): String =
+    E2ECrypto.deviceTag(secretHex).joinToString("") { "%02x".format(it) }
+
 /** One paired Mac. [id] is a stable non-secret identifier derived from the secret. */
 data class PairedMac(
     val secretHex: String,
     val name: String?,
     val pairedAtMs: Long
 ) {
-    val id: String by lazy {
-        E2ECrypto.deviceTag(secretHex).joinToString("") { "%02x".format(it) }
-    }
+    val id: String by lazy { deviceTagHex(secretHex) }
 }
 
 class PairingStore internal constructor(private val encryptedPrefs: SharedPreferences?) : SettingsProvider {
@@ -99,8 +101,7 @@ class PairingStore internal constructor(private val encryptedPrefs: SharedPrefer
         return runCatching {
             val editor = prefs.edit()
             if (identityTagHex() == null) {
-                val tagHex = E2ECrypto.deviceTag(secretHex).joinToString("") { "%02x".format(it) }
-                editor.putString(KEY_IDENTITY_TAG, tagHex)
+                editor.putString(KEY_IDENTITY_TAG, deviceTagHex(secretHex))
             }
             editor.putString(KEY_PAIRED_MACS, encode(macs + PairedMac(secretHex, name, pairedAtMs)))
             editor.apply()
@@ -189,10 +190,9 @@ class PairingStore internal constructor(private val encryptedPrefs: SharedPrefer
         runCatching {
             val legacy = prefs.getString(KEY_SHARED_SECRET, null) ?: return
             if (prefs.getString(KEY_PAIRED_MACS, null) == null) {
-                val tagHex = E2ECrypto.deviceTag(legacy).joinToString("") { "%02x".format(it) }
                 prefs.edit()
                     .putString(KEY_PAIRED_MACS, encode(listOf(PairedMac(legacy, null, 0L))))
-                    .putString(KEY_IDENTITY_TAG, tagHex)
+                    .putString(KEY_IDENTITY_TAG, deviceTagHex(legacy))
                     .remove(KEY_SHARED_SECRET)
                     .apply()
             } else {

--- a/android/app/src/main/java/org/cliprelay/pairing/PairingStore.kt
+++ b/android/app/src/main/java/org/cliprelay/pairing/PairingStore.kt
@@ -1,21 +1,44 @@
 package org.cliprelay.pairing
 
-// Persists the shared secret in EncryptedSharedPreferences.
+// Persists paired Macs (up to MAX_PAIRED_MACS) and the phone identity tag in EncryptedSharedPreferences.
 
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import org.cliprelay.crypto.E2ECrypto
 import org.cliprelay.protocol.SettingsProvider
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** One paired Mac. [id] is a stable non-secret identifier derived from the secret. */
+data class PairedMac(
+    val secretHex: String,
+    val name: String?,
+    val pairedAtMs: Long
+) {
+    val id: String by lazy {
+        E2ECrypto.deviceTag(secretHex).joinToString("") { "%02x".format(it) }
+    }
+}
 
 class PairingStore internal constructor(private val encryptedPrefs: SharedPreferences?) : SettingsProvider {
     companion object {
+        const val MAX_PAIRED_MACS = 5
+
         private const val TAG = "PairingStore"
         private const val PREFS_NAME = "cliprelay_pairing"
+        // Legacy single-Mac key, migrated to KEY_PAIRED_MACS on first load.
         internal const val KEY_SHARED_SECRET = "shared_secret"
+        internal const val KEY_PAIRED_MACS = "paired_macs"
+        internal const val KEY_IDENTITY_TAG = "identity_tag"
         internal const val KEY_RICH_MEDIA_ENABLED = "rich_media_enabled"
         internal const val KEY_RICH_MEDIA_ENABLED_CHANGED_AT = "rich_media_enabled_changed_at"
+    }
+
+    init {
+        migrateLegacySecretIfNeeded()
     }
 
     constructor(context: Context) : this(
@@ -36,21 +59,95 @@ class PairingStore internal constructor(private val encryptedPrefs: SharedPrefer
         }
     )
 
-    fun saveSharedSecret(secret: String): Boolean {
+    // ── Paired Macs ───────────────────────────────────────────────────
+
+    fun loadPairedMacs(): List<PairedMac> {
+        val prefs = encryptedPrefs ?: return emptyList()
+        val raw = runCatching { prefs.getString(KEY_PAIRED_MACS, null) }.getOrNull() ?: return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            (0 until array.length()).mapNotNull { i ->
+                val obj = array.optJSONObject(i) ?: return@mapNotNull null
+                val secret = obj.optString("secret").takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+                PairedMac(
+                    secretHex = secret,
+                    name = obj.optString("name").takeIf { it.isNotEmpty() },
+                    pairedAtMs = obj.optLong("pairedAt", 0L)
+                )
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    fun hasPairedMacs(): Boolean = loadPairedMacs().isNotEmpty()
+
+    /**
+     * Add (or re-add) a paired Mac. Sets the identity tag from this secret when
+     * none exists yet (first pairing — old Macs scan for the secret-derived tag).
+     * Returns false when storage is unavailable or the list is full.
+     */
+    fun addPairedMac(secretHex: String, name: String?, pairedAtMs: Long = System.currentTimeMillis()): Boolean {
         val prefs = encryptedPrefs
         if (prefs == null) {
-            Log.e(TAG, "Cannot save shared secret: encrypted storage unavailable")
+            Log.e(TAG, "Cannot save pairing: encrypted storage unavailable")
+            return false
+        }
+        val macs = loadPairedMacs().filterNot { it.secretHex == secretHex }
+        if (macs.size >= MAX_PAIRED_MACS) {
+            Log.w(TAG, "Cannot add pairing: limit of $MAX_PAIRED_MACS reached")
             return false
         }
         return runCatching {
-            prefs.edit().putString(KEY_SHARED_SECRET, secret).apply()
+            val editor = prefs.edit()
+            if (identityTagHex() == null) {
+                val tagHex = E2ECrypto.deviceTag(secretHex).joinToString("") { "%02x".format(it) }
+                editor.putString(KEY_IDENTITY_TAG, tagHex)
+            }
+            editor.putString(KEY_PAIRED_MACS, encode(macs + PairedMac(secretHex, name, pairedAtMs)))
+            editor.apply()
             true
         }.getOrDefault(false)
     }
 
-    fun loadSharedSecret(): String? {
-        return readSecret(encryptedPrefs)
+    /** Update the display name of an existing pairing (from the handshake's remote name). */
+    fun updateMacName(secretHex: String, name: String) {
+        val prefs = encryptedPrefs ?: return
+        val macs = loadPairedMacs()
+        if (macs.none { it.secretHex == secretHex && it.name != name }) return
+        val updated = macs.map { if (it.secretHex == secretHex) it.copy(name = name) else it }
+        runCatching { prefs.edit().putString(KEY_PAIRED_MACS, encode(updated)).apply() }
     }
+
+    /**
+     * Remove one pairing. When the last Mac is removed the identity tag is
+     * cleared too, so the next first pairing derives a fresh one.
+     */
+    fun removePairedMac(secretHex: String) {
+        val prefs = encryptedPrefs ?: return
+        val remaining = loadPairedMacs().filterNot { it.secretHex == secretHex }
+        runCatching {
+            val editor = prefs.edit()
+            if (remaining.isEmpty()) {
+                editor.remove(KEY_PAIRED_MACS)
+                editor.remove(KEY_IDENTITY_TAG)
+            } else {
+                editor.putString(KEY_PAIRED_MACS, encode(remaining))
+            }
+            editor.apply()
+        }
+    }
+
+    /** Stable 8-byte tag advertised over BLE; null when nothing is paired. */
+    fun identityTag(): ByteArray? {
+        val hex = identityTagHex() ?: return null
+        return runCatching { E2ECrypto.hexToBytes(hex) }.getOrNull()
+    }
+
+    fun identityTagHex(): String? {
+        val prefs = encryptedPrefs ?: return null
+        return runCatching { prefs.getString(KEY_IDENTITY_TAG, null) }.getOrNull()
+    }
+
+    // ── Rich media settings (global, synced last-write-wins) ─────────
 
     override fun isRichMediaEnabled(): Boolean {
         val prefs = encryptedPrefs ?: return false
@@ -73,22 +170,47 @@ class PairingStore internal constructor(private val encryptedPrefs: SharedPrefer
     }
 
     fun clear() {
-        clearAll(encryptedPrefs)
-    }
-
-    private fun readSecret(prefs: SharedPreferences?): String? {
-        if (prefs == null) return null
-        return runCatching { prefs.getString(KEY_SHARED_SECRET, null) }.getOrNull()
-    }
-
-    private fun clearAll(prefs: SharedPreferences?) {
-        if (prefs == null) return
+        val prefs = encryptedPrefs ?: return
         runCatching {
             prefs.edit()
                 .remove(KEY_SHARED_SECRET)
+                .remove(KEY_PAIRED_MACS)
+                .remove(KEY_IDENTITY_TAG)
                 .remove(KEY_RICH_MEDIA_ENABLED)
                 .remove(KEY_RICH_MEDIA_ENABLED_CHANGED_AT)
                 .apply()
         }
+    }
+
+    // ── Migration ─────────────────────────────────────────────────────
+
+    private fun migrateLegacySecretIfNeeded() {
+        val prefs = encryptedPrefs ?: return
+        runCatching {
+            val legacy = prefs.getString(KEY_SHARED_SECRET, null) ?: return
+            if (prefs.getString(KEY_PAIRED_MACS, null) == null) {
+                val tagHex = E2ECrypto.deviceTag(legacy).joinToString("") { "%02x".format(it) }
+                prefs.edit()
+                    .putString(KEY_PAIRED_MACS, encode(listOf(PairedMac(legacy, null, 0L))))
+                    .putString(KEY_IDENTITY_TAG, tagHex)
+                    .remove(KEY_SHARED_SECRET)
+                    .apply()
+            } else {
+                prefs.edit().remove(KEY_SHARED_SECRET).apply()
+            }
+            Log.w(TAG, "Migrated legacy single-Mac pairing to paired_macs list")
+        }
+    }
+
+    private fun encode(macs: List<PairedMac>): String {
+        val array = JSONArray()
+        macs.forEach { mac ->
+            array.put(JSONObject().apply {
+                put("secret", mac.secretHex)
+                mac.name?.let { put("name", it) }
+                put("pairedAt", mac.pairedAtMs)
+            })
+        }
+        return array.toString()
     }
 }

--- a/android/app/src/main/java/org/cliprelay/protocol/Session.kt
+++ b/android/app/src/main/java/org/cliprelay/protocol/Session.kt
@@ -34,7 +34,9 @@ sealed class SessionMode {
     class Pairing(
         val ownPrivateKey: PrivateKey,
         val ownPublicKeyRaw: ByteArray,
-        val remotePublicKeyRaw: ByteArray
+        val remotePublicKeyRaw: ByteArray,
+        /** Stable phone identity tag (hex) to share with the Mac; null on first pairing. */
+        val identityTagHex: String? = null
     ) : SessionMode()
 }
 
@@ -61,7 +63,13 @@ class Session(
     internal var handshakeTimeoutMs: Long = 5_000L,
     internal var transferTimeoutMs: Long = 30_000L,
     internal var pairingTimeoutMs: Long = 60_000L,
-    private val settingsProvider: SettingsProvider? = null
+    private val settingsProvider: SettingsProvider? = null,
+    /**
+     * Candidate shared secrets for responder mode with multiple paired Macs.
+     * The HELLO's HMAC identifies which Mac is connecting; the matching secret
+     * becomes this session's shared secret (see [matchedSecretHex]).
+     */
+    private val candidateSecretsHex: List<String> = emptyList()
 ) {
     private val tag = "Session"
     private val closed = AtomicBoolean(false)
@@ -72,6 +80,12 @@ class Session(
     /** Remote device name received during handshake. Available after onSessionReady. */
     var remoteName: String? = null
         private set
+
+    /**
+     * The shared secret this session ended up using. With [candidateSecretsHex]
+     * this identifies which Mac connected. Available after onSessionReady.
+     */
+    val matchedSecretHex: String? get() = sharedSecretHex
 
     /** Auth key derived from the shared secret, used for HMAC authentication during handshake. */
     private var authKey: SecretKey? = sharedSecretHex?.let {
@@ -118,7 +132,7 @@ class Session(
         try {
             when (val m = mode) {
                 is SessionMode.Normal -> {
-                    if (sharedSecretHex == null) {
+                    if (sharedSecretHex == null && candidateSecretsHex.isEmpty()) {
                         throw ProtocolException("Shared secret required for Normal mode")
                     }
                     if (isInitiator) {
@@ -206,6 +220,11 @@ class Session(
         val exchangeJson = JSONObject().apply {
             put("pubkey", pubkeyHex)
             localName?.let { put("name", it) }
+            // Stable phone identity tag: the Mac scans for this instead of the
+            // secret-derived tag, so one advertisement serves all paired Macs.
+            // Absent on first pairing — the Mac then falls back to the
+            // secret-derived tag, which equals the identity tag the phone adopts.
+            pairing.identityTagHex?.let { put("tag", it) }
         }
         val keyExchange = Message(MessageType.KEY_EXCHANGE, exchangeJson.toString().toByteArray())
         MessageCodec.write(output, keyExchange)
@@ -795,9 +814,19 @@ class Session(
             throw ProtocolException("Authentication failed")
         }
         val authBytes = E2ECrypto.hexToBytes(authHex)
-        val ak = authKey ?: throw ProtocolException("Authentication failed")
-        if (!E2ECrypto.verifyAuth(remoteEkBytes, ak, authBytes)) {
-            throw ProtocolException("Authentication failed")
+        val ak = authKey
+        if (ak != null) {
+            if (!E2ECrypto.verifyAuth(remoteEkBytes, ak, authBytes)) {
+                throw ProtocolException("Authentication failed")
+            }
+        } else {
+            // Multiple paired Macs: the HMAC identifies which one is connecting.
+            val matched = candidateSecretsHex.firstOrNull { secretHex ->
+                val candidateKey = E2ECrypto.deriveAuthKey(E2ECrypto.hexToBytes(secretHex))
+                E2ECrypto.verifyAuth(remoteEkBytes, candidateKey, authBytes)
+            } ?: throw ProtocolException("Authentication failed")
+            sharedSecretHex = matched
+            authKey = E2ECrypto.deriveAuthKey(E2ECrypto.hexToBytes(matched))
         }
 
         // Resolve settings with last-write-wins

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -61,7 +61,6 @@ class ClipRelayService : Service(), L2capServerCallback {
         const val EXTRA_TEXT = "extra_text"
         const val EXTRA_CONNECTED = "extra_connected"
         const val EXTRA_DEVICE_NAME = "extra_device_name"
-        const val EXTRA_DEVICE_TAG = "extra_device_tag"
         const val EXTRA_DEVICE_ID = "extra_device_id"
         const val EXTRA_CONNECTED_IDS = "extra_connected_ids"
         const val EXTRA_FROM_MAC = "extra_from_mac"
@@ -613,13 +612,9 @@ class ClipRelayService : Service(), L2capServerCallback {
             saveConnectedDeviceName(remoteName)
         }
 
-        // Broadcast pairing complete with device tag for UI
-        val deviceTagHex = E2ECrypto.deviceTag(sharedSecret).take(4)
-            .joinToString("") { "%02X".format(it) }
-            .chunked(4).joinToString(" ")
+        // Broadcast pairing complete (the UI re-reads the pairing store)
         val pairingIntent = Intent(ACTION_PAIRING_COMPLETE)
         pairingIntent.setPackage(packageName)
-        pairingIntent.putExtra(EXTRA_DEVICE_TAG, deviceTagHex)
         pairingIntent.putExtra(EXTRA_DEVICE_NAME, scannedName)
         sendBroadcast(pairingIntent)
         publishDirectShareShortcut(directShareLabel())

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -41,11 +41,12 @@ import java.io.IOException
 import java.security.MessageDigest
 import java.util.concurrent.Executors
 
-class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
+class ClipRelayService : Service(), L2capServerCallback {
     companion object {
         const val ACTION_PUSH_TEXT = "org.cliprelay.action.PUSH_TEXT"
         const val ACTION_RELOAD_PAIRING = "org.cliprelay.action.RELOAD_PAIRING"
         const val ACTION_UNPAIR = "org.cliprelay.action.UNPAIR"
+        const val ACTION_FORGET_DEVICE = "org.cliprelay.action.FORGET_DEVICE"
         const val ACTION_START_PAIRING = "org.cliprelay.action.START_PAIRING"
         const val ACTION_CONNECTION_STATE = "org.cliprelay.action.CONNECTION_STATE"
         const val ACTION_QUERY_CONNECTION = "org.cliprelay.action.QUERY_CONNECTION"
@@ -61,6 +62,8 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         const val EXTRA_CONNECTED = "extra_connected"
         const val EXTRA_DEVICE_NAME = "extra_device_name"
         const val EXTRA_DEVICE_TAG = "extra_device_tag"
+        const val EXTRA_DEVICE_ID = "extra_device_id"
+        const val EXTRA_CONNECTED_IDS = "extra_connected_ids"
         const val EXTRA_FROM_MAC = "extra_from_mac"
 
         const val ACTION_VERSION_MISMATCH = "org.cliprelay.action.VERSION_MISMATCH"
@@ -75,6 +78,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
         const val PREFS_NAME = "cliprelay_state"
         const val KEY_CONNECTED_DEVICE = "connected_device_name"
+        const val KEY_PENDING_PAIRING_NAME = "pending_pairing_name"
 
         private const val TAG = "ClipRelayService"
         private const val MAX_CLIPBOARD_BYTES = 102_400
@@ -86,13 +90,12 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     private var advertiser: Advertiser? = null
     private var l2capServer: L2capServer? = null
 
-    // Active L2CAP session (at most one)
-    @Volatile
-    private var activeSession: Session? = null
-    private var sessionThread: Thread? = null
+    // Active L2CAP sessions, one per connected Mac (guarded by sessionLock).
+    private val sessionLock = Any()
+    private val sessions = mutableListOf<SessionHandle>()
 
     // Pairing state
-    private val isPaired: Boolean get() = pairingStore.loadSharedSecret() != null
+    private val isPaired: Boolean get() = pairingStore.hasPairedMacs()
     @Volatile
     private var lastInboundHash: String? = null
     @Volatile
@@ -124,6 +127,57 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     private var lastClipboardLaunchMs = 0L
     @Volatile
     private var ghostActivityInFlight = false
+
+    // ── Session handles ───────────────────────────────────────────────
+
+    /**
+     * Per-connection SessionCallback adapter. Each connected Mac gets its own
+     * handle; which Mac it is becomes known once the handshake identifies the
+     * matching shared secret (or pairing completes).
+     */
+    private inner class SessionHandle : SessionCallback {
+        @Volatile var session: Session? = null
+        @Volatile var thread: Thread? = null
+        /** Shared secret of the Mac on this connection (after handshake/pairing). */
+        @Volatile var secretHex: String? = null
+        @Volatile var ready = false
+
+        fun close() {
+            session?.close()
+            thread?.let { t -> runCatching { t.join(2000) } }
+        }
+
+        override fun onSessionReady() = handleSessionReady(this)
+        override fun onClipboardReceived(plaintext: ByteArray, hash: String) =
+            handleClipboardReceivedFromMac(plaintext, hash)
+        override fun onTransferComplete(hash: String) = handleTransferComplete(hash)
+        override fun onSessionError(error: Exception) = handleSessionError(this, error)
+        override fun hasHash(hash: String): Boolean = hash == lastInboundHash
+        override fun onPairingComplete(sharedSecret: ByteArray, remoteName: String?) =
+            handlePairingSecretEstablished(this, sharedSecret, remoteName)
+        override fun onRichMediaSettingChanged(enabled: Boolean) =
+            handleRichMediaSettingChanged(enabled)
+        override fun onImageReceived(data: ByteArray, contentType: String, hash: String) =
+            handleImageReceived(data, contentType, hash)
+        override fun onImageSendFailed(reason: String) = handleImageSendFailed(reason)
+        override fun isDeviceAwake(): Boolean = isDeviceAwakeNow()
+    }
+
+    private fun readySessions(): List<SessionHandle> =
+        synchronized(sessionLock) { sessions.filter { it.ready } }
+
+    /** Remove a handle from the list. Returns false when it was already removed. */
+    private fun removeSession(handle: SessionHandle): Boolean =
+        synchronized(sessionLock) { sessions.remove(handle) }
+
+    private fun closeAllSessions() {
+        val snapshot = synchronized(sessionLock) {
+            val copy = sessions.toList()
+            sessions.clear()
+            copy
+        }
+        snapshot.forEach { it.close() }
+    }
 
     private val bluetoothStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -164,7 +218,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
         // Publish direct share shortcut if already paired
         if (isPaired) {
-            publishDirectShareShortcut(loadConnectedDeviceName())
+            publishDirectShareShortcut(directShareLabel())
         }
     }
 
@@ -184,6 +238,10 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         when (intent?.action) {
             ACTION_UNPAIR -> {
                 handleUnpairRequest()
+                return START_STICKY
+            }
+            ACTION_FORGET_DEVICE -> {
+                intent.getStringExtra(EXTRA_DEVICE_ID)?.let { handleForgetDevice(it) }
                 return START_STICKY
             }
             ACTION_START_PAIRING -> {
@@ -222,7 +280,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                 return START_STICKY
             }
             ACTION_SEND_CONFIG_UPDATE -> {
-                activeSession?.sendConfigUpdate()
+                readySessions().forEach { it.session?.sendConfigUpdate() }
                 return START_STICKY
             }
             ACTION_PUSH_IMAGE -> {
@@ -244,9 +302,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                 }
             }
             ACTION_QUERY_CONNECTION -> {
-                val connected = activeSession != null
-                val name = if (connected) loadConnectedDeviceName() else null
-                sendConnectionBroadcast(connected, name)
+                broadcastConnectionState()
             }
         }
 
@@ -316,9 +372,7 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
                         .copyOfRange(0, 8)
                 }
             } else {
-                pairingStore.loadSharedSecret()?.let { secret ->
-                    E2ECrypto.deviceTag(E2ECrypto.hexToBytes(secret))
-                }
+                pairingStore.identityTag()
             }
             adv.start()
             advertiser = adv
@@ -346,13 +400,8 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     }
 
     private fun stopBleComponents(broadcastDisconnected: Boolean = true) {
-        // Tear down active session
-        activeSession?.close()
-        sessionThread?.let { thread ->
-            try { thread.join(2000) } catch (_: InterruptedException) {}
-        }
-        activeSession = null
-        sessionThread = null
+        // Tear down all active sessions
+        closeAllSessions()
 
         // Stop BLE stack
         advertiser?.stop()
@@ -367,12 +416,9 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     }
 
     private fun loadPairingState() {
-        val secret = pairingStore.loadSharedSecret()
-        if (secret != null) {
-            val secretBytes = E2ECrypto.hexToBytes(secret)
-            advertiser?.deviceTag = E2ECrypto.deviceTag(secretBytes)
-        } else {
-            advertiser?.deviceTag = null
+        val identityTag = pairingStore.identityTag()
+        advertiser?.deviceTag = identityTag
+        if (identityTag == null) {
             saveConnectedDeviceName(null)
         }
     }
@@ -384,12 +430,6 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
         if (pairingInProgress) {
             sendPairingStatus(PAIRING_STAGE_EXCHANGING_KEYS)
-        }
-
-        // Tear down previous session
-        activeSession?.close()
-        sessionThread?.let { thread ->
-            try { thread.join(2000) } catch (_: InterruptedException) {}
         }
 
         // Determine session mode
@@ -405,26 +445,30 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             SessionMode.Pairing(
                 ownPrivateKey = keyPair.private,
                 ownPublicKeyRaw = E2ECrypto.x25519PublicKeyToRaw(keyPair.public),
-                remotePublicKeyRaw = macPub
+                remotePublicKeyRaw = macPub,
+                identityTagHex = pairingStore.identityTagHex()
             )
         } else {
             SessionMode.Normal
         }
 
-        // Create new session (Android is the responder)
-        val secret = if (pairingInProgress) null else pairingStore.loadSharedSecret()
+        // Create new session (Android is the responder). The HELLO's HMAC
+        // identifies which paired Mac is connecting, so pass all secrets.
+        val handle = SessionHandle()
         val session = Session(
             socket.inputStream, socket.outputStream,
             isInitiator = false,
-            this,  // SessionCallback
+            handle,
             mode = mode,
-            sharedSecretHex = secret,
-            settingsProvider = pairingStore
+            settingsProvider = pairingStore,
+            candidateSecretsHex = if (pairingInProgress) emptyList()
+                else pairingStore.loadPairedMacs().map { it.secretHex }
         )
         session.localName = android.os.Build.MODEL
-        activeSession = session
+        handle.session = session
+        synchronized(sessionLock) { sessions.add(handle) }
 
-        sessionThread = Thread({
+        handle.thread = Thread({
             session.performHandshake()
             session.listenForMessages()
         }, "L2CAP-Session").apply {
@@ -447,10 +491,27 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         }
     }
 
-    // ── SessionCallback ───────────────────────────────────────────────
+    // ── Session event handlers (called from SessionHandle) ───────────
 
-    override fun onSessionReady() {
+    private fun handleSessionReady(handle: SessionHandle) {
         Log.w(TAG, "L2CAP session ready")
+
+        val session = handle.session
+        // The handshake identified which Mac this is (pairing sessions set
+        // secretHex earlier, in handlePairingSecretEstablished).
+        if (handle.secretHex == null) {
+            handle.secretHex = session?.matchedSecretHex
+        }
+        handle.ready = true
+
+        // If the same Mac reconnected while a stale session lingered, drop the
+        // old one. Remove it from the list first so its error callback is a no-op.
+        val stale = synchronized(sessionLock) {
+            val others = sessions.filter { it !== handle && it.secretHex == handle.secretHex }
+            sessions.removeAll(others)
+            others
+        }
+        stale.forEach { it.close() }
 
         // If the advertiser's device tag was updated during pairing (without a
         // restart), restart it now so future reconnections use the correct tag.
@@ -462,17 +523,19 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         // it so the UI always shows the real hostname (e.g. "Christian's Mac")
         // instead of null — during pairing, KEY_CONFIRM doesn't include a name
         // so this is the first point where the Mac's name is available.
-        activeSession?.remoteName?.let {
-            saveConnectedDeviceName(it)
-            publishDirectShareShortcut(it)
+        val remoteName = session?.remoteName
+        val secret = handle.secretHex
+        if (remoteName != null && secret != null) {
+            pairingStore.updateMacName(secret, remoteName)
+            saveConnectedDeviceName(remoteName)
         }
+        publishDirectShareShortcut(directShareLabel())
 
-        val name = loadConnectedDeviceName()
-        sendConnectionBroadcast(true, name)
+        broadcastConnectionState()
         DebugSmokeProbe.onConnectionChanged(this, true)
     }
 
-    override fun onClipboardReceived(plaintext: ByteArray, hash: String) {
+    private fun handleClipboardReceivedFromMac(plaintext: ByteArray, hash: String) {
         val decodedText = plaintext.toString(Charsets.UTF_8)
         if (decodedText.isEmpty()) return
 
@@ -483,17 +546,18 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         DebugSmokeProbe.onInboundClipboardApplied(this, decodedText)
     }
 
-    override fun onTransferComplete(hash: String) {
+    private fun handleTransferComplete(hash: String) {
         Log.d(TAG, "Outbound transfer complete: $hash")
         sendClipboardTransferBroadcast(fromMac = false)
     }
 
-    override fun onSessionError(error: Exception) {
+    private fun handleSessionError(handle: SessionHandle, error: Exception) {
         Log.e(TAG, "Session error: ${error.message}")
-        activeSession = null
-        sessionThread = null
-        sendConnectionBroadcast(false)
-        DebugSmokeProbe.onConnectionChanged(this, false)
+        // Already removed means we closed it deliberately — nothing to report.
+        if (!removeSession(handle)) return
+
+        broadcastConnectionState()
+        DebugSmokeProbe.onConnectionChanged(this, readySessions().isNotEmpty())
 
         if (error is VersionMismatchException) {
             val intent = Intent(ACTION_VERSION_MISMATCH)
@@ -503,25 +567,35 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         // L2CAP server is still listening, will accept next connection
     }
 
-    override fun hasHash(hash: String): Boolean {
-        return hash == lastInboundHash
-    }
-
-    override fun onPairingComplete(sharedSecret: ByteArray, remoteName: String?) {
+    private fun handlePairingSecretEstablished(
+        handle: SessionHandle,
+        sharedSecret: ByteArray,
+        remoteName: String?
+    ) {
         val secretHex = sharedSecret.joinToString("") { "%02x".format(it) }
         Log.w(TAG, "ECDH pairing complete, storing shared secret")
         clearPairingTimeout()
 
-        // Store the shared secret
-        pairingStore.saveSharedSecret(secretHex)
+        // Store the new pairing. The QR-scanned Mac name (if any) serves as the
+        // initial display name until the handshake delivers the real hostname.
+        val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+        val scannedName = prefs.getString(KEY_PENDING_PAIRING_NAME, null)?.takeIf { it.isNotBlank() }
+            ?: remoteName
+        if (!pairingStore.addPairedMac(secretHex, scannedName)) {
+            Log.e(TAG, "Could not store new pairing (limit reached or storage unavailable)")
+            cancelPairing(broadcastFailed = true)
+            handle.session?.close()
+            return
+        }
+        handle.secretHex = secretHex
 
         // Update the device tag for future advertisements, but do NOT restart
         // advertising now — the HELLO/WELCOME handshake is still in progress on
         // this same L2CAP connection.  Restarting BLE advertising mid-handshake
         // can disrupt the active connection on some Android devices.  The
-        // advertiser will be restarted in onSessionReady() once the full
+        // advertiser will be restarted in handleSessionReady() once the full
         // handshake completes.
-        advertiser?.deviceTag = E2ECrypto.deviceTag(sharedSecret)
+        advertiser?.deviceTag = pairingStore.identityTag()
 
         // Clear pairing state
         pairingInProgress = false
@@ -529,8 +603,9 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         pendingMacPublicKeyRaw = null
 
         // Clean up temporary prefs
-        getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+        prefs.edit()
             .remove("pending_pairing_pubkey")
+            .remove(KEY_PENDING_PAIRING_NAME)
             .apply()
 
         // Save device name
@@ -545,19 +620,19 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         val pairingIntent = Intent(ACTION_PAIRING_COMPLETE)
         pairingIntent.setPackage(packageName)
         pairingIntent.putExtra(EXTRA_DEVICE_TAG, deviceTagHex)
-        pairingIntent.putExtra(EXTRA_DEVICE_NAME, remoteName)
+        pairingIntent.putExtra(EXTRA_DEVICE_NAME, scannedName)
         sendBroadcast(pairingIntent)
-        publishDirectShareShortcut(remoteName)
+        publishDirectShareShortcut(directShareLabel())
     }
 
-    override fun onRichMediaSettingChanged(enabled: Boolean) {
+    private fun handleRichMediaSettingChanged(enabled: Boolean) {
         val intent = Intent(ACTION_RICH_MEDIA_SETTING_CHANGED)
         intent.setPackage(packageName)
         intent.putExtra(EXTRA_RICH_MEDIA_ENABLED, enabled)
         sendBroadcast(intent)
     }
 
-    override fun onImageSendFailed(reason: String) {
+    private fun handleImageSendFailed(reason: String) {
         Log.w(TAG, "Image send failed: $reason")
         Handler(Looper.getMainLooper()).post {
             android.widget.Toast.makeText(
@@ -568,14 +643,14 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         }
     }
 
-    override fun onImageReceived(data: ByteArray, contentType: String, hash: String) {
+    private fun handleImageReceived(data: ByteArray, contentType: String, hash: String) {
         lastReceivedImageHash = hash
         Log.w(TAG, "Received image from Mac (${data.size} bytes, $contentType)")
         clipboardWriter.writeImage(data, contentType)
         sendClipboardTransferBroadcast(fromMac = true)
     }
 
-    override fun isDeviceAwake(): Boolean {
+    private fun isDeviceAwakeNow(): Boolean {
         val pm = getSystemService(Context.POWER_SERVICE) as android.os.PowerManager
         val km = getSystemService(Context.KEYGUARD_SERVICE) as android.app.KeyguardManager
         return pm.isInteractive && !km.isDeviceLocked
@@ -599,13 +674,13 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         }
         lastSentTextHash = textHash
 
-        val session = activeSession
-        if (session == null) {
+        val targets = readySessions()
+        if (targets.isEmpty()) {
             Log.d(TAG, "No active L2CAP session; skipping Android->Mac push")
             return
         }
 
-        session.sendClipboard(plaintext)
+        targets.forEach { it.session?.sendClipboard(plaintext) }
         DebugSmokeProbe.onOutboundClipboardPublished(this, text)
     }
 
@@ -628,8 +703,8 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             return
         }
 
-        val session = activeSession
-        if (session == null) {
+        val targets = readySessions()
+        if (targets.isEmpty()) {
             Log.w(TAG, "No active session; cannot send image")
             Handler(Looper.getMainLooper()).post {
                 android.widget.Toast.makeText(this, "Not connected to Mac", android.widget.Toast.LENGTH_SHORT).show()
@@ -645,8 +720,8 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             return
         }
 
-        session.sendImage(imageData, mimeType)
-        Log.w(TAG, "Queued image for send (${imageData.size} bytes, $mimeType)")
+        targets.forEach { it.session?.sendImage(imageData, mimeType) }
+        Log.w(TAG, "Queued image for send to ${targets.size} Mac(s) (${imageData.size} bytes, $mimeType)")
     }
 
     // ── Pairing ────────────────────────────────────────────────────────
@@ -655,6 +730,12 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         val macPubKeyHex = prefs.getString("pending_pairing_pubkey", null) ?: return
         val macPubKeyRaw = E2ECrypto.hexToBytes(macPubKeyHex)
+
+        if (pairingStore.loadPairedMacs().size >= PairingStore.MAX_PAIRED_MACS) {
+            Log.w(TAG, "Pairing rejected: limit of ${PairingStore.MAX_PAIRED_MACS} Macs reached")
+            sendPairingStatus(PAIRING_STAGE_FAILED)
+            return
+        }
 
         // Replace any pairing already in flight (e.g. user re-scanned).
         clearPairingTimeout()
@@ -669,11 +750,17 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
 
         Log.w(TAG, "Started pairing mode with pairing tag")
 
-        // Restart BLE components with pairing tag
+        // Switch the advertisement to the pairing tag. Existing connections to
+        // other Macs stay up — only the advertiser cycles; the L2CAP server
+        // keeps listening on the same PSM.
         if (bleStarted) {
-            stopBleComponents(broadcastDisconnected = false)
+            advertiser?.deviceTag = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(macPubKeyRaw)
+                .copyOfRange(0, 8)
+            advertiser?.restart()
+        } else {
+            ensureBleComponentsState()
         }
-        ensureBleComponentsState()
 
         if (!bleStarted) {
             // BLE startup failed (e.g. Bluetooth off) — fail fast instead of
@@ -715,13 +802,21 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         pendingMacPublicKeyRaw = null
         getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
             .remove("pending_pairing_pubkey")
+            .remove(KEY_PENDING_PAIRING_NAME)
             .apply()
         if (broadcastFailed) {
             // Broadcast FAILED before tearing down BLE so the ViewModel is already
             // in Unpaired state when the disconnected broadcast arrives.
             sendPairingStatus(PAIRING_STAGE_FAILED)
         }
-        stopBleComponents(broadcastDisconnected = false)
+        if (isPaired && bleStarted) {
+            // Other Macs remain paired — go back to advertising the identity
+            // tag without dropping their live sessions.
+            advertiser?.deviceTag = pairingStore.identityTag()
+            advertiser?.restart()
+        } else {
+            stopBleComponents(broadcastDisconnected = false)
+        }
     }
 
     // ── Unpair ────────────────────────────────────────────────────────
@@ -740,6 +835,33 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
             stopBleComponents()
         } else {
             sendConnectionBroadcast(false)
+        }
+    }
+
+    /** Forget a single Mac (by PairedMac.id). Falls back to full unpair cleanup for the last one. */
+    private fun handleForgetDevice(deviceId: String) {
+        val mac = pairingStore.loadPairedMacs().firstOrNull { it.id == deviceId } ?: return
+        Log.w(TAG, "Forgetting paired Mac ${mac.name ?: deviceId}")
+        pairingStore.removePairedMac(mac.secretHex)
+
+        // Drop the live session for that Mac, if any
+        val doomed = synchronized(sessionLock) {
+            val matches = sessions.filter { it.secretHex == mac.secretHex }
+            sessions.removeAll(matches)
+            matches
+        }
+        doomed.forEach { it.close() }
+
+        if (!isPaired) {
+            // Last Mac forgotten — same cleanup as a full unpair
+            clipboardSettingsStore.setAutoCopyOnboardingShown(false)
+            clipboardSettingsStore.setAutoCopyEnabled(false)
+            removeDirectShareShortcut()
+            loadPairingState()
+            stopBleComponents()
+        } else {
+            publishDirectShareShortcut(directShareLabel())
+            broadcastConnectionState()
         }
     }
 
@@ -769,10 +891,11 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
     // ── Auto-copy (triggered by AccessibilityService) ────────────────
 
     private fun handleClipboardChanged() {
-        Log.d(TAG, "Clipboard changed — activeSession=${activeSession != null}, ghostInFlight=$ghostActivityInFlight")
+        val readyCount = readySessions().size
+        Log.d(TAG, "Clipboard changed — readySessions=$readyCount, ghostInFlight=$ghostActivityInFlight")
 
         // Skip if no active session (no Mac connected)
-        if (activeSession == null) {
+        if (readyCount == 0) {
             Log.d(TAG, "Skipping clipboard: no active session")
             return
         }
@@ -846,8 +969,37 @@ class ClipRelayService : Service(), L2capServerCallback, SessionCallback {
         val intent = Intent(ACTION_CONNECTION_STATE)
         intent.setPackage(packageName)
         intent.putExtra(EXTRA_CONNECTED, connected)
+        intent.putStringArrayListExtra(EXTRA_CONNECTED_IDS, ArrayList())
         if (deviceName != null) intent.putExtra(EXTRA_DEVICE_NAME, deviceName)
         sendBroadcast(intent)
+    }
+
+    /** Broadcast the full per-Mac connection state (ids of Macs with a ready session). */
+    private fun broadcastConnectionState() {
+        val macs = pairingStore.loadPairedMacs()
+        val ids = ArrayList<String>()
+        var firstName: String? = null
+        readySessions().forEach { handle ->
+            val mac = macs.firstOrNull { it.secretHex == handle.secretHex } ?: return@forEach
+            ids.add(mac.id)
+            if (firstName == null) firstName = mac.name ?: handle.session?.remoteName
+        }
+        val intent = Intent(ACTION_CONNECTION_STATE)
+        intent.setPackage(packageName)
+        intent.putExtra(EXTRA_CONNECTED, ids.isNotEmpty())
+        intent.putStringArrayListExtra(EXTRA_CONNECTED_IDS, ids)
+        firstName?.let { intent.putExtra(EXTRA_DEVICE_NAME, it) }
+        sendBroadcast(intent)
+    }
+
+    /** Share-sheet target label: single Mac shows its name, several show a collective label. */
+    private fun directShareLabel(): String? {
+        val macs = pairingStore.loadPairedMacs()
+        return when {
+            macs.isEmpty() -> null
+            macs.size == 1 -> macs[0].name ?: loadConnectedDeviceName()
+            else -> "All Macs"
+        }
     }
 
     // ── Preferences ───────────────────────────────────────────────────

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardTileService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardTileService.kt
@@ -25,7 +25,7 @@ class ClipboardTileService : TileService() {
         super.onClick()
 
         val pairingStore = PairingStore(this)
-        if (pairingStore.loadSharedSecret() == null) {
+        if (!pairingStore.hasPairedMacs()) {
             Log.d(TAG, "Not paired — ignoring tile tap")
             return
         }
@@ -52,11 +52,15 @@ class ClipboardTileService : TileService() {
     private fun updateTileState() {
         val tile = qsTile ?: return
         val pairingStore = PairingStore(this)
-        val isPaired = pairingStore.loadSharedSecret() != null
+        val macs = pairingStore.loadPairedMacs()
 
-        if (isPaired) {
-            val deviceName = getSharedPreferences(ClipRelayService.PREFS_NAME, MODE_PRIVATE)
-                .getString(ClipRelayService.KEY_CONNECTED_DEVICE, null)
+        if (macs.isNotEmpty()) {
+            val deviceName = if (macs.size == 1) {
+                macs[0].name ?: getSharedPreferences(ClipRelayService.PREFS_NAME, MODE_PRIVATE)
+                    .getString(ClipRelayService.KEY_CONNECTED_DEVICE, null)
+            } else {
+                "${macs.size} Macs"
+            }
             tile.label = getString(R.string.tile_label)
             tile.subtitle = deviceName
             tile.state = Tile.STATE_INACTIVE

--- a/android/app/src/main/java/org/cliprelay/ui/BeamCanvas.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/BeamCanvas.kt
@@ -35,8 +35,9 @@ fun BeamCanvas(
     when (state) {
         is AppState.Unpaired -> UnpairedBeam(modifier)
         is AppState.Pairing -> SearchingBeam(modifier)
-        is AppState.Searching -> SearchingBeam(modifier)
-        is AppState.Connected -> ConnectedBeam(clipboardTransferFlow, modifier)
+        is AppState.Paired ->
+            if (state.anyConnected) ConnectedBeam(clipboardTransferFlow, modifier)
+            else SearchingBeam(modifier)
     }
 }
 

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -93,7 +95,7 @@ fun ClipRelayScreen(
     onPairingCancelClick: () -> Unit = {},
     onPairingErrorDismiss: () -> Unit = {},
     onPairClick: () -> Unit,
-    onUnpairClick: () -> Unit,
+    onForgetMacClick: (String) -> Unit = {},
     onBurstShown: () -> Unit,
     onAutoClearSettingChanged: (Boolean) -> Unit,
     onAutoCopySettingChanged: (Boolean) -> Unit,
@@ -102,7 +104,7 @@ fun ClipRelayScreen(
     onHelpClick: () -> Unit = {},
     onSupportLinkClick: (String) -> Unit = {},
 ) {
-    val isConnected = state is AppState.Connected
+    val isConnected = state is AppState.Paired && state.anyConnected
     val isPaired = state !is AppState.Unpaired
 
     val bgTop by animateColorAsState(
@@ -159,45 +161,59 @@ fun ClipRelayScreen(
                 )
             }
     ) {
-        Column(
+        // Scrollable so the footer stays reachable when the Mac list grows the
+        // card beyond the screen. When everything fits, SpaceBetween with a
+        // min-height of the viewport reproduces the old centered layout.
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding()
-                .navigationBarsPadding(),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .navigationBarsPadding()
         ) {
-            Spacer(modifier = Modifier.height(12.dp))
-            StatusChip(state = state)
-            Spacer(modifier = Modifier.weight(1f))
-            MainCard(
-                state = state,
-                clipboardTransferFlow = clipboardTransferFlow,
-                autoClearEnabled = autoClearEnabled,
-                autoCopyEnabled = autoCopyEnabled,
-                autoCopyAccessibilityEnabled = autoCopyAccessibilityEnabled,
-                imageSyncEnabled = imageSyncEnabled,
-                pairingFailed = pairingFailed,
-                onPairingCancelClick = onPairingCancelClick,
-                onPairingErrorDismiss = onPairingErrorDismiss,
-                onPairClick = onPairClick,
-                onUnpairClick = onUnpairClick,
-                onAutoClearSettingChanged = onAutoClearSettingChanged,
-                onAutoCopySettingChanged = onAutoCopySettingChanged,
-                onImageSyncSettingChanged = onImageSyncSettingChanged,
-                onAutoCopyFixClick = onAutoCopyFixClick
-            )
-            Spacer(modifier = Modifier.weight(1f))
+            val viewportHeight = maxHeight
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .heightIn(min = viewportHeight),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Spacer(modifier = Modifier.height(12.dp))
+                StatusChip(state = state)
+            }
+            Box(modifier = Modifier.padding(vertical = 16.dp)) {
+                MainCard(
+                    state = state,
+                    clipboardTransferFlow = clipboardTransferFlow,
+                    autoClearEnabled = autoClearEnabled,
+                    autoCopyEnabled = autoCopyEnabled,
+                    autoCopyAccessibilityEnabled = autoCopyAccessibilityEnabled,
+                    imageSyncEnabled = imageSyncEnabled,
+                    pairingFailed = pairingFailed,
+                    onPairingCancelClick = onPairingCancelClick,
+                    onPairingErrorDismiss = onPairingErrorDismiss,
+                    onPairClick = onPairClick,
+                    onForgetMacClick = onForgetMacClick,
+                    onAutoClearSettingChanged = onAutoClearSettingChanged,
+                    onAutoCopySettingChanged = onAutoCopySettingChanged,
+                    onImageSyncSettingChanged = onImageSyncSettingChanged,
+                    onAutoCopyFixClick = onAutoCopyFixClick
+                )
+            }
             FooterSection(
                 isPaired = isPaired,
                 bleState = when {
                     isConnected -> "connected"
-                    state is AppState.Searching -> "searching"
+                    state is AppState.Paired -> "searching"
                     state is AppState.Pairing -> "searching"
                     else -> "unpaired"
                 },
                 onHelpClick = onHelpClick,
                 onSupportLinkClick = onSupportLinkClick,
             )
+            }
         }
 
         // Pairing burst overlay
@@ -227,17 +243,19 @@ private fun StatusChip(state: AppState) {
             text = Teal,
             label = "Pairing…"
         )
-        is AppState.Searching -> ChipStyle(
-            bg = Color(0x1400FFD5),
-            dot = Color(0xFFBDBDBD),
-            text = Teal,
-            label = "Searching for Mac"
-        )
-        is AppState.Connected -> ChipStyle(
+        is AppState.Paired -> if (state.anyConnected) ChipStyle(
             bg = Color(0x1A00FFD5),
             dot = Aqua,
             text = Teal,
-            label = "Connected"
+            label = when {
+                state.macs.size == 1 -> "Connected"
+                else -> "Connected to ${state.connectedCount} of ${state.macs.size} Macs"
+            }
+        ) else ChipStyle(
+            bg = Color(0x1400FFD5),
+            dot = Color(0xFFBDBDBD),
+            text = Teal,
+            label = if (state.macs.size == 1) "Searching for Mac" else "Searching for Macs"
         )
     }
 
@@ -246,7 +264,7 @@ private fun StatusChip(state: AppState) {
             .clip(RoundedCornerShape(20.dp))
             .background(bgColor)
             .then(
-                if (state is AppState.Connected)
+                if (state is AppState.Paired && state.anyConnected)
                     Modifier.border(1.dp, Aqua.copy(alpha = 0.3f), RoundedCornerShape(20.dp))
                 else Modifier
             )
@@ -254,7 +272,7 @@ private fun StatusChip(state: AppState) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         // Animated dot for Searching/Pairing states
-        if (state is AppState.Searching || state is AppState.Pairing) {
+        if ((state is AppState.Paired && !state.anyConnected) || state is AppState.Pairing) {
             BlinkingDot(color = dotColor)
         } else {
             Box(
@@ -311,45 +329,40 @@ private fun MainCard(
     onPairingCancelClick: () -> Unit = {},
     onPairingErrorDismiss: () -> Unit = {},
     onPairClick: () -> Unit,
-    onUnpairClick: () -> Unit,
+    onForgetMacClick: (String) -> Unit = {},
     onAutoClearSettingChanged: (Boolean) -> Unit,
     onAutoCopySettingChanged: (Boolean) -> Unit,
     onImageSyncSettingChanged: (Boolean) -> Unit = {},
     onAutoCopyFixClick: () -> Unit = {}
 ) {
     val isPaired = state !is AppState.Unpaired
-    val isConnected = state is AppState.Connected
+    val isConnected = state is AppState.Paired && state.anyConnected
+    val macs = (state as? AppState.Paired)?.macs ?: emptyList()
 
     val cardTopColor by animateColorAsState(
-        targetValue = when (state) {
-            is AppState.Unpaired -> Color.White
-            is AppState.Pairing -> Color(0xFFF5FFFC)
-            is AppState.Searching -> Color(0xFFF5FFFC)
-            is AppState.Connected -> Color(0xFFF0FFFC)
+        targetValue = when {
+            state is AppState.Unpaired -> Color.White
+            isConnected -> Color(0xFFF0FFFC)
+            else -> Color(0xFFF5FFFC)
         },
         animationSpec = tween(600),
         label = "cardTop"
     )
 
     val borderColor by animateColorAsState(
-        targetValue = when (state) {
-            is AppState.Unpaired -> Color(0x1400FFD5)
-            is AppState.Pairing -> Color(0x1F00FFD5)
-            is AppState.Searching -> Color(0x1F00FFD5)
-            is AppState.Connected -> Color(0x3300FFD5)
+        targetValue = when {
+            state is AppState.Unpaired -> Color(0x1400FFD5)
+            isConnected -> Color(0x3300FFD5)
+            else -> Color(0x1F00FFD5)
         },
         animationSpec = tween(600),
         label = "cardBorder"
     )
 
-    val deviceName = when (state) {
-        is AppState.Connected -> state.deviceName
-        is AppState.Searching -> state.deviceName
-        else -> null
-    }
-    val deviceTag = when (state) {
-        is AppState.Connected -> state.deviceTag
-        is AppState.Searching -> state.deviceTag
+    // Node label: single Mac shows its name; several show a count.
+    val deviceName = when {
+        macs.size == 1 -> macs[0].name
+        macs.size > 1 -> "${macs.size} Macs"
         else -> null
     }
 
@@ -476,14 +489,6 @@ private fun MainCard(
                         color = Teal.copy(alpha = 0.4f),
                         fontWeight = FontWeight.Medium
                     )
-                    if (deviceTag != null) {
-                        Text(
-                            text = "Pairing: $deviceTag",
-                            fontSize = 11.sp,
-                            color = Teal.copy(alpha = 0.45f),
-                            fontWeight = FontWeight.Normal
-                        )
-                    }
                 }
                 }
 
@@ -552,35 +557,21 @@ private fun MainCard(
                     )
                 }
             } else {
-                val unpairBg by animateColorAsState(
-                    targetValue = if (isConnected) Color(0x1400FFD5) else Color(0x0F00FFD5),
-                    animationSpec = tween(400),
-                    label = "unpairBg"
-                )
-                val unpairBorder by animateColorAsState(
-                    targetValue = if (isConnected) Color(0x2600FFD5) else Color(0x1A00FFD5),
-                    animationSpec = tween(400),
-                    label = "unpairBorder"
-                )
-                Button(
-                    onClick = onUnpairClick,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(1.dp, unpairBorder, RoundedCornerShape(28.dp)),
-                    shape = RoundedCornerShape(28.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = unpairBg,
-                        contentColor = Teal
-                    ),
-                    elevation = ButtonDefaults.buttonElevation(0.dp, 0.dp, 0.dp)
-                ) {
-                    Text(
-                        text = "Unpair",
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.Medium,
-                        modifier = Modifier.padding(vertical = 4.dp)
+                if (pairingFailed) {
+                    PairingFailedCard(
+                        onTryAgain = {
+                            onPairingErrorDismiss()
+                            onPairClick()
+                        },
+                        onDismiss = onPairingErrorDismiss
                     )
+                    Spacer(modifier = Modifier.height(12.dp))
                 }
+                MacListSection(
+                    macs = macs,
+                    onForgetMacClick = onForgetMacClick,
+                    onPairAnotherClick = onPairClick
+                )
             }
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -642,6 +633,111 @@ private fun PairingStatusRow(
                 color = Teal.copy(alpha = 0.6f),
                 fontSize = 13.sp
             )
+        }
+    }
+}
+
+// ─── Paired Mac List ─────────────────────────────────────────────────────────
+@Composable
+private fun MacListSection(
+    macs: List<PairedMacUi>,
+    onForgetMacClick: (String) -> Unit,
+    onPairAnotherClick: () -> Unit
+) {
+    var macPendingForget by remember { mutableStateOf<PairedMacUi?>(null) }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        macs.forEachIndexed { index, mac ->
+            MacRow(mac = mac, onForgetClick = { macPendingForget = mac })
+            if (index < macs.lastIndex) Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        if (macs.size < org.cliprelay.pairing.PairingStore.MAX_PAIRED_MACS) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = onPairAnotherClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(1.dp, Color(0x1A00FFD5), RoundedCornerShape(28.dp)),
+                shape = RoundedCornerShape(28.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0x0F00FFD5),
+                    contentColor = Teal
+                ),
+                elevation = ButtonDefaults.buttonElevation(0.dp, 0.dp, 0.dp)
+            ) {
+                Text(
+                    text = "+ Pair another Mac",
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+            }
+        }
+    }
+
+    macPendingForget?.let { mac ->
+        AlertDialog(
+            onDismissRequest = { macPendingForget = null },
+            title = { Text("Forget ${mac.name ?: "this Mac"}?") },
+            text = { Text("This Mac will no longer sync with your phone. You can pair it again anytime.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    onForgetMacClick(mac.id)
+                    macPendingForget = null
+                }) {
+                    Text("Forget", color = Color(0xFFB71C1C), fontWeight = FontWeight.SemiBold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { macPendingForget = null }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun MacRow(mac: PairedMacUi, onForgetClick: () -> Unit) {
+    val rowBg = if (mac.connected) Color(0x1400FFD5) else Color(0x08000000)
+    val rowBorder = if (mac.connected) Color(0x2B00FFD5) else Color(0x14000000)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(rowBg)
+            .border(1.dp, rowBorder, RoundedCornerShape(18.dp))
+            .padding(start = 14.dp, end = 4.dp, top = 6.dp, bottom = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (mac.connected) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(Aqua)
+            )
+        } else {
+            BlinkingDot(color = Color(0xFFBDBDBD))
+        }
+        Spacer(modifier = Modifier.width(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = mac.name ?: "Mac",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xCC000000),
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+            )
+            Text(
+                text = (if (mac.connected) "Connected" else "Searching") + " · ${mac.tagDisplay}",
+                fontSize = 11.sp,
+                color = Color(0x73000000)
+            )
+        }
+        TextButton(onClick = onForgetClick) {
+            Text(text = "Forget", fontSize = 12.sp, color = Color(0x80000000))
         }
     }
 }
@@ -890,7 +986,7 @@ private fun DeviceNode(
     label: String
 ) {
     val isPaired = state !is AppState.Unpaired
-    val isConnected = state is AppState.Connected
+    val isConnected = state is AppState.Paired && state.anyConnected
     // Phone is "active" once paired; Mac is active only when connected
     val isActive = if (isPhone) isPaired else isConnected
 

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
-import org.cliprelay.crypto.E2ECrypto
 import org.cliprelay.pairing.PairingStore
 import org.cliprelay.permissions.BlePermissions
 import org.cliprelay.service.ClipboardAccessibilityService
@@ -40,13 +39,13 @@ class MainActivity : AppCompatActivity() {
         override fun onReceive(context: Context?, intent: Intent?) {
             when (intent?.action) {
                 ClipRelayService.ACTION_CONNECTION_STATE -> {
-                    val connected = intent.getBooleanExtra(ClipRelayService.EXTRA_CONNECTED, false)
-                    val name = intent.getStringExtra(ClipRelayService.EXTRA_DEVICE_NAME)
-                    viewModel.onConnectionChanged(connected, name)
+                    val connectedIds =
+                        intent.getStringArrayListExtra(ClipRelayService.EXTRA_CONNECTED_IDS)
+                            ?: arrayListOf()
+                    viewModel.onMacsChanged(loadMacsForUi(connectedIds.toSet()))
                 }
                 ClipRelayService.ACTION_PAIRING_COMPLETE -> {
-                    val deviceTag = intent.getStringExtra(ClipRelayService.EXTRA_DEVICE_TAG)
-                    viewModel.onPaired(deviceTag)
+                    viewModel.onPaired(loadMacsForUi(emptySet()))
                     requestBatteryOptimizationAndOnboarding()
                 }
                 ClipRelayService.ACTION_PAIRING_STATUS -> {
@@ -118,18 +117,10 @@ class MainActivity : AppCompatActivity() {
         clipboardSettingsStore = ClipboardSettingsStore(this)
 
         val pairingStore = PairingStore(this)
-        val secret = pairingStore.loadSharedSecret()
-        val isPaired = secret != null
-        val deviceName = getSharedPreferences(ClipRelayService.PREFS_NAME, MODE_PRIVATE)
-            .getString(ClipRelayService.KEY_CONNECTED_DEVICE, null)
-        val deviceTag = secret?.let { s ->
-            val hex = E2ECrypto.deviceTag(s).take(4).joinToString("") { "%02X".format(it) }
-            hex.chunked(4).joinToString(" ")
-        }
         val autoClearEnabled = clipboardSettingsStore.isAutoClearSyncedClipboardEnabled()
         val autoCopyEnabled = clipboardSettingsStore.isAutoCopyEnabled()
         val imageSyncEnabled = pairingStore.isRichMediaEnabled()
-        viewModel.initState(isPaired, deviceName, deviceTag, autoClearEnabled, autoCopyEnabled, imageSyncEnabled)
+        viewModel.initState(loadMacsForUi(emptySet()), autoClearEnabled, autoCopyEnabled, imageSyncEnabled)
 
         setContent {
             val state by viewModel.state.collectAsState()
@@ -183,13 +174,19 @@ class MainActivity : AppCompatActivity() {
                 onPairClick = {
                     scannerLauncher.launch(Intent(this, QrScannerActivity::class.java))
                 },
-                onUnpairClick = {
-                    viewModel.onUnpaired()
-                    val unpairIntent = Intent(this, ClipRelayService::class.java)
-                    unpairIntent.action = ClipRelayService.ACTION_UNPAIR
-                    if (!startServiceSafely(unpairIntent)) {
-                        PairingStore(this).clear()
+                onForgetMacClick = { macId ->
+                    val forgetIntent = Intent(this, ClipRelayService::class.java)
+                    forgetIntent.action = ClipRelayService.ACTION_FORGET_DEVICE
+                    forgetIntent.putExtra(ClipRelayService.EXTRA_DEVICE_ID, macId)
+                    if (!startServiceSafely(forgetIntent)) {
+                        // Service unavailable (e.g. missing BLE permissions) — remove directly.
+                        val store = PairingStore(this)
+                        store.loadPairedMacs().firstOrNull { it.id == macId }
+                            ?.let { store.removePairedMac(it.secretHex) }
                     }
+                    // The service removes the pairing asynchronously — drop it
+                    // from the UI immediately rather than waiting for the broadcast.
+                    viewModel.onMacForgotten(loadMacsForUi(emptySet()).filterNot { it.id == macId })
                 },
                 onBurstShown = {
                     viewModel.onBurstShown()
@@ -252,6 +249,12 @@ class MainActivity : AppCompatActivity() {
         super.onPause()
         unregisterReceiver(connectionReceiver)
     }
+
+    /** Read the paired Macs from the store and apply per-Mac connection flags. */
+    private fun loadMacsForUi(connectedIds: Set<String>): List<PairedMacUi> =
+        PairingStore(this).loadPairedMacs().map { mac ->
+            PairedMacUi(id = mac.id, name = mac.name, connected = mac.id in connectedIds)
+        }
 
     private fun ensureServiceRunning() {
         startServiceSafely(Intent(this, ClipRelayService::class.java))

--- a/android/app/src/main/java/org/cliprelay/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainViewModel.kt
@@ -1,6 +1,6 @@
 package org.cliprelay.ui
 
-// ViewModel exposing app state (pairing, connection, transfer events) to the Compose UI.
+// ViewModel exposing app state (pairing, per-Mac connection, transfer events) to the Compose UI.
 
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -11,16 +11,31 @@ import kotlinx.coroutines.flow.asStateFlow
 
 enum class PairingStage { Connecting, ExchangingKeys }
 
+/** One paired Mac as shown in the UI. [id] is PairedMac.id (device-tag hex). */
+data class PairedMacUi(
+    val id: String,
+    val name: String?,
+    val connected: Boolean = false
+) {
+    /** Short human-checkable pairing code, e.g. "AB12 CD34". */
+    val tagDisplay: String get() = id.take(8).uppercase().chunked(4).joinToString(" ")
+}
+
 sealed class AppState {
     object Unpaired : AppState()
     data class Pairing(val stage: PairingStage) : AppState()
-    data class Searching(val deviceName: String? = null, val deviceTag: String? = null) : AppState()
-    data class Connected(val deviceName: String?, val deviceTag: String? = null) : AppState()
+    data class Paired(val macs: List<PairedMacUi>) : AppState() {
+        val anyConnected: Boolean get() = macs.any { it.connected }
+        val connectedCount: Int get() = macs.count { it.connected }
+    }
 }
 
 class MainViewModel : ViewModel() {
     private val _state = MutableStateFlow<AppState>(AppState.Unpaired)
     val state: StateFlow<AppState> = _state.asStateFlow()
+
+    /** Last known paired Macs (with connection flags), kept across Pairing state. */
+    private var macs: List<PairedMacUi> = emptyList()
 
     private val _showBurst = MutableStateFlow(false)
     val showBurst: StateFlow<Boolean> = _showBurst.asStateFlow()
@@ -47,15 +62,30 @@ class MainViewModel : ViewModel() {
     private val _clipboardTransfer = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
     val clipboardTransfer: SharedFlow<Boolean> = _clipboardTransfer
 
-    fun initState(isPaired: Boolean, deviceName: String? = null, deviceTag: String? = null, autoClearEnabled: Boolean = false, autoCopyEnabled: Boolean = false, imageSyncEnabled: Boolean = false) {
-        _state.value = if (isPaired) AppState.Searching(deviceName, deviceTag) else AppState.Unpaired
+    fun initState(
+        macs: List<PairedMacUi>,
+        autoClearEnabled: Boolean = false,
+        autoCopyEnabled: Boolean = false,
+        imageSyncEnabled: Boolean = false
+    ) {
+        this.macs = macs
+        refreshPairedState()
         _autoClearEnabled.value = autoClearEnabled
         _autoCopyEnabled.value = autoCopyEnabled
         _imageSyncEnabled.value = imageSyncEnabled
     }
 
-    fun onPaired(deviceTag: String? = null) {
-        _state.value = AppState.Searching(deviceTag = deviceTag)
+    /** Paired list or per-Mac connection flags changed (store re-read / connection broadcast). */
+    fun onMacsChanged(macs: List<PairedMacUi>) {
+        this.macs = macs
+        // Don't let connection broadcasts kick us out of an in-progress pairing.
+        if (_state.value is AppState.Pairing) return
+        refreshPairedState()
+    }
+
+    fun onPaired(macs: List<PairedMacUi>) {
+        this.macs = macs
+        refreshPairedState()
         _pairingFailed.value = false
         _showBurst.value = true
     }
@@ -72,12 +102,12 @@ class MainViewModel : ViewModel() {
 
     fun onPairingFailed() {
         if (_state.value !is AppState.Pairing) return
-        _state.value = AppState.Unpaired
+        refreshPairedState()
         _pairingFailed.value = true
     }
 
     fun onPairingCancelled() {
-        _state.value = AppState.Unpaired
+        refreshPairedState()
         _pairingFailed.value = false
     }
 
@@ -90,21 +120,21 @@ class MainViewModel : ViewModel() {
     }
 
     fun onUnpaired() {
+        macs = emptyList()
         _state.value = AppState.Unpaired
         _autoCopyEnabled.value = false
     }
 
-    fun onConnectionChanged(connected: Boolean, deviceName: String?) {
-        // Don't let stale connection broadcasts override the Unpaired state,
-        // and don't let "disconnected" answers kick us out of an in-progress pairing.
-        if (_state.value is AppState.Unpaired) return
-        if (_state.value is AppState.Pairing && !connected) return
-        val currentTag = when (val s = _state.value) {
-            is AppState.Searching -> s.deviceTag
-            is AppState.Connected -> s.deviceTag
-            else -> null
+    fun onMacForgotten(remaining: List<PairedMacUi>) {
+        macs = remaining
+        refreshPairedState()
+        if (remaining.isEmpty()) {
+            _autoCopyEnabled.value = false
         }
-        _state.value = if (connected) AppState.Connected(deviceName, currentTag) else AppState.Searching(deviceName, currentTag)
+    }
+
+    private fun refreshPairedState() {
+        _state.value = if (macs.isEmpty()) AppState.Unpaired else AppState.Paired(macs)
     }
 
     fun onClipboardTransfer(fromMac: Boolean) {

--- a/android/app/src/main/java/org/cliprelay/ui/QrScannerActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/QrScannerActivity.kt
@@ -66,7 +66,7 @@ class QrScannerActivity : AppCompatActivity() {
         val prefs = getSharedPreferences(ClipRelayService.PREFS_NAME, MODE_PRIVATE)
         prefs.edit()
             .putString("pending_pairing_pubkey", info.publicKeyHex)
-            .putString(ClipRelayService.KEY_CONNECTED_DEVICE, info.deviceName ?: "")
+            .putString(ClipRelayService.KEY_PENDING_PAIRING_NAME, info.deviceName ?: "")
             .apply()
 
         // Signal the service to start pairing mode

--- a/android/app/src/test/java/org/cliprelay/pairing/PairingStoreTest.kt
+++ b/android/app/src/test/java/org/cliprelay/pairing/PairingStoreTest.kt
@@ -6,12 +6,16 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Unit tests for PairingStore rich media settings.
+ * Unit tests for PairingStore multi-Mac storage, identity tag, migration,
+ * and rich media settings.
  * Uses an in-memory SharedPreferences fake so no Android context is needed.
  */
 class PairingStoreTest {
 
     private lateinit var store: PairingStore
+
+    private val secretA = "aa".repeat(32)
+    private val secretB = "bb".repeat(32)
 
     @Before
     fun setUp() {
@@ -56,17 +60,101 @@ class PairingStoreTest {
     }
 
     @Test
-    fun `clear also resets shared secret`() {
-        store.saveSharedSecret("abc123")
+    fun `clear also resets paired macs and identity tag`() {
+        store.addPairedMac(secretA, "Mac A")
         store.clear()
-        assertNull(store.loadSharedSecret())
+        assertTrue(store.loadPairedMacs().isEmpty())
+        assertNull(store.identityTagHex())
     }
 
     @Test
-    fun `shared secret round-trip still works`() {
-        val secret = "deadbeef"
-        assertTrue(store.saveSharedSecret(secret))
-        assertEquals(secret, store.loadSharedSecret())
+    fun `paired mac round-trip`() {
+        assertTrue(store.addPairedMac(secretA, "Mac A", pairedAtMs = 42L))
+        val macs = store.loadPairedMacs()
+        assertEquals(1, macs.size)
+        assertEquals(secretA, macs[0].secretHex)
+        assertEquals("Mac A", macs[0].name)
+        assertEquals(42L, macs[0].pairedAtMs)
+    }
+
+    @Test
+    fun `first pairing sets identity tag from secret`() {
+        store.addPairedMac(secretA, "Mac A")
+        val expected = org.cliprelay.crypto.E2ECrypto.deviceTag(secretA)
+            .joinToString("") { "%02x".format(it) }
+        assertEquals(expected, store.identityTagHex())
+    }
+
+    @Test
+    fun `second pairing keeps the original identity tag`() {
+        store.addPairedMac(secretA, "Mac A")
+        val tag = store.identityTagHex()
+        store.addPairedMac(secretB, "Mac B")
+        assertEquals(tag, store.identityTagHex())
+        assertEquals(2, store.loadPairedMacs().size)
+    }
+
+    @Test
+    fun `identity tag survives removal of the first mac while others remain`() {
+        store.addPairedMac(secretA, "Mac A")
+        val tag = store.identityTagHex()
+        store.addPairedMac(secretB, "Mac B")
+        store.removePairedMac(secretA)
+        assertEquals(tag, store.identityTagHex())
+        assertEquals(listOf(secretB), store.loadPairedMacs().map { it.secretHex })
+    }
+
+    @Test
+    fun `removing the last mac clears the identity tag`() {
+        store.addPairedMac(secretA, "Mac A")
+        store.removePairedMac(secretA)
+        assertTrue(store.loadPairedMacs().isEmpty())
+        assertNull(store.identityTagHex())
+    }
+
+    @Test
+    fun `re-adding the same secret replaces instead of duplicating`() {
+        store.addPairedMac(secretA, "Old Name")
+        store.addPairedMac(secretA, "New Name")
+        val macs = store.loadPairedMacs()
+        assertEquals(1, macs.size)
+        assertEquals("New Name", macs[0].name)
+    }
+
+    @Test
+    fun `addPairedMac enforces the limit`() {
+        repeat(PairingStore.MAX_PAIRED_MACS) { i ->
+            assertTrue(store.addPairedMac("%02x".format(i + 1).repeat(32), "Mac $i"))
+        }
+        assertFalse(store.addPairedMac("ff".repeat(32), "One Too Many"))
+        assertEquals(PairingStore.MAX_PAIRED_MACS, store.loadPairedMacs().size)
+    }
+
+    @Test
+    fun `updateMacName renames an existing pairing`() {
+        store.addPairedMac(secretA, null)
+        store.updateMacName(secretA, "Christian's Mac")
+        assertEquals("Christian's Mac", store.loadPairedMacs()[0].name)
+    }
+
+    @Test
+    fun `legacy single secret migrates to paired macs list with identity tag`() {
+        val legacyPrefs = FakeSharedPreferences()
+        legacyPrefs.edit().putString(PairingStore.KEY_SHARED_SECRET, secretA).apply()
+        val migrated = PairingStore(legacyPrefs)
+        assertEquals(listOf(secretA), migrated.loadPairedMacs().map { it.secretHex })
+        val expectedTag = org.cliprelay.crypto.E2ECrypto.deviceTag(secretA)
+            .joinToString("") { "%02x".format(it) }
+        assertEquals(expectedTag, migrated.identityTagHex())
+        assertNull(legacyPrefs.getString(PairingStore.KEY_SHARED_SECRET, null))
+    }
+
+    @Test
+    fun `mac id is stable and derived from secret`() {
+        store.addPairedMac(secretA, "Mac A")
+        val expected = org.cliprelay.crypto.E2ECrypto.deviceTag(secretA)
+            .joinToString("") { "%02x".format(it) }
+        assertEquals(expected, store.loadPairedMacs()[0].id)
     }
 }
 

--- a/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
+++ b/android/app/src/test/java/org/cliprelay/protocol/SessionTest.kt
@@ -1801,6 +1801,104 @@ class SessionTest {
         return SessionEnvHolder(SessionEnv(macSession, androidSession, macCallback, androidCallback))
     }
 
+    // ── Candidate-secret (multi-Mac) handshake tests ─────────────────
+
+    @Test
+    fun `responder with candidate secrets matches the connecting mac`() {
+        val otherSecret = "11".repeat(32)
+        val env = createSessionsWithCandidates(
+            macSecret = testSharedSecret,
+            candidates = listOf(otherSecret, testSharedSecret)
+        )
+        val readyLatch = CountDownLatch(2)
+        env.macCallback.onReady = { readyLatch.countDown() }
+        env.androidCallback.onReady = { readyLatch.countDown() }
+
+        startBothSessions(env)
+
+        assertTrue("Both sessions should become ready", readyLatch.await(5, TimeUnit.SECONDS))
+        assertEquals(testSharedSecret, env.androidSession.matchedSecretHex)
+        cleanup(env)
+    }
+
+    @Test
+    fun `responder with candidate secrets transfers clipboard end to end`() {
+        val env = createSessionsWithCandidates(
+            macSecret = testSharedSecret,
+            candidates = listOf("22".repeat(32), testSharedSecret, "33".repeat(32))
+        )
+        val receivedLatch = CountDownLatch(1)
+        var received: ByteArray? = null
+        env.androidCallback.onReceived = { plaintext, _ ->
+            received = plaintext
+            receivedLatch.countDown()
+        }
+        val readyLatch = CountDownLatch(2)
+        env.macCallback.onReady = { readyLatch.countDown() }
+        env.androidCallback.onReady = { readyLatch.countDown() }
+
+        startBothSessions(env)
+        assertTrue(readyLatch.await(5, TimeUnit.SECONDS))
+
+        env.macSession.sendClipboard("hello from mac".toByteArray())
+
+        assertTrue("Clipboard should arrive", receivedLatch.await(5, TimeUnit.SECONDS))
+        assertEquals("hello from mac", String(received!!))
+        cleanup(env)
+    }
+
+    @Test
+    fun `responder rejects mac whose secret is not among candidates`() {
+        val env = createSessionsWithCandidates(
+            macSecret = testSharedSecret,
+            candidates = listOf("44".repeat(32), "55".repeat(32))
+        )
+        val errorLatch = CountDownLatch(1)
+        var capturedError: Exception? = null
+        env.androidCallback.onError = { e ->
+            capturedError = e
+            errorLatch.countDown()
+        }
+
+        startBothSessions(env)
+
+        assertTrue("Responder should fail auth", errorLatch.await(5, TimeUnit.SECONDS))
+        assertTrue(
+            "Error should mention authentication",
+            capturedError!!.message!!.contains("Authentication")
+        )
+        cleanup(env)
+    }
+
+    /** Like createPairedSessions, but the Android responder gets a candidate list instead of a single secret. */
+    private fun createSessionsWithCandidates(macSecret: String, candidates: List<String>): SessionEnv {
+        val macToAndroidOut = PipedOutputStream()
+        val macToAndroidIn = PipedInputStream(macToAndroidOut)
+        val androidToMacOut = PipedOutputStream()
+        val androidToMacIn = PipedInputStream(androidToMacOut)
+
+        val macCallback = TestCallback()
+        val androidCallback = TestCallback()
+
+        val macSession = Session(
+            input = androidToMacIn,
+            output = macToAndroidOut,
+            isInitiator = true,
+            callback = macCallback,
+            sharedSecretHex = macSecret
+        )
+
+        val androidSession = Session(
+            input = macToAndroidIn,
+            output = androidToMacOut,
+            isInitiator = false,
+            callback = androidCallback,
+            candidateSecretsHex = candidates
+        )
+
+        return SessionEnv(macSession, androidSession, macCallback, androidCallback)
+    }
+
     private fun startBothSessions(env: SessionEnv) {
         val macThread = Thread {
             env.macSession.performHandshake()

--- a/android/app/src/test/java/org/cliprelay/ui/MainViewModelTest.kt
+++ b/android/app/src/test/java/org/cliprelay/ui/MainViewModelTest.kt
@@ -7,6 +7,9 @@ import org.junit.Test
 
 class MainViewModelTest {
 
+    private val macA = PairedMacUi(id = "aabbccdd00112233", name = "Mac A")
+    private val macB = PairedMacUi(id = "eeff445566778899", name = "Mac B")
+
     @Test
     fun pairingStarted_entersConnectingState_andClearsFailedFlag() {
         val vm = MainViewModel()
@@ -27,9 +30,9 @@ class MainViewModelTest {
     @Test
     fun pairingStatus_ignoredWhenNotPairing() {
         val vm = MainViewModel()
-        vm.initState(isPaired = true, deviceName = "Mac")
+        vm.initState(macs = listOf(macA))
         vm.onPairingStatus(PairingStage.ExchangingKeys)
-        assertTrue(vm.state.value is AppState.Searching)
+        assertTrue(vm.state.value is AppState.Paired)
     }
 
     @Test
@@ -42,12 +45,22 @@ class MainViewModelTest {
     }
 
     @Test
+    fun pairingFailed_withExistingMacs_revertsToPairedAndSetsFlag() {
+        val vm = MainViewModel()
+        vm.initState(macs = listOf(macA))
+        vm.onPairingStarted()
+        vm.onPairingFailed()
+        assertEquals(AppState.Paired(listOf(macA)), vm.state.value)
+        assertTrue(vm.pairingFailed.value)
+    }
+
+    @Test
     fun pairingFailed_afterPairingComplete_isIgnored() {
         val vm = MainViewModel()
         vm.onPairingStarted()
-        vm.onPaired(deviceTag = "AB12 CD34")
+        vm.onPaired(listOf(macA))
         vm.onPairingFailed()
-        assertTrue(vm.state.value is AppState.Searching)
+        assertTrue(vm.state.value is AppState.Paired)
         assertFalse(vm.pairingFailed.value)
     }
 
@@ -73,8 +86,8 @@ class MainViewModelTest {
     fun disconnectedBroadcast_doesNotKickOutOfPairingState() {
         val vm = MainViewModel()
         vm.onPairingStarted()
-        // Service answers ACTION_QUERY_CONNECTION with connected=false on resume
-        vm.onConnectionChanged(connected = false, deviceName = null)
+        // Service answers ACTION_QUERY_CONNECTION with no connected Macs on resume
+        vm.onMacsChanged(emptyList())
         assertEquals(AppState.Pairing(PairingStage.Connecting), vm.state.value)
     }
 
@@ -82,8 +95,43 @@ class MainViewModelTest {
     fun pairedThenConnected_reachesConnectedState() {
         val vm = MainViewModel()
         vm.onPairingStarted()
-        vm.onPaired(deviceTag = "AB12 CD34")
-        vm.onConnectionChanged(connected = true, deviceName = "Mac")
-        assertTrue(vm.state.value is AppState.Connected)
+        vm.onPaired(listOf(macA))
+        vm.onMacsChanged(listOf(macA.copy(connected = true)))
+        val state = vm.state.value
+        assertTrue(state is AppState.Paired && state.anyConnected)
+    }
+
+    @Test
+    fun multipleMacs_partialConnection_reportsCounts() {
+        val vm = MainViewModel()
+        vm.initState(macs = listOf(macA, macB))
+        vm.onMacsChanged(listOf(macA.copy(connected = true), macB))
+        val state = vm.state.value as AppState.Paired
+        assertTrue(state.anyConnected)
+        assertEquals(1, state.connectedCount)
+        assertEquals(2, state.macs.size)
+    }
+
+    @Test
+    fun forgettingLastMac_returnsToUnpaired_andDisablesAutoCopy() {
+        val vm = MainViewModel()
+        vm.initState(macs = listOf(macA), autoCopyEnabled = true)
+        vm.onMacForgotten(emptyList())
+        assertEquals(AppState.Unpaired, vm.state.value)
+        assertFalse(vm.autoCopyEnabled.value)
+    }
+
+    @Test
+    fun forgettingOneOfTwoMacs_staysPaired() {
+        val vm = MainViewModel()
+        vm.initState(macs = listOf(macA, macB), autoCopyEnabled = true)
+        vm.onMacForgotten(listOf(macB))
+        assertEquals(AppState.Paired(listOf(macB)), vm.state.value)
+        assertTrue(vm.autoCopyEnabled.value)
+    }
+
+    @Test
+    fun tagDisplay_formatsFirstFourBytes() {
+        assertEquals("AABB CCDD", macA.tagDisplay)
     }
 }

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -264,17 +264,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 // MARK: - ConnectionControllerDelegate
 
 extension AppDelegate: ConnectionControllerDelegate {
-    func didChangeState(connected: Bool, deviceName: String?, token: String?) {
-        if connected, let deviceName, let token {
-            let peer = PeerSummary(
+    func didChangeState(connectedTokens: [String]) {
+        statusBarController.setConnectedPeers(peerSummaries(for: connectedTokens))
+    }
+
+    private func peerSummaries(for tokens: [String]) -> [PeerSummary] {
+        let devices = pairingManager.loadDevices()
+        return tokens.compactMap { token in
+            guard let device = devices.first(where: { $0.sharedSecret == token }) else { return nil }
+            return PeerSummary(
                 id: deviceStableID(token: token),
-                description: deviceName,
+                description: device.displayName,
                 secret: token,
                 deviceTagHex: formattedDeviceTagHex(token: token)
             )
-            statusBarController.setConnectedPeers([peer])
-        } else {
-            statusBarController.setConnectedPeers([])
         }
     }
 
@@ -347,10 +350,8 @@ extension AppDelegate: ConnectionControllerDelegate {
 
     func didChangeImageSyncSetting(enabled: Bool) {
         // Refresh the menu to update the checkmark
-        if let cc = connectionController, let token = cc.connectedToken {
-            let deviceName = cc.pairedDevices.first(where: { $0.sharedSecret == token })?.displayName ?? "Android"
-            let peer = PeerSummary(id: deviceStableID(token: token), description: deviceName, secret: token, deviceTagHex: formattedDeviceTagHex(token: token))
-            statusBarController.setConnectedPeers([peer])
+        if let cc = connectionController {
+            statusBarController.setConnectedPeers(peerSummaries(for: cc.connectedTokens))
         }
     }
 

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -371,7 +371,7 @@ class ConnectionController: NSObject {
 
     private func pairedDeviceTags() -> [(token: String, tag: Data)] {
         pairingManager.loadDevices().compactMap { device in
-            guard let tag = pairingManager.deviceTag(for: device.sharedSecret) else { return nil }
+            guard let tag = pairingManager.scanTag(for: device) else { return nil }
             return (token: device.sharedSecret, tag: tag)
         }
     }
@@ -823,7 +823,8 @@ extension ConnectionController {
                 let updated = PairedDevice(sharedSecret: existing.sharedSecret, displayName: name,
                                            datePaired: existing.datePaired,
                                            richMediaEnabled: existing.richMediaEnabled,
-                                           richMediaEnabledChangedAt: existing.richMediaEnabledChangedAt)
+                                           richMediaEnabledChangedAt: existing.richMediaEnabledChangedAt,
+                                           advertTagHex: existing.advertTagHex)
                 pairingManager.addDevice(updated)
             }
         }
@@ -884,7 +885,11 @@ extension ConnectionController {
     fileprivate func handlePairingComplete(sharedSecret: Data, remoteName: String?) {
         let secretHex = sharedSecret.map { String(format: "%02x", $0) }.joined()
         log("Pairing complete")
-        let device = PairedDevice(sharedSecret: secretHex, displayName: remoteName ?? "Android", datePaired: Date())
+        // The phone's stable identity tag arrived in KEY_EXCHANGE (nil on the
+        // phone's first pairing — it then advertises the secret-derived tag).
+        let advertTagHex = activeSession(from: state)?.remoteAdvertTagHex
+        let device = PairedDevice(sharedSecret: secretHex, displayName: remoteName ?? "Android",
+                                  datePaired: Date(), advertTagHex: advertTagHex)
         pairingManager.addDevice(device)
         pairingManager.clearEphemeralKey()
         // Wire settings provider (hold strong ref via settingsProviderRef so weak var isn't immediately nil)

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -489,7 +489,12 @@ extension ConnectionController {
         queue.async { [self] in
             guard let data = text.data(using: .utf8) else { return }
             let hash = Session.sha256Hex(data)
-            pendingClipboard = data
+            // Don't cache text we just received for reconnect-replay — it would
+            // be sent back to its originator when that device reconnects.
+            // (Live relay to *other* devices below is unaffected.)
+            if hash != lastReceivedTextHash {
+                pendingClipboard = data
+            }
             var sentCount = 0
             for device in devices.values where device.state.isReady {
                 // Skip the device that delivered this text to us (echo guard);

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -1,52 +1,94 @@
-// Unified BLE connection controller: owns the full lifecycle from scanning through
-// session ready state, with a single cleanup path and generation-based cancellation.
+// BLE connection controller: maintains one connection per paired Android device
+// concurrently. Each device has its own small state machine, backoff, and session;
+// scanning runs whenever any paired device is unconnected (or pairing is active).
 
 import CoreBluetooth
 import CryptoKit
 import Foundation
 import os
 
-// MARK: - Connection State
+// MARK: - Per-Device State
 
-enum ConnectionState: CustomStringConvertible {
+enum DeviceState: CustomStringConvertible {
     case idle
-    case scanning
-    case bleConnecting(CBPeripheral, CBL2CAPPSM, token: String, generation: UInt)
-    case l2capOpening(CBPeripheral, token: String, generation: UInt)
-    case pairingConnecting(CBPeripheral, CBL2CAPPSM, generation: UInt)
-    case pairingL2CAP(CBPeripheral, generation: UInt)
-    case pairingHandshake(Session, generation: UInt)
-    case handshaking(Session, token: String, generation: UInt)
-    case ready(Session, token: String, generation: UInt)
-
-    var generation: UInt? {
-        switch self {
-        case .idle, .scanning:
-            return nil
-        case .bleConnecting(_, _, _, let g),
-             .l2capOpening(_, _, let g),
-             .pairingConnecting(_, _, let g),
-             .pairingL2CAP(_, let g),
-             .pairingHandshake(_, let g),
-             .handshaking(_, _, let g),
-             .ready(_, _, let g):
-            return g
-        }
-    }
+    case bleConnecting(CBL2CAPPSM)
+    case l2capOpening
+    case handshaking(Session)
+    case ready(Session)
 
     var description: String {
         switch self {
         case .idle: return "idle"
-        case .scanning: return "scanning"
-        case .bleConnecting(_, let psm, _, let g): return "bleConnecting(psm=\(psm), gen=\(g))"
-        case .l2capOpening(_, _, let g): return "l2capOpening(gen=\(g))"
-        case .pairingConnecting(_, let psm, let g): return "pairingConnecting(psm=\(psm), gen=\(g))"
-        case .pairingL2CAP(_, let g): return "pairingL2CAP(gen=\(g))"
-        case .pairingHandshake(_, let g): return "pairingHandshake(gen=\(g))"
-        case .handshaking(_, _, let g): return "handshaking(gen=\(g))"
-        case .ready(_, _, let g): return "ready(gen=\(g))"
+        case .bleConnecting(let psm): return "bleConnecting(psm=\(psm))"
+        case .l2capOpening: return "l2capOpening"
+        case .handshaking: return "handshaking"
+        case .ready: return "ready"
         }
     }
+
+    var session: Session? {
+        switch self {
+        case .handshaking(let s), .ready(let s): return s
+        default: return nil
+        }
+    }
+
+    var isReady: Bool {
+        if case .ready = self { return true }
+        return false
+    }
+
+    var isIdle: Bool {
+        if case .idle = self { return true }
+        return false
+    }
+}
+
+/// Exponential reconnect backoff: 1, 2, 4, ... capped at maxReconnectDelay.
+struct ReconnectBackoff {
+    private(set) var delay: TimeInterval = 1.0
+
+    mutating func next() -> TimeInterval {
+        let current = delay
+        delay = min(delay * 2, ConnectionController.maxReconnectDelay)
+        return current
+    }
+
+    mutating func reset() {
+        delay = 1.0
+    }
+}
+
+/// Connection bookkeeping for one paired Android device. Only accessed on the
+/// controller's serial queue.
+final class DeviceConnection {
+    let token: String
+    var state: DeviceState = .idle
+    /// Peripheral of the current attempt/connection (kept outside `state` so it
+    /// can always be cancelled during teardown).
+    var peripheral: CBPeripheral?
+    /// The open L2CAP channel. Must stay retained — releasing a CBL2CAPChannel
+    /// closes the underlying connection.
+    var channel: CBL2CAPChannel?
+    var connectingStartTime: Date?
+    var backoff = ReconnectBackoff()
+    /// Earliest time the next connect attempt may start (per-device flap guard).
+    var nextAttemptAt = Date.distantPast
+    var adapter: SessionAdapter?
+    var settingsProvider: DeviceSettingsProvider?
+
+    init(token: String) {
+        self.token = token
+    }
+}
+
+// MARK: - Pairing State
+
+private enum PairingPhase {
+    case scanning
+    case connecting(CBPeripheral, CBL2CAPPSM)
+    case l2capOpening(CBPeripheral)
+    case handshake(Session)
 }
 
 // MARK: - Connection Error
@@ -60,7 +102,7 @@ enum ConnectionError {
 // MARK: - Delegate
 
 protocol ConnectionControllerDelegate: AnyObject {
-    func didChangeState(connected: Bool, deviceName: String?, token: String?)
+    func didChangeState(connectedTokens: [String])
     func didReceiveClipboard(text: String)
     func didReceiveImage(data: Data, contentType: String)
     func didCompletePairing(deviceName: String?)
@@ -88,30 +130,27 @@ class ConnectionController: NSObject {
 
     // MARK: State
 
-    /// Internal state — only access from the connection queue.
-    private(set) var state: ConnectionState = .idle
+    /// One connection record per paired device, keyed by token. Queue-only.
+    private(set) var devices: [String: DeviceConnection] = [:]
+    /// Bumped when everything is torn down (BT off, disconnect) so in-flight
+    /// session callbacks from before the teardown are ignored.
     private(set) var generation: UInt = 0
     weak var delegate: ConnectionControllerDelegate?
 
-    /// Main-thread-safe cached values, updated on every state transition.
-    /// Use these from AppDelegate/UI closures instead of reading `state` directly.
+    /// Main-thread-safe cached values, updated on every readiness change.
     private(set) var isConnected: Bool = false
-    private(set) var connectedToken: String?
+    private(set) var connectedTokens: [String] = []
+    var connectedToken: String? { connectedTokens.first }
 
     // MARK: BLE
 
     private var centralManager: CBCentralManager!
-    private var l2capChannel: CBL2CAPChannel?
-    private var connectingStartTime: Date?
-    /// Last peripheral we attempted to connect to. Retained across transitionToIdle
-    /// so we can re-cancel it when BT powers on (cancelPeripheralConnection during
-    /// BT-off may be a no-op, leaving internal CB connection bookkeeping dangling).
-    private var lastAttemptedPeripheral: CBPeripheral?
+    /// Peripherals from attempts that may have dangling CoreBluetooth connection
+    /// bookkeeping (e.g. cancel during BT-off is a no-op). Re-cancelled at poweredOn.
+    private var staleAttemptedPeripherals: [CBPeripheral] = []
 
-    // MARK: Reconnect
+    // MARK: Timers
 
-    private var reconnectDelay: TimeInterval = 1.0
-    private var reconnectTimer: DispatchSourceTimer?
     private var healthCheckTimer: DispatchSourceTimer?
 
     // MARK: Pairing
@@ -119,13 +158,12 @@ class ConnectionController: NSObject {
     private let pairingManager: PairingManager
     private var pairingTag: Data?
     private var pairingPrivateKey: Curve25519.KeyAgreement.PrivateKey?
-
-    // MARK: Session Adapter
-
-    /// Retained to prevent adapter deallocation during session lifetime.
-    fileprivate var currentAdapter: SessionAdapter?
-    /// Strong reference to settings provider (Session.settingsProvider is weak).
-    private var settingsProviderRef: DeviceSettingsProvider?
+    private var pairingPhase: PairingPhase = .scanning
+    private var pairingPeripheral: CBPeripheral?
+    /// Retained for the same reason as DeviceConnection.channel.
+    private var pairingChannel: CBL2CAPChannel?
+    private var pairingConnectingStartTime: Date?
+    private var pairingAdapter: SessionAdapter?
 
     // MARK: Dedup
 
@@ -161,115 +199,72 @@ class ConnectionController: NSObject {
         logger.notice("\(message, privacy: .public)")
     }
 
-    // MARK: - State Transitions
+    // MARK: - Device list
 
-    private func transition(to newState: ConnectionState, reason: String) {
-        let wasReady = isReady(state)
-        let oldDesc = state.description
-        state = newState
-        let nowReady = isReady(state)
-        log("[\(reason)] \(oldDesc) → \(newState)")
-
-        if wasReady != nowReady {
-            let token: String?
-            let deviceName: String?
-            switch newState {
-            case .ready(_, let t, _):
-                token = t
-                deviceName = pairingManager.loadDevices().first(where: { $0.sharedSecret == t })?.displayName
-            default:
-                token = nil
-                deviceName = nil
+    /// Reconcile the per-device connection records with the pairing store.
+    private func syncDevicesWithStore() {
+        let stored = Set(pairingManager.loadDevices().map(\.sharedSecret))
+        for token in stored where devices[token] == nil {
+            devices[token] = DeviceConnection(token: token)
+        }
+        for token in devices.keys where !stored.contains(token) {
+            if let device = devices[token] {
+                closeConnection(of: device)
             }
-            let connected = nowReady
-            // Update main-thread-safe cached values
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.isConnected = connected
-                self.connectedToken = token
-                self.delegate?.didChangeState(connected: connected, deviceName: deviceName, token: token)
-            }
+            devices.removeValue(forKey: token)
         }
     }
 
-    private func isReady(_ state: ConnectionState) -> Bool {
-        if case .ready = state { return true }
-        return false
-    }
-
-    // MARK: - Cleanup (single path)
-
-    private func transitionToIdle(reason: String, reconnect: Bool, preservePairingContext: Bool = false) {
-        // Cancel peripheral connection if we have one
-        if let peripheral = trackedPeripheral(from: state) ?? lastAttemptedPeripheral {
+    /// Tear down a device's session/peripheral and return it to idle.
+    /// Does NOT notify the delegate — callers decide.
+    private func closeConnection(of device: DeviceConnection) {
+        device.state.session?.close()
+        if let peripheral = device.peripheral {
             centralManager?.cancelPeripheralConnection(peripheral)
+            staleAttemptedPeripherals.append(peripheral)
         }
+        device.peripheral = nil
+        device.channel = nil
+        device.connectingStartTime = nil
+        device.adapter = nil
+        device.settingsProvider = nil
+        device.state = .idle
+    }
 
-        // Stop scanning
-        if case .scanning = state {
-            centralManager?.stopScan()
+    /// A connect attempt failed or the connection dropped: back off and retry
+    /// via scanning.
+    private func failAttempt(_ device: DeviceConnection, reason: String) {
+        let wasReady = device.state.isReady
+        let delay = device.backoff.next()
+        log("[\(reason)] \(device.token.prefix(8))… \(device.state) → idle (retry in \(String(format: "%.1f", delay))s)")
+        closeConnection(of: device)
+        device.nextAttemptAt = Date().addingTimeInterval(delay)
+        if wasReady {
+            notifyConnectionChanged()
         }
+        ensureScanning()
+    }
 
-        // Close session if active
-        if let session = activeSession(from: state) {
-            session.close()
-        }
+    // MARK: - Scanning
 
-        // Clear all connection state (pendingClipboard intentionally preserved
-        // across reconnection cycles so it can be sent after reconnecting)
-        l2capChannel = nil
-        connectingStartTime = nil
-        if !preservePairingContext {
-            pairingTag = nil
-            pairingPrivateKey = nil
-        }
-        settingsProviderRef = nil
-
-        // Increment generation so any in-flight callbacks from the old connection are ignored
-        generation &+= 1
-
-        transition(to: .idle, reason: reason)
-
-        if reconnect {
-            scheduleReconnect()
+    /// Start or stop scanning based on need: scanning runs while pairing is
+    /// active or any paired device is unconnected.
+    fileprivate func ensureScanning() {
+        guard let centralManager, centralManager.state == .poweredOn else { return }
+        let needScan = pairingTag != nil || devices.values.contains { $0.state.isIdle }
+        if needScan && !centralManager.isScanning {
+            log("Scanning (paired: \(devices.count), pairing: \(pairingTag != nil))")
+            centralManager.scanForPeripherals(
+                withServices: [Self.serviceUUID],
+                options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
+            )
+        } else if !needScan && centralManager.isScanning {
+            log("All paired devices connected — stopping scan")
+            centralManager.stopScan()
         }
     }
 
-    // MARK: - State Helpers
-
-    private func trackedPeripheral(from state: ConnectionState) -> CBPeripheral? {
-        switch state {
-        case .bleConnecting(let p, _, _, _),
-             .l2capOpening(let p, _, _),
-             .pairingConnecting(let p, _, _),
-             .pairingL2CAP(let p, _):
-            return p
-        case .idle, .scanning, .pairingHandshake, .handshaking, .ready:
-            return nil
-        }
-    }
-
-    private func activeSession(from state: ConnectionState) -> Session? {
-        switch state {
-        case .pairingHandshake(let s, _),
-             .handshaking(let s, _, _),
-             .ready(let s, _, _):
-            return s
-        default:
-            return nil
-        }
-    }
-
-    private func shouldPreservePairingContext(for state: ConnectionState) -> Bool {
-        switch state {
-        case .pairingConnecting, .pairingL2CAP, .pairingHandshake:
-            return true
-        default:
-            return false
-        }
-    }
-
-    // MARK: - Timers
+    // MARK: - Health Check
 
     private func startHealthCheck() {
         healthCheckTimer?.cancel()
@@ -280,100 +275,110 @@ class ConnectionController: NSObject {
         healthCheckTimer = timer
     }
 
-    private func scheduleReconnect() {
-        reconnectTimer?.cancel()
-        let delay = reconnectDelay
-        log("Scheduling reconnect in \(String(format: "%.1f", delay))s")
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + delay)
-        timer.setEventHandler { [weak self] in
-            guard let self else { return }
-            self.reconnectTimer = nil
-            self.startScanning()
-        }
-        timer.resume()
-        reconnectTimer = timer
-        reconnectDelay = min(reconnectDelay * 2, Self.maxReconnectDelay)
-    }
-
-    // MARK: - Scanning
-
-    func startScanning() {
-        dispatchPrecondition(condition: .onQueue(queue))
-        guard let centralManager else {
-            log("startScanning: no central manager")
-            return
-        }
-        guard centralManager.state == .poweredOn else {
-            log("startScanning: BT not poweredOn (\(centralManager.state.rawValue))")
-            return
-        }
-        guard case .idle = state else {
-            log("startScanning: not idle (\(state))")
-            return
-        }
-        log("Scanning (paired: \(pairedDeviceTags().count))")
-        transition(to: .scanning, reason: "startScanning")
-        centralManager.scanForPeripherals(
-            withServices: [Self.serviceUUID],
-            options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
-        )
-    }
-
-    // MARK: - Health Check
-
     private func performHealthCheck() {
         dispatchPrecondition(condition: .onQueue(queue))
-        guard centralManager.state == .poweredOn else { return }
+        guard let centralManager, centralManager.state == .poweredOn else { return }
 
-        switch state {
-        case .bleConnecting, .l2capOpening, .pairingConnecting, .pairingL2CAP:
-            if let start = connectingStartTime,
-               Date().timeIntervalSince(start) > Self.connectingTimeout {
-                log("Health check: connecting timed out")
-                transitionToIdle(
-                    reason: "connectingTimeout",
-                    reconnect: true,
-                    preservePairingContext: shouldPreservePairingContext(for: state)
-                )
+        // Per-device connecting timeout
+        for device in devices.values {
+            switch device.state {
+            case .bleConnecting, .l2capOpening:
+                if let start = device.connectingStartTime,
+                   Date().timeIntervalSince(start) > Self.connectingTimeout {
+                    failAttempt(device, reason: "connectingTimeout")
+                }
+            default:
+                break
             }
-        case .scanning:
-            // Cycle the scan to pick up new advertisements
-            centralManager.stopScan()
-            centralManager.scanForPeripherals(
-                withServices: [Self.serviceUUID],
-                options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
-            )
-        case .idle:
-            resetReconnectDelay()
-            startScanning()
-        case .handshaking, .ready:
-            break
-        case .pairingHandshake:
-            break
         }
+
+        // Pairing connecting timeout
+        if pairingTag != nil {
+            switch pairingPhase {
+            case .connecting, .l2capOpening:
+                if let start = pairingConnectingStartTime,
+                   Date().timeIntervalSince(start) > Self.connectingTimeout {
+                    log("Health check: pairing connect timed out — back to scanning")
+                    abortPairingAttempt()
+                }
+            default:
+                break
+            }
+        }
+
+        // Cycle the scan to pick up new advertisements
+        if centralManager.isScanning {
+            centralManager.stopScan()
+        }
+        ensureScanning()
     }
 
-    // MARK: - Reconnect Delay
+    // MARK: - Teardown
 
-    func resetReconnectDelay() {
-        reconnectDelay = 1.0
+    /// Tear down all connections (BT off, app shutdown). Preserves pairing
+    /// context when requested so pairing resumes once BT returns.
+    private func teardownAll(reason: String, preservePairingContext: Bool) {
+        log("[\(reason)] tearing down all connections")
+        for device in devices.values {
+            closeConnection(of: device)
+            device.backoff.reset()
+            device.nextAttemptAt = .distantPast
+        }
+        if case .handshake(let session) = pairingPhase {
+            session.close()
+        }
+        if let peripheral = pairingPeripheral {
+            centralManager?.cancelPeripheralConnection(peripheral)
+            staleAttemptedPeripherals.append(peripheral)
+        }
+        pairingPeripheral = nil
+        pairingChannel = nil
+        pairingConnectingStartTime = nil
+        pairingAdapter = nil
+        pairingPhase = .scanning
+        if !preservePairingContext {
+            pairingTag = nil
+            pairingPrivateKey = nil
+        }
+        if centralManager?.isScanning == true {
+            centralManager?.stopScan()
+        }
+        generation &+= 1
+        notifyConnectionChanged()
     }
 
-    @discardableResult
-    func nextReconnectDelay() -> TimeInterval {
-        let current = reconnectDelay
-        reconnectDelay = min(reconnectDelay * 2, Self.maxReconnectDelay)
-        return current
+    // MARK: - Notifications
+
+    fileprivate func notifyConnectionChanged() {
+        let readyTokens = devices.values
+            .filter { $0.state.isReady }
+            .map(\.token)
+            .sorted()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isConnected = !readyTokens.isEmpty
+            self.connectedTokens = readyTokens
+            self.delegate?.didChangeState(connectedTokens: readyTokens)
+        }
     }
 
     // MARK: - Paired Device Lookup
 
-    private func pairedDeviceTags() -> [(token: String, tag: Data)] {
-        pairingManager.loadDevices().compactMap { device in
-            guard let tag = pairingManager.scanTag(for: device) else { return nil }
-            return (token: device.sharedSecret, tag: tag)
+    private func device(matching tag: Data) -> DeviceConnection? {
+        let stored = pairingManager.loadDevices()
+        for paired in stored {
+            guard pairingManager.scanTag(for: paired) == tag else { continue }
+            return devices[paired.sharedSecret]
         }
+        return nil
+    }
+
+    private func device(of peripheral: CBPeripheral) -> DeviceConnection? {
+        devices.values.first { $0.peripheral === peripheral }
+    }
+
+    private func device(of session: Session) -> DeviceConnection? {
+        devices.values.first { $0.state.session === session }
     }
 
     // MARK: - Manufacturer Data Extraction
@@ -397,9 +402,7 @@ class ConnectionController: NSObject {
             guard let self else { return }
             self.healthCheckTimer?.cancel()
             self.healthCheckTimer = nil
-            self.reconnectTimer?.cancel()
-            self.reconnectTimer = nil
-            self.transitionToIdle(reason: "disconnect", reconnect: false)
+            self.teardownAll(reason: "disconnect", preservePairingContext: false)
         }
     }
 }
@@ -415,8 +418,7 @@ extension ConnectionController {
     // MARK: Pairing
 
     /// Start pairing flow. Generates ECDH key pair, returns QR URI.
-    /// PairingManager operations happen on the calling thread (main).
-    /// BLE scanning dispatched to connection queue.
+    /// Existing device connections stay up — only the scan gains a pairing tag.
     func startPairing() -> PairingInfo? {
         pairingManager.removePendingDevices()
         let privateKey = pairingManager.generateKeyPair()
@@ -425,12 +427,8 @@ extension ConnectionController {
         queue.async { [self] in
             pairingPrivateKey = privateKey
             pairingTag = tag
-            transitionToIdle(
-                reason: "entering pairing mode",
-                reconnect: false,
-                preservePairingContext: true
-            )
-            startScanning()
+            pairingPhase = .scanning
+            ensureScanning()
         }
         return PairingInfo(uri: uri)
     }
@@ -439,14 +437,29 @@ extension ConnectionController {
         queue.async { [self] in
             pairingManager.clearEphemeralKey()
             pairingManager.removePendingDevices()
-            switch state {
-            case .scanning, .pairingConnecting, .pairingL2CAP, .pairingHandshake:
-                transitionToIdle(reason: "pairing cancelled", reconnect: false)
-            default:
-                pairingTag = nil
-                pairingPrivateKey = nil
-            }
+            abortPairingAttempt()
+            pairingTag = nil
+            pairingPrivateKey = nil
+            ensureScanning()
         }
+    }
+
+    /// Abort an in-flight pairing connection attempt, returning the pairing
+    /// flow to scanning (pairing tag/key stay set unless cleared by caller).
+    fileprivate func abortPairingAttempt() {
+        if case .handshake(let session) = pairingPhase {
+            session.close()
+        }
+        if let peripheral = pairingPeripheral {
+            centralManager?.cancelPeripheralConnection(peripheral)
+            staleAttemptedPeripherals.append(peripheral)
+        }
+        pairingPeripheral = nil
+        pairingChannel = nil
+        pairingConnectingStartTime = nil
+        pairingAdapter = nil
+        pairingPhase = .scanning
+        ensureScanning()
     }
 
     // MARK: Sending
@@ -455,11 +468,18 @@ extension ConnectionController {
         queue.async { [self] in
             guard let data = text.data(using: .utf8) else { return }
             let hash = Session.sha256Hex(data)
-            guard hash != lastReceivedTextHash else { return }
             pendingClipboard = data
-            if case .ready(let session, _, _) = state {
-                session.sendClipboard(data)
-                log("Queued clipboard (\(data.count) bytes)")
+            var sentCount = 0
+            for device in devices.values where device.state.isReady {
+                // Skip the device that delivered this text to us (echo guard);
+                // other devices still receive it, which relays a clipboard
+                // from one phone to the rest.
+                if device.adapter?.lastTextHash == hash { continue }
+                device.state.session?.sendClipboard(data)
+                sentCount += 1
+            }
+            if sentCount > 0 {
+                log("Queued clipboard (\(data.count) bytes) to \(sentCount) device(s)")
             } else {
                 log("Clipboard cached for reconnect (\(data.count) bytes)")
             }
@@ -470,9 +490,10 @@ extension ConnectionController {
         queue.async { [self] in
             let hash = Session.sha256Hex(data)
             guard hash != lastReceivedImageHash else { return }
-            guard case .ready(let session, let token, _) = state else { return }
-            guard imageSyncEnabled(for: token) else { return }
-            session.sendImage(data, contentType: contentType)
+            for device in devices.values where device.state.isReady {
+                guard imageSyncEnabled(for: device.token) else { continue }
+                device.state.session?.sendImage(data, contentType: contentType)
+            }
         }
     }
 
@@ -481,25 +502,17 @@ extension ConnectionController {
     func forgetDevice(token: String, completion: (() -> Void)? = nil) {
         queue.async { [self] in
             pairingManager.removeDevice(secret: token)
-            defer {
-                if let completion {
-                    DispatchQueue.main.async(execute: completion)
+            if let device = devices[token] {
+                let wasReady = device.state.isReady
+                closeConnection(of: device)
+                devices.removeValue(forKey: token)
+                if wasReady {
+                    notifyConnectionChanged()
                 }
             }
-            switch state {
-            case .ready(_, let t, _) where t == token:
-                transitionToIdle(reason: "device forgotten", reconnect: false)
-            case .handshaking(_, let t, _) where t == token:
-                transitionToIdle(reason: "device forgotten", reconnect: false)
-            case .bleConnecting(_, _, let t, _) where t == token:
-                transitionToIdle(reason: "device forgotten", reconnect: false)
-            case .l2capOpening(_, let t, _) where t == token:
-                transitionToIdle(reason: "device forgotten", reconnect: false)
-            default:
-                break
-            }
-            if case .idle = state, !pairingManager.loadDevices().isEmpty {
-                startScanning()
+            ensureScanning()
+            if let completion {
+                DispatchQueue.main.async(execute: completion)
             }
         }
     }
@@ -510,28 +523,30 @@ extension ConnectionController {
 
     // MARK: Settings
 
+    /// Toggle image sync. With multiple connected devices the new value is
+    /// applied to all of them (the setting syncs last-write-wins anyway).
     func toggleImageSync() {
         queue.async { [self] in
-            let secret: String?
-            if case .ready(_, let token, _) = state {
-                secret = token
-            } else {
-                secret = pairingManager.loadDevices().first?.sharedSecret
-            }
-            guard let secret else { return }
-            let devices = pairingManager.loadDevices()
-            guard let device = devices.first(where: { $0.sharedSecret == secret }) else { return }
-            let newEnabled = !device.richMediaEnabled
+            let readyTokens = devices.values.filter { $0.state.isReady }.map(\.token)
+            let targets = readyTokens.isEmpty
+                ? pairingManager.loadDevices().prefix(1).map(\.sharedSecret)
+                : readyTokens
+            guard let first = targets.first else { return }
+            let current = pairingManager.loadDevices()
+                .first(where: { $0.sharedSecret == first })?.richMediaEnabled ?? false
+            let newEnabled = !current
             let changedAt = Int64(Date().timeIntervalSince1970)
-            pairingManager.setRichMediaEnabled(newEnabled, changedAt: changedAt, forSecret: secret)
-            if case .ready(let session, _, _) = state {
-                session.sendConfigUpdate()
+            for token in targets {
+                pairingManager.setRichMediaEnabled(newEnabled, changedAt: changedAt, forSecret: token)
             }
-            log("Image sync toggled to \(newEnabled)")
+            for device in devices.values where device.state.isReady {
+                device.state.session?.sendConfigUpdate()
+            }
+            log("Image sync toggled to \(newEnabled) for \(targets.count) device(s)")
         }
     }
 
-    /// Safe to call from main thread — uses cached `connectedToken`.
+    /// Safe to call from main thread — uses cached `connectedTokens`.
     var isImageSyncEnabled: Bool {
         guard let secret = connectedToken else { return false }
         return imageSyncEnabled(for: secret)
@@ -550,21 +565,23 @@ extension ConnectionController: CBCentralManagerDelegate {
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         log("BT state: \(central.state.rawValue)")
         if central.state == .poweredOn {
-            // Re-cancel any peripheral from before the power cycle. cancelPeripheralConnection
+            // Re-cancel peripherals from before the power cycle. cancelPeripheralConnection
             // during BT-off is a no-op, so internal CB connection bookkeeping can accumulate
-            // across brief power nap cycles (BT on for ~2s, off, repeat). Re-cancelling now
-            // that BT is back on releases those dangling slots.
-            if let stale = lastAttemptedPeripheral {
+            // across brief power nap cycles. Re-cancelling now releases dangling slots.
+            for stale in staleAttemptedPeripherals {
                 central.cancelPeripheralConnection(stale)
-                lastAttemptedPeripheral = nil
             }
-            resetReconnectDelay()
+            staleAttemptedPeripherals.removeAll()
+            syncDevicesWithStore()
+            for device in devices.values {
+                device.backoff.reset()
+                device.nextAttemptAt = .distantPast
+            }
             startHealthCheck()
-            startScanning()
+            ensureScanning()
         } else {
-            transitionToIdle(
+            teardownAll(
                 reason: "BT state \(central.state.rawValue)",
-                reconnect: false,
                 preservePairingContext: pairingTag != nil
             )
         }
@@ -580,70 +597,60 @@ extension ConnectionController: CBCentralManagerDelegate {
         advertisementData: [String: Any],
         rssi RSSI: NSNumber
     ) {
-        guard case .scanning = state else { return }
-
         guard let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data,
               let deviceTag = Self.extractDeviceTag(from: manufacturerData),
               let psm = Self.extractPSM(from: manufacturerData)
         else { return }
 
-        // Check for active pairing request
+        // Active pairing request takes priority
         if let pairingTag, pairingTag == deviceTag {
-            central.stopScan()
-            generation &+= 1
-            transition(
-                to: .pairingConnecting(peripheral, psm, generation: generation),
-                reason: "pairingDiscovered"
-            )
-            connectingStartTime = Date()
-            lastAttemptedPeripheral = peripheral
+            guard case .scanning = pairingPhase else { return }
+            log("Pairing target discovered, PSM=\(psm), RSSI=\(RSSI)")
+            pairingPhase = .connecting(peripheral, psm)
+            pairingPeripheral = peripheral
+            pairingConnectingStartTime = Date()
             peripheral.delegate = self
             central.connect(peripheral, options: nil)
+            ensureScanning()
             return
         }
 
-        // In pairing mode, only match the pairing tag — don't connect to existing paired devices
+        // In pairing mode, only match the pairing tag — don't start new
+        // connections to existing paired devices (live ones stay connected).
         if pairingTag != nil { return }
 
-        // Check against paired devices
-        let paired = pairedDeviceTags()
-        if let matched = paired.first(where: { $0.tag == deviceTag }) {
-            log("Matched device tag, PSM=\(psm), RSSI=\(RSSI)")
-            central.stopScan()
-            generation &+= 1
-            transition(
-                to: .bleConnecting(peripheral, psm, token: matched.token, generation: generation),
-                reason: "pairedDeviceDiscovered"
-            )
-            connectingStartTime = Date()
-            lastAttemptedPeripheral = peripheral
-            peripheral.delegate = self
-            central.connect(peripheral, options: nil)
-        }
+        // Match against paired devices that are idle and past their backoff
+        guard let device = device(matching: deviceTag),
+              device.state.isIdle,
+              Date() >= device.nextAttemptAt
+        else { return }
+
+        log("Matched device tag for \(device.token.prefix(8))…, PSM=\(psm), RSSI=\(RSSI)")
+        device.state = .bleConnecting(psm)
+        device.peripheral = peripheral
+        device.connectingStartTime = Date()
+        peripheral.delegate = self
+        central.connect(peripheral, options: nil)
+        // Keep scanning if other devices are still unconnected
+        ensureScanning()
     }
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        switch state {
-        case .bleConnecting(_, let psm, let token, let gen) where gen == generation:
-            transition(
-                to: .l2capOpening(peripheral, token: token, generation: gen),
-                reason: "didConnect"
-            )
-            connectingStartTime = Date()  // reset for L2CAP open timeout
+        if peripheral === pairingPeripheral, case .connecting(_, let psm) = pairingPhase {
+            pairingPhase = .l2capOpening(peripheral)
+            pairingConnectingStartTime = Date()  // reset for L2CAP open timeout
             peripheral.openL2CAPChannel(psm)
-
-        case .pairingConnecting(_, let psm, let gen) where gen == generation:
-            transition(
-                to: .pairingL2CAP(peripheral, generation: gen),
-                reason: "didConnect(pairing)"
-            )
-            connectingStartTime = Date()  // reset for L2CAP open timeout
-            peripheral.openL2CAPChannel(psm)
-
-        default:
-            log("Stale didConnect (\(state)), cancelling")
-            central.cancelPeripheralConnection(peripheral)
+            return
         }
+
+        guard let device = device(of: peripheral), case .bleConnecting(let psm) = device.state else {
+            log("Stale didConnect, cancelling")
+            central.cancelPeripheralConnection(peripheral)
+            return
+        }
+        device.state = .l2capOpening
+        device.connectingStartTime = Date()  // reset for L2CAP open timeout
+        peripheral.openL2CAPChannel(psm)
     }
 
     func centralManager(
@@ -653,11 +660,13 @@ extension ConnectionController: CBCentralManagerDelegate {
     ) {
         log("didFailToConnect: \(error?.localizedDescription ?? "unknown")")
         central.cancelPeripheralConnection(peripheral)
-        transitionToIdle(
-            reason: "didFailToConnect",
-            reconnect: true,
-            preservePairingContext: shouldPreservePairingContext(for: state)
-        )
+        if peripheral === pairingPeripheral {
+            abortPairingAttempt()
+            return
+        }
+        if let device = device(of: peripheral) {
+            failAttempt(device, reason: "didFailToConnect")
+        }
     }
 
     func centralManager(
@@ -665,27 +674,16 @@ extension ConnectionController: CBCentralManagerDelegate {
         didDisconnectPeripheral peripheral: CBPeripheral,
         error: Error?
     ) {
-        log("didDisconnect (\(state)): \(error?.localizedDescription ?? "clean")")
-
-        guard state.generation == generation else {
-            log("Stale didDisconnect (state gen \(state.generation?.description ?? "nil") != \(generation))")
+        log("didDisconnect: \(error?.localizedDescription ?? "clean")")
+        if peripheral === pairingPeripheral {
+            abortPairingAttempt()
             return
         }
-
-        switch state {
-        case .bleConnecting, .l2capOpening:
-            transitionToIdle(reason: "didDisconnect(connecting)", reconnect: true)
-        case .pairingConnecting, .pairingL2CAP, .pairingHandshake:
-            transitionToIdle(
-                reason: "didDisconnect(pairing)",
-                reconnect: true,
-                preservePairingContext: true
-            )
-        case .handshaking, .ready:
-            transitionToIdle(reason: "didDisconnect(session)", reconnect: true)
-        case .idle, .scanning:
-            log("didDisconnect while \(state), ignoring")
+        guard let device = device(of: peripheral) else {
+            log("didDisconnect for unknown peripheral, ignoring")
+            return
         }
+        failAttempt(device, reason: "didDisconnect")
     }
 }
 
@@ -694,41 +692,48 @@ extension ConnectionController: CBCentralManagerDelegate {
 extension ConnectionController: CBPeripheralDelegate {
 
     func peripheral(_ peripheral: CBPeripheral, didOpen channel: CBL2CAPChannel?, error: Error?) {
-        connectingStartTime = nil
+        let isPairing = peripheral === pairingPeripheral
 
         if let error {
             log("L2CAP open error: \(error.localizedDescription)")
-            transitionToIdle(
-                reason: "L2CAP open error",
-                reconnect: true,
-                preservePairingContext: shouldPreservePairingContext(for: state)
-            )
+            if isPairing {
+                abortPairingAttempt()
+            } else if let device = device(of: peripheral) {
+                failAttempt(device, reason: "L2CAP open error")
+            }
             return
         }
 
         guard let channel else {
             log("L2CAP open returned nil channel")
-            transitionToIdle(
-                reason: "L2CAP nil channel",
-                reconnect: true,
-                preservePairingContext: shouldPreservePairingContext(for: state)
-            )
+            if isPairing {
+                abortPairingAttempt()
+            } else if let device = device(of: peripheral) {
+                failAttempt(device, reason: "L2CAP nil channel")
+            }
             return
         }
 
-        l2capChannel = channel
-
-        switch state {
-        case .l2capOpening(_, let token, let gen) where gen == generation:
-            startSession(channel: channel, token: token, gen: gen, isPairing: false)
-
-        case .pairingL2CAP(_, let gen) where gen == generation:
-            startSession(channel: channel, token: nil, gen: gen, isPairing: true)
-
-        default:
-            log("Stale didOpen (\(state)), cancelling")
-            centralManager?.cancelPeripheralConnection(peripheral)
+        if isPairing {
+            guard case .l2capOpening = pairingPhase else {
+                log("Stale pairing didOpen, cancelling")
+                centralManager?.cancelPeripheralConnection(peripheral)
+                return
+            }
+            pairingConnectingStartTime = nil
+            pairingChannel = channel
+            startSession(channel: channel, device: nil)
+            return
         }
+
+        guard let device = device(of: peripheral), case .l2capOpening = device.state else {
+            log("Stale didOpen, cancelling")
+            centralManager?.cancelPeripheralConnection(peripheral)
+            return
+        }
+        device.connectingStartTime = nil
+        device.channel = channel
+        startSession(channel: channel, device: device)
     }
 }
 
@@ -736,14 +741,16 @@ extension ConnectionController: CBPeripheralDelegate {
 
 extension ConnectionController {
 
-    fileprivate func startSession(channel: CBL2CAPChannel, token: String?, gen: UInt, isPairing: Bool) {
+    /// Start a session on an opened L2CAP channel. `device == nil` means this
+    /// is the pairing flow.
+    fileprivate func startSession(channel: CBL2CAPChannel, device: DeviceConnection?) {
         guard let inputStream = channel.inputStream, let outputStream = channel.outputStream else {
             log("L2CAP channel missing streams")
-            transitionToIdle(
-                reason: "missing streams",
-                reconnect: true,
-                preservePairingContext: isPairing
-            )
+            if let device {
+                failAttempt(device, reason: "missing streams")
+            } else {
+                abortPairingAttempt()
+            }
             return
         }
 
@@ -753,40 +760,36 @@ extension ConnectionController {
         inputStream.open()
         outputStream.open()
 
-        let adapter = SessionAdapter(controller: self, generation: gen)
-        currentAdapter = adapter
+        let adapter = SessionAdapter(controller: self, generation: generation)
 
         let session: Session
-        if isPairing {
+        if let device {
+            let settingsProvider = DeviceSettingsProvider(pairingManager: pairingManager, secret: device.token)
+            session = Session(inputStream: inputStream, outputStream: outputStream,
+                              isInitiator: true, delegate: adapter, sharedSecretHex: device.token)
+            session.localName = Host.current().localizedName ?? ProcessInfo.processInfo.hostName
+            session.settingsProvider = settingsProvider
+            device.adapter = adapter
+            device.settingsProvider = settingsProvider  // retain (Session.settingsProvider is weak)
+            device.state = .handshaking(session)
+        } else {
             guard let privateKey = pairingPrivateKey else {
                 log("Pairing channel but no ephemeral key")
-                transitionToIdle(reason: "missing pairing key", reconnect: false)
+                abortPairingAttempt()
                 return
             }
             session = Session(inputStream: inputStream, outputStream: outputStream,
                               isInitiator: true, delegate: adapter,
                               mode: .pairing(privateKey: privateKey))
             session.localName = Host.current().localizedName ?? ProcessInfo.processInfo.hostName
-            transition(to: .pairingHandshake(session, generation: gen), reason: "pairing handshake")
-        } else {
-            guard let token else {
-                log("Normal channel but no token")
-                transitionToIdle(reason: "missing token", reconnect: false)
-                return
-            }
-            let settingsProvider = DeviceSettingsProvider(pairingManager: pairingManager, secret: token)
-            settingsProviderRef = settingsProvider  // retain (Session.settingsProvider is weak)
-            session = Session(inputStream: inputStream, outputStream: outputStream,
-                              isInitiator: true, delegate: adapter, sharedSecretHex: token)
-            session.localName = Host.current().localizedName ?? ProcessInfo.processInfo.hostName
-            session.settingsProvider = settingsProvider
-            transition(to: .handshaking(session, token: token, generation: gen), reason: "handshake")
+            pairingAdapter = adapter
+            pairingPhase = .handshake(session)
         }
 
-        reconnectDelay = 1.0  // reset backoff on successful L2CAP
+        device?.backoff.reset()  // successful L2CAP — reset backoff
 
         // Spawn session thread
-        let thread = Thread { [weak self] in
+        let thread = Thread {
             inputStream.remove(from: .main, forMode: .common)
             outputStream.remove(from: .main, forMode: .common)
             let runLoop = RunLoop.current
@@ -794,13 +797,8 @@ extension ConnectionController {
             outputStream.schedule(in: runLoop, forMode: .common)
             session.performHandshake()
             session.listenForMessages()
-            // Session ended — clean up adapter reference
-            self?.queue.async {
-                guard self?.currentAdapter === adapter else { return }
-                self?.currentAdapter = nil
-            }
         }
-        thread.name = isPairing ? "L2CAP-Pairing" : "L2CAP-Session"
+        thread.name = device == nil ? "L2CAP-Pairing" : "L2CAP-Session"
         thread.start()
     }
 }
@@ -809,17 +807,17 @@ extension ConnectionController {
 
 extension ConnectionController {
 
-    fileprivate func handleSessionReady(_ session: Session, generation gen: UInt) {
-        let remoteName = session.remoteName
-        guard case .handshaking(_, let token, let g) = state, g == gen else {
-            log("Stale sessionReady (gen \(gen) != \(generation))")
+    fileprivate func handleSessionReady(_ session: Session) {
+        guard let device = device(of: session), case .handshaking = device.state else {
+            log("Stale sessionReady, ignoring")
             return
         }
+        let remoteName = session.remoteName
         // Update stored device name
         if let name = remoteName {
-            let devices = pairingManager.loadDevices()
-            if let existing = devices.first(where: { $0.sharedSecret == token && $0.displayName != name }) {
-                pairingManager.removeDevice(secret: token)
+            let stored = pairingManager.loadDevices()
+            if let existing = stored.first(where: { $0.sharedSecret == device.token && $0.displayName != name }) {
+                pairingManager.removeDevice(secret: device.token)
                 let updated = PairedDevice(sharedSecret: existing.sharedSecret, displayName: name,
                                            datePaired: existing.datePaired,
                                            richMediaEnabled: existing.richMediaEnabled,
@@ -828,8 +826,12 @@ extension ConnectionController {
                 pairingManager.addDevice(updated)
             }
         }
-        transition(to: .ready(session, token: token, generation: gen), reason: "handshake complete")
-        log("Session ready — remote: \(remoteName ?? "unknown")")
+        device.state = .ready(session)
+        device.backoff.reset()
+        device.nextAttemptAt = .distantPast
+        log("Session ready — remote: \(remoteName ?? "unknown") (\(connectedReadyCount()) connected)")
+        notifyConnectionChanged()
+        ensureScanning()
         // Send pending clipboard
         if let pending = pendingClipboard {
             session.sendClipboard(pending)
@@ -837,25 +839,30 @@ extension ConnectionController {
         }
     }
 
-    fileprivate func handleSessionError(_ error: Error) {
+    private func connectedReadyCount() -> Int {
+        devices.values.filter { $0.state.isReady }.count
+    }
+
+    fileprivate func handleSessionError(_ session: Session, error: Error) {
         log("Session error: \(error)")
         if case SessionError.versionMismatch(let v) = error {
-            transitionToIdle(reason: "version mismatch (v\(v))", reconnect: false)
             DispatchQueue.main.async { [weak self] in
                 self?.delegate?.didEncounterError(error: .versionMismatch(v))
             }
+        }
+        if case .handshake(let pairingSession) = pairingPhase, pairingSession === session {
+            abortPairingAttempt()
             return
         }
-        transitionToIdle(
-            reason: "session error",
-            reconnect: true,
-            preservePairingContext: shouldPreservePairingContext(for: state)
-        )
+        guard let device = device(of: session) else {
+            log("Session error for unknown session, ignoring")
+            return
+        }
+        failAttempt(device, reason: "session error")
     }
 
     fileprivate func handleClipboardReceived(plaintext: Data, hash: String) {
         lastReceivedTextHash = hash
-        currentAdapter?.lastTextHash = hash
         guard let text = String(data: plaintext, encoding: .utf8) else {
             log("Received data not valid UTF-8")
             return
@@ -882,28 +889,42 @@ extension ConnectionController {
         }
     }
 
-    fileprivate func handlePairingComplete(sharedSecret: Data, remoteName: String?) {
+    fileprivate func handlePairingComplete(_ session: Session, sharedSecret: Data, remoteName: String?) {
         let secretHex = sharedSecret.map { String(format: "%02x", $0) }.joined()
         log("Pairing complete")
         // The phone's stable identity tag arrived in KEY_EXCHANGE (nil on the
         // phone's first pairing — it then advertises the secret-derived tag).
-        let advertTagHex = activeSession(from: state)?.remoteAdvertTagHex
-        let device = PairedDevice(sharedSecret: secretHex, displayName: remoteName ?? "Android",
+        let advertTagHex = session.remoteAdvertTagHex
+        let paired = PairedDevice(sharedSecret: secretHex, displayName: remoteName ?? "Android",
                                   datePaired: Date(), advertTagHex: advertTagHex)
-        pairingManager.addDevice(device)
+        pairingManager.addDevice(paired)
         pairingManager.clearEphemeralKey()
-        // Wire settings provider (hold strong ref via settingsProviderRef so weak var isn't immediately nil)
-        if let session = activeSession(from: state) {
-            let provider = DeviceSettingsProvider(pairingManager: pairingManager, secret: secretHex)
-            settingsProviderRef = provider
-            session.settingsProvider = provider
+
+        // Wire settings provider (hold strong ref via the device record so the
+        // session's weak var isn't immediately nil)
+        let provider = DeviceSettingsProvider(pairingManager: pairingManager, secret: secretHex)
+        session.settingsProvider = provider
+
+        // Promote the pairing session to a normal device connection: the
+        // HELLO/WELCOME handshake continues on the same channel.
+        syncDevicesWithStore()
+        if let device = devices[secretHex] {
+            device.state = .handshaking(session)
+            device.peripheral = pairingPeripheral
+            device.channel = pairingChannel
+            device.adapter = pairingAdapter
+            device.settingsProvider = provider
         }
+
+        pairingPeripheral = nil
+        pairingChannel = nil
+        pairingConnectingStartTime = nil
+        pairingAdapter = nil
+        pairingPhase = .scanning
         pairingTag = nil
         pairingPrivateKey = nil
-        // Transition from pairingHandshake to handshaking
-        if case .pairingHandshake(let session, let gen) = state, gen == generation {
-            transition(to: .handshaking(session, token: secretHex, generation: gen), reason: "pairing complete")
-        }
+        ensureScanning()
+
         DispatchQueue.main.async { [weak self] in
             self?.delegate?.didCompletePairing(deviceName: remoteName)
         }
@@ -927,8 +948,10 @@ extension ConnectionController {
 // MARK: - SessionAdapter
 
 /// Bridges `SessionDelegate` callbacks (fired on the session thread) to
-/// `ConnectionController` handler methods on its serial queue, guarded by generation.
-private class SessionAdapter: NSObject, SessionDelegate {
+/// `ConnectionController` handler methods on its serial queue, guarded by
+/// generation. Handlers additionally locate the owning device by session
+/// identity, so callbacks from replaced sessions are ignored.
+class SessionAdapter: NSObject, SessionDelegate {
     weak var controller: ConnectionController?
     let generation: UInt
 
@@ -958,11 +981,11 @@ private class SessionAdapter: NSObject, SessionDelegate {
     // MARK: SessionDelegate
 
     func sessionDidBecomeReady(_ session: Session) {
-        dispatch { $0.handleSessionReady(session, generation: self.generation) }
+        dispatch { $0.handleSessionReady(session) }
     }
 
     func session(_ session: Session, didFailWithError error: Error) {
-        dispatch { $0.handleSessionError(error) }
+        dispatch { $0.handleSessionError(session, error: error) }
     }
 
     func session(_ session: Session, didReceivePlaintext plaintext: Data, hash: String) {
@@ -979,7 +1002,7 @@ private class SessionAdapter: NSObject, SessionDelegate {
     }
 
     func session(_ session: Session, didCompletePairingWithSecret sharedSecret: Data, remoteName: String?) {
-        dispatch { $0.handlePairingComplete(sharedSecret: sharedSecret, remoteName: remoteName) }
+        dispatch { $0.handlePairingComplete(session, sharedSecret: sharedSecret, remoteName: remoteName) }
     }
 
     func session(_ session: Session, didChangeRichMediaSetting enabled: Bool) {

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -74,6 +74,9 @@ final class DeviceConnection {
     var backoff = ReconnectBackoff()
     /// Earliest time the next connect attempt may start (per-device flap guard).
     var nextAttemptAt = Date.distantPast
+    /// Set on version mismatch: stays paired but no reconnect attempts (and no
+    /// repeated alerts) until the next Bluetooth power cycle.
+    var suspended = false
     var adapter: SessionAdapter?
     var settingsProvider: DeviceSettingsProvider?
 
@@ -145,9 +148,16 @@ class ConnectionController: NSObject {
     // MARK: BLE
 
     private var centralManager: CBCentralManager!
-    /// Peripherals from attempts that may have dangling CoreBluetooth connection
-    /// bookkeeping (e.g. cancel during BT-off is a no-op). Re-cancelled at poweredOn.
-    private var staleAttemptedPeripherals: [CBPeripheral] = []
+    /// Peripherals whose cancel happened while Bluetooth was off (a no-op that
+    /// leaves dangling CoreBluetooth connection bookkeeping). Re-cancelled at
+    /// poweredOn. Cancels issued while powered on take effect immediately and
+    /// are not tracked.
+    private var staleAttemptedPeripherals: [UUID: CBPeripheral] = [:]
+
+    private func rememberStaleAttemptIfNeeded(_ peripheral: CBPeripheral) {
+        guard centralManager?.state != .poweredOn else { return }
+        staleAttemptedPeripherals[peripheral.identifier] = peripheral
+    }
 
     // MARK: Timers
 
@@ -221,7 +231,7 @@ class ConnectionController: NSObject {
         device.state.session?.close()
         if let peripheral = device.peripheral {
             centralManager?.cancelPeripheralConnection(peripheral)
-            staleAttemptedPeripherals.append(peripheral)
+            rememberStaleAttemptIfNeeded(peripheral)
         }
         device.peripheral = nil
         device.channel = nil
@@ -251,7 +261,8 @@ class ConnectionController: NSObject {
     /// active or any paired device is unconnected.
     fileprivate func ensureScanning() {
         guard let centralManager, centralManager.state == .poweredOn else { return }
-        let needScan = pairingTag != nil || devices.values.contains { $0.state.isIdle }
+        let needScan = pairingTag != nil
+            || devices.values.contains { $0.state.isIdle && !$0.suspended }
         if needScan && !centralManager.isScanning {
             log("Scanning (paired: \(devices.count), pairing: \(pairingTag != nil))")
             centralManager.scanForPeripherals(
@@ -329,7 +340,7 @@ class ConnectionController: NSObject {
         }
         if let peripheral = pairingPeripheral {
             centralManager?.cancelPeripheralConnection(peripheral)
-            staleAttemptedPeripherals.append(peripheral)
+            rememberStaleAttemptIfNeeded(peripheral)
         }
         pairingPeripheral = nil
         pairingChannel = nil
@@ -364,11 +375,21 @@ class ConnectionController: NSObject {
 
     // MARK: - Paired Device Lookup
 
-    private func device(matching tag: Data) -> DeviceConnection? {
-        let stored = pairingManager.loadDevices()
-        for paired in stored {
-            guard pairingManager.scanTag(for: paired) == tag else { continue }
-            return devices[paired.sharedSecret]
+    /// First device that matches the advertised tag AND is eligible for a
+    /// connect attempt. Several records can share a tag (e.g. a stale record
+    /// left behind by re-pairing the same phone), so don't stop at the first
+    /// tag match — a perpetually-failing stale record must not shadow the
+    /// valid one.
+    private func connectableDevice(matching tag: Data) -> DeviceConnection? {
+        let now = Date()
+        for paired in pairingManager.loadDevices() {
+            guard pairingManager.scanTag(for: paired) == tag,
+                  let device = devices[paired.sharedSecret],
+                  device.state.isIdle,
+                  !device.suspended,
+                  now >= device.nextAttemptAt
+            else { continue }
+            return device
         }
         return nil
     }
@@ -452,7 +473,7 @@ extension ConnectionController {
         }
         if let peripheral = pairingPeripheral {
             centralManager?.cancelPeripheralConnection(peripheral)
-            staleAttemptedPeripherals.append(peripheral)
+            rememberStaleAttemptIfNeeded(peripheral)
         }
         pairingPeripheral = nil
         pairingChannel = nil
@@ -568,7 +589,7 @@ extension ConnectionController: CBCentralManagerDelegate {
             // Re-cancel peripherals from before the power cycle. cancelPeripheralConnection
             // during BT-off is a no-op, so internal CB connection bookkeeping can accumulate
             // across brief power nap cycles. Re-cancelling now releases dangling slots.
-            for stale in staleAttemptedPeripherals {
+            for stale in staleAttemptedPeripherals.values {
                 central.cancelPeripheralConnection(stale)
             }
             staleAttemptedPeripherals.removeAll()
@@ -576,6 +597,7 @@ extension ConnectionController: CBCentralManagerDelegate {
             for device in devices.values {
                 device.backoff.reset()
                 device.nextAttemptAt = .distantPast
+                device.suspended = false  // version-mismatch suspension lifts on BT cycle
             }
             startHealthCheck()
             ensureScanning()
@@ -620,10 +642,7 @@ extension ConnectionController: CBCentralManagerDelegate {
         if pairingTag != nil { return }
 
         // Match against paired devices that are idle and past their backoff
-        guard let device = device(matching: deviceTag),
-              device.state.isIdle,
-              Date() >= device.nextAttemptAt
-        else { return }
+        guard let device = connectableDevice(matching: deviceTag) else { return }
 
         log("Matched device tag for \(device.token.prefix(8))…, PSM=\(psm), RSSI=\(RSSI)")
         device.state = .bleConnecting(psm)
@@ -845,17 +864,26 @@ extension ConnectionController {
 
     fileprivate func handleSessionError(_ session: Session, error: Error) {
         log("Session error: \(error)")
-        if case SessionError.versionMismatch(let v) = error {
-            DispatchQueue.main.async { [weak self] in
-                self?.delegate?.didEncounterError(error: .versionMismatch(v))
-            }
-        }
         if case .handshake(let pairingSession) = pairingPhase, pairingSession === session {
             abortPairingAttempt()
             return
         }
         guard let device = device(of: session) else {
             log("Session error for unknown session, ignoring")
+            return
+        }
+        if case SessionError.versionMismatch(let v) = error {
+            // Don't keep retrying an outdated peer — every attempt would fail
+            // the same way and re-trigger the update alert. Suspend until the
+            // next Bluetooth power cycle.
+            log("Version mismatch (v\(v)) — suspending \(device.token.prefix(8))…")
+            closeConnection(of: device)
+            device.suspended = true
+            notifyConnectionChanged()
+            ensureScanning()
+            DispatchQueue.main.async { [weak self] in
+                self?.delegate?.didEncounterError(error: .versionMismatch(v))
+            }
             return
         }
         failAttempt(device, reason: "session error")

--- a/macos/ClipRelayMac/Sources/Pairing/PairingManager.swift
+++ b/macos/ClipRelayMac/Sources/Pairing/PairingManager.swift
@@ -13,14 +13,20 @@ struct PairedDevice: Codable, Equatable {
     let datePaired: Date
     var richMediaEnabled: Bool
     var richMediaEnabledChangedAt: Int64 // Unix seconds
+    /// 16-char hex tag the phone advertises (its stable identity tag, shared
+    /// during pairing). nil for pre-multi-Mac pairings — fall back to the
+    /// secret-derived tag, which is what those phones advertise.
+    var advertTagHex: String?
 
     init(sharedSecret: String, displayName: String, datePaired: Date,
-         richMediaEnabled: Bool = false, richMediaEnabledChangedAt: Int64 = 0) {
+         richMediaEnabled: Bool = false, richMediaEnabledChangedAt: Int64 = 0,
+         advertTagHex: String? = nil) {
         self.sharedSecret = sharedSecret
         self.displayName = displayName
         self.datePaired = datePaired
         self.richMediaEnabled = richMediaEnabled
         self.richMediaEnabledChangedAt = richMediaEnabledChangedAt
+        self.advertTagHex = advertTagHex
     }
 
     // Custom decoding to handle existing data without the new fields
@@ -31,6 +37,7 @@ struct PairedDevice: Codable, Equatable {
         datePaired = try container.decode(Date.self, forKey: .datePaired)
         richMediaEnabled = try container.decodeIfPresent(Bool.self, forKey: .richMediaEnabled) ?? false
         richMediaEnabledChangedAt = try container.decodeIfPresent(Int64.self, forKey: .richMediaEnabledChangedAt) ?? 0
+        advertTagHex = try container.decodeIfPresent(String.self, forKey: .advertTagHex)
     }
 }
 
@@ -109,6 +116,16 @@ final class PairingManager {
         guard let result = E2ECrypto.deviceTag(secretBytes: secretBytes) else { return nil }
         tagCache[secret] = result
         return result
+    }
+
+    /// Tag to match against the phone's BLE advertisement: the phone's stable
+    /// identity tag when known (multi-Mac pairing), otherwise the legacy
+    /// secret-derived tag.
+    func scanTag(for device: PairedDevice) -> Data? {
+        if let hex = device.advertTagHex, let tag = E2ECrypto.hexToData(hex), tag.count == 8 {
+            return tag
+        }
+        return deviceTag(for: device.sharedSecret)
     }
 
     func encryptionKey(for secret: String) -> SymmetricKey? {

--- a/macos/ClipRelayMac/Sources/Pairing/PairingManager.swift
+++ b/macos/ClipRelayMac/Sources/Pairing/PairingManager.swift
@@ -45,7 +45,16 @@ final class PairingManager {
     private static let keychainAccount = "paired_devices"
     private static let pendingDisplayNamePrefix = "Pending pairing"
     private let keychain: SecretStore
+    /// Guards the caches: PairingManager is used from the connection queue and
+    /// the main thread (status bar menu).
+    private let cacheLock = NSLock()
     private var tagCache: [String: Data] = [:]
+    /// Decoded device list, invalidated on every persist(). loadDevices() is on
+    /// the BLE discovery hot path (every advertisement while scanning), so it
+    /// must not hit the keychain each time. All mutations go through persist()
+    /// in-process; the smoke CLI writes from a separate process only while the
+    /// app is not running.
+    private var devicesCache: [PairedDevice]?
 
     init(keychain: SecretStore = KeychainStore(service: "cliprelay")) {
         self.keychain = keychain
@@ -65,8 +74,22 @@ final class PairingManager {
     }
 
     func loadDevices() -> [PairedDevice] {
-        guard let data = keychain.data(for: Self.keychainAccount) else { return [] }
-        return (try? JSONDecoder().decode([PairedDevice].self, from: data)) ?? []
+        cacheLock.lock()
+        if let cached = devicesCache {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+        let loaded: [PairedDevice]
+        if let data = keychain.data(for: Self.keychainAccount) {
+            loaded = (try? JSONDecoder().decode([PairedDevice].self, from: data)) ?? []
+        } else {
+            loaded = []
+        }
+        cacheLock.lock()
+        devicesCache = loaded
+        cacheLock.unlock()
+        return loaded
     }
 
     func addDevice(_ device: PairedDevice) {
@@ -115,10 +138,17 @@ final class PairingManager {
     }
 
     func deviceTag(for secret: String) -> Data? {
-        if let cached = tagCache[secret] { return cached }
+        cacheLock.lock()
+        if let cached = tagCache[secret] {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
         guard let secretBytes = E2ECrypto.hexToData(secret) else { return nil }
         guard let result = E2ECrypto.deviceTag(secretBytes: secretBytes) else { return nil }
+        cacheLock.lock()
         tagCache[secret] = result
+        cacheLock.unlock()
         return result
     }
 
@@ -139,7 +169,10 @@ final class PairingManager {
 
 
     private func persist(_ devices: [PairedDevice]) {
+        cacheLock.lock()
         tagCache.removeAll()
+        devicesCache = devices
+        cacheLock.unlock()
         guard let data = try? JSONEncoder().encode(devices) else { return }
         keychain.setData(data, for: Self.keychainAccount)
     }

--- a/macos/ClipRelayMac/Sources/Pairing/PairingManager.swift
+++ b/macos/ClipRelayMac/Sources/Pairing/PairingManager.swift
@@ -44,8 +44,12 @@ struct PairedDevice: Codable, Equatable {
 final class PairingManager {
     private static let keychainAccount = "paired_devices"
     private static let pendingDisplayNamePrefix = "Pending pairing"
-    private let keychain = KeychainStore(service: "cliprelay")
+    private let keychain: SecretStore
     private var tagCache: [String: Data] = [:]
+
+    init(keychain: SecretStore = KeychainStore(service: "cliprelay")) {
+        self.keychain = keychain
+    }
 
     /// Ephemeral ECDH key pair for in-progress pairing. Lives only during pairing window.
     private(set) var ephemeralPrivateKey: Curve25519.KeyAgreement.PrivateKey?

--- a/macos/ClipRelayMac/Sources/Protocol/Session.swift
+++ b/macos/ClipRelayMac/Sources/Protocol/Session.swift
@@ -84,6 +84,10 @@ final class Session {
     /// Remote device name received during handshake. Available after sessionDidBecomeReady.
     private(set) var remoteName: String?
 
+    /// Phone identity tag (16-char hex) received in KEY_EXCHANGE during pairing.
+    /// nil when the phone has no other paired Macs (first pairing).
+    private(set) var remoteAdvertTagHex: String?
+
     private let lock = NSLock()
     private var _closed = false
     private var closed: Bool {
@@ -256,6 +260,14 @@ final class Session {
 
         // Extract remote name from KEY_EXCHANGE if present
         let exchangeRemoteName = json["name"] as? String
+
+        // Extract the phone's stable identity tag (multi-Mac phones include it
+        // so this Mac scans for the right advertisement)
+        if let tagHex = json["tag"] as? String,
+           tagHex.count == 16,
+           tagHex.allSatisfy({ $0.isHexDigit }) {
+            remoteAdvertTagHex = tagHex.lowercased()
+        }
 
         // Notify delegate of completed pairing
         delegate?.session(self, didCompletePairingWithSecret: sharedSecret, remoteName: exchangeRemoteName)

--- a/macos/ClipRelayMac/Sources/Security/KeychainStore.swift
+++ b/macos/ClipRelayMac/Sources/Security/KeychainStore.swift
@@ -3,7 +3,31 @@
 import Foundation
 import Security
 
-final class KeychainStore {
+/// Abstraction over keychain storage so tests can use an in-memory store
+/// instead of the real login keychain (which triggers ACL password prompts
+/// for every freshly-signed test bundle).
+protocol SecretStore: AnyObject {
+    func data(for account: String) -> Data?
+    @discardableResult
+    func setData(_ data: Data, for account: String) -> Bool
+}
+
+/// In-memory SecretStore for unit tests.
+final class InMemorySecretStore: SecretStore {
+    private var storage: [String: Data] = [:]
+
+    func data(for account: String) -> Data? {
+        storage[account]
+    }
+
+    @discardableResult
+    func setData(_ data: Data, for account: String) -> Bool {
+        storage[account] = data
+        return true
+    }
+}
+
+final class KeychainStore: SecretStore {
     private let service: String
 
     init(service: String) {

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/ConnectionControllerTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/ConnectionControllerTests.swift
@@ -4,35 +4,35 @@ import XCTest
 final class ConnectionControllerTests: XCTestCase {
 
     private func makeController() -> ConnectionController {
-        let pm = PairingManager()
+        let pm = PairingManager(keychain: InMemorySecretStore())
         return ConnectionController(pairingManager: pm, skipCentralManager: true)
     }
 
     // MARK: - Backoff Tests
 
     func testBackoffSequence() {
-        let controller = makeController()
+        var backoff = ReconnectBackoff()
         let expected: [TimeInterval] = [1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 30.0, 30.0]
         for (i, expectedDelay) in expected.enumerated() {
-            let delay = controller.nextReconnectDelay()
+            let delay = backoff.next()
             XCTAssertEqual(delay, expectedDelay, accuracy: 0.001,
                            "Backoff step \(i): expected \(expectedDelay), got \(delay)")
         }
     }
 
     func testBackoffResetsToOneSecond() {
-        let controller = makeController()
-        _ = controller.nextReconnectDelay()
-        _ = controller.nextReconnectDelay()
-        _ = controller.nextReconnectDelay()
-        controller.resetReconnectDelay()
-        XCTAssertEqual(controller.nextReconnectDelay(), 1.0, accuracy: 0.001)
+        var backoff = ReconnectBackoff()
+        _ = backoff.next()
+        _ = backoff.next()
+        _ = backoff.next()
+        backoff.reset()
+        XCTAssertEqual(backoff.next(), 1.0, accuracy: 0.001)
     }
 
     func testBackoffCapAtMaxDelay() {
-        let controller = makeController()
+        var backoff = ReconnectBackoff()
         for _ in 0..<20 {
-            let delay = controller.nextReconnectDelay()
+            let delay = backoff.next()
             XCTAssertLessThanOrEqual(delay, ConnectionController.maxReconnectDelay)
         }
     }
@@ -103,9 +103,11 @@ final class ConnectionControllerTests: XCTestCase {
 
     // MARK: - State Tests
 
-    func testInitialStateIsIdle() {
+    func testInitialStateIsDisconnected() {
         let controller = makeController()
-        XCTAssertEqual(controller.state.description, "idle")
+        XCTAssertFalse(controller.isConnected)
+        XCTAssertTrue(controller.connectedTokens.isEmpty)
+        XCTAssertNil(controller.connectedToken)
     }
 
     func testInitialGenerationIsZero() {
@@ -113,14 +115,24 @@ final class ConnectionControllerTests: XCTestCase {
         XCTAssertEqual(controller.generation, 0)
     }
 
-    func testStateDescriptions() {
-        XCTAssertEqual(ConnectionState.idle.description, "idle")
-        XCTAssertEqual(ConnectionState.scanning.description, "scanning")
+    func testDeviceStateDescriptions() {
+        XCTAssertEqual(DeviceState.idle.description, "idle")
+        XCTAssertEqual(DeviceState.l2capOpening.description, "l2capOpening")
+        XCTAssertEqual(DeviceState.bleConnecting(131).description, "bleConnecting(psm=131)")
     }
 
-    func testStateGenerationNilForIdleAndScanning() {
-        XCTAssertNil(ConnectionState.idle.generation)
-        XCTAssertNil(ConnectionState.scanning.generation)
+    func testDeviceStateReadiness() {
+        XCTAssertTrue(DeviceState.idle.isIdle)
+        XCTAssertFalse(DeviceState.idle.isReady)
+        XCTAssertFalse(DeviceState.l2capOpening.isIdle)
+        XCTAssertNil(DeviceState.idle.session)
+    }
+
+    func testNewDeviceConnectionStartsIdle() {
+        let device = DeviceConnection(token: "aabb")
+        XCTAssertTrue(device.state.isIdle)
+        XCTAssertNil(device.peripheral)
+        XCTAssertEqual(device.nextAttemptAt, .distantPast)
     }
 
     // MARK: - Constants Tests

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/PairedDeviceTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/PairedDeviceTests.swift
@@ -56,6 +56,48 @@ final class PairedDeviceTests: XCTestCase {
         XCTAssertEqual(decoded[0].richMediaEnabledChangedAt, 42)
     }
 
+    // MARK: - Advert tag (phone identity tag)
+
+    func testAdvertTagDefaultsToNil() {
+        let device = PairedDevice(sharedSecret: "aabb", displayName: "Test", datePaired: Date())
+        XCTAssertNil(device.advertTagHex)
+    }
+
+    func testAdvertTagRoundTrip() throws {
+        let device = PairedDevice(sharedSecret: "aabb", displayName: "Test", datePaired: Date(),
+                                  advertTagHex: "0011223344556677")
+        let data = try JSONEncoder().encode([device])
+        let decoded = try JSONDecoder().decode([PairedDevice].self, from: data)
+        XCTAssertEqual(decoded[0].advertTagHex, "0011223344556677")
+    }
+
+    func testDecodingLegacyDataWithoutAdvertTag() throws {
+        let legacyJSON = """
+        [{"sharedSecret":"aabb","displayName":"OldDevice","datePaired":0}]
+        """
+        let data = legacyJSON.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode([PairedDevice].self, from: data)
+        XCTAssertNil(decoded[0].advertTagHex)
+    }
+
+    func testScanTagUsesAdvertTagWhenPresent() {
+        let manager = PairingManager()
+        let device = PairedDevice(
+            sharedSecret: "b4e4716bc736cde97aa0b585beddab79e190a2531e21bdd410914aeec7a2a4e1",
+            displayName: "Test", datePaired: Date(),
+            advertTagHex: "0011223344556677"
+        )
+        XCTAssertEqual(manager.scanTag(for: device), E2ECrypto.hexToData("0011223344556677"))
+    }
+
+    func testScanTagFallsBackToSecretDerivedTag() {
+        let manager = PairingManager()
+        let secret = "b4e4716bc736cde97aa0b585beddab79e190a2531e21bdd410914aeec7a2a4e1"
+        let device = PairedDevice(sharedSecret: secret, displayName: "Test", datePaired: Date())
+        XCTAssertEqual(manager.scanTag(for: device), manager.deviceTag(for: secret))
+        XCTAssertNotNil(manager.scanTag(for: device))
+    }
+
     // MARK: - PairingManager integration (uses real Keychain)
 
     func testSetRichMediaEnabledUpdatesDevice() {

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/PairedDeviceTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/PairedDeviceTests.swift
@@ -81,7 +81,7 @@ final class PairedDeviceTests: XCTestCase {
     }
 
     func testScanTagUsesAdvertTagWhenPresent() {
-        let manager = PairingManager()
+        let manager = PairingManager(keychain: InMemorySecretStore())
         let device = PairedDevice(
             sharedSecret: "b4e4716bc736cde97aa0b585beddab79e190a2531e21bdd410914aeec7a2a4e1",
             displayName: "Test", datePaired: Date(),
@@ -91,17 +91,17 @@ final class PairedDeviceTests: XCTestCase {
     }
 
     func testScanTagFallsBackToSecretDerivedTag() {
-        let manager = PairingManager()
+        let manager = PairingManager(keychain: InMemorySecretStore())
         let secret = "b4e4716bc736cde97aa0b585beddab79e190a2531e21bdd410914aeec7a2a4e1"
         let device = PairedDevice(sharedSecret: secret, displayName: "Test", datePaired: Date())
         XCTAssertEqual(manager.scanTag(for: device), manager.deviceTag(for: secret))
         XCTAssertNotNil(manager.scanTag(for: device))
     }
 
-    // MARK: - PairingManager integration (uses real Keychain)
+    // MARK: - PairingManager integration (in-memory store)
 
     func testSetRichMediaEnabledUpdatesDevice() {
-        let manager = PairingManager()
+        let manager = PairingManager(keychain: InMemorySecretStore())
         let secret = "ff" + String(repeating: "00", count: 31)
         let device = PairedDevice(sharedSecret: secret, displayName: "RichMediaTest", datePaired: Date())
 
@@ -124,7 +124,7 @@ final class PairedDeviceTests: XCTestCase {
     }
 
     func testClearRichMediaBySettingFalse() {
-        let manager = PairingManager()
+        let manager = PairingManager(keychain: InMemorySecretStore())
         let secret = "ee" + String(repeating: "00", count: 31)
         let device = PairedDevice(sharedSecret: secret, displayName: "ClearTest", datePaired: Date())
 

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -19,6 +19,7 @@ SPARKLE_PLIST_KEYS="<key>SUPublicEDKey</key>
 BUILD_MAC=true
 BUILD_ANDROID=true
 ANDROID_RELEASE=false
+MAC_CONFIGURATION=release
 
 usage() {
   cat <<'EOF'
@@ -30,6 +31,8 @@ Options:
   --mac-only       Build only macOS app
   --android-only   Build only Android artifacts
   --release        Build Android release AAB/APK instead of debug APK
+  --debug          Build the macOS app in debug configuration (enables the
+                   smoke-test CLI used by scripts/hardware-smoke-test.sh)
   -h, --help       Show this help message
 EOF
 }
@@ -46,6 +49,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --release)
       ANDROID_RELEASE=true
+      shift
+      ;;
+    --debug)
+      MAC_CONFIGURATION=debug
       shift
       ;;
     -h|--help)
@@ -74,14 +81,14 @@ build_mac() {
   fi
 
   echo "==> Building macOS app"
-  swift build --configuration release --package-path "$MAC_PROJECT_DIR"
+  swift build --configuration "$MAC_CONFIGURATION" --package-path "$MAC_PROJECT_DIR"
 
-  local binary_path="$MAC_PROJECT_DIR/.build/release/ClipRelay"
+  local binary_path="$MAC_PROJECT_DIR/.build/$MAC_CONFIGURATION/ClipRelay"
   if [[ ! -x "$binary_path" ]]; then
-    if [[ -x "$MAC_PROJECT_DIR/.build/arm64-apple-macosx/release/ClipRelay" ]]; then
-      binary_path="$MAC_PROJECT_DIR/.build/arm64-apple-macosx/release/ClipRelay"
-    elif [[ -x "$MAC_PROJECT_DIR/.build/x86_64-apple-macosx/release/ClipRelay" ]]; then
-      binary_path="$MAC_PROJECT_DIR/.build/x86_64-apple-macosx/release/ClipRelay"
+    if [[ -x "$MAC_PROJECT_DIR/.build/arm64-apple-macosx/$MAC_CONFIGURATION/ClipRelay" ]]; then
+      binary_path="$MAC_PROJECT_DIR/.build/arm64-apple-macosx/$MAC_CONFIGURATION/ClipRelay"
+    elif [[ -x "$MAC_PROJECT_DIR/.build/x86_64-apple-macosx/$MAC_CONFIGURATION/ClipRelay" ]]; then
+      binary_path="$MAC_PROJECT_DIR/.build/x86_64-apple-macosx/$MAC_CONFIGURATION/ClipRelay"
     else
       echo "Could not locate built macOS binary." >&2
       exit 1

--- a/scripts/hardware-smoke-test-auto.sh
+++ b/scripts/hardware-smoke-test-auto.sh
@@ -46,6 +46,8 @@ Runs a near-fully automated BLE smoke test on debug builds:
 Notes:
   - Requires an attached Android device via USB debugging or wireless debugging
   - Requires debug APK installed (for debug smoke receiver and probe state)
+  - Requires a debug macOS bundle in dist/ (the smoke CLI is #if DEBUG only):
+    build it with ./scripts/build-all.sh --debug --mac-only
   - BLE connection waits are capped at 10 seconds
   - Cleans up the temporary pairing token on both devices at the end (unless --keep-pairing is set)
 EOF
@@ -653,6 +655,17 @@ fi
 
 if [[ ! -x "$MAC_BIN" ]]; then
   echo "Missing macOS binary: $MAC_BIN" >&2
+  exit 1
+fi
+
+# The smoke-test CLI (--smoke-import-pairing / --smoke-remove-pairing) is
+# compiled only under #if DEBUG. A release binary silently ignores those flags
+# and launches the full app instead, so the import becomes a no-op and the
+# test times out with "paired: 0". Detect that statically (running the binary
+# to probe would launch the app), and fail fast with a fix.
+if ! grep -q -e "--smoke-import-pairing" "$MAC_BIN"; then
+  echo "dist/ClipRelay.app is a release build without the smoke-test CLI." >&2
+  echo "Rebuild a debug bundle first: ./scripts/build-all.sh --debug --mac-only" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What

Removes the one-device-per-side limitation in both directions:

- **Android → multiple Macs (up to 5):** the phone stores a list of paired Macs, holds one concurrent L2CAP session per Mac in range, and broadcasts clipboard/images to all of them. The UI replaces the single device card with a per-Mac list (live status dot, pairing code, confirm-guarded Forget) plus a "Pair another Mac" button, and the screen is now scrollable so the footer stays reachable as the list grows.
- **Mac → multiple Android devices:** `ConnectionController` is rearchitected from a single global state machine into per-device connection records — scanning continues while any paired phone is unconnected, each phone connects/handshakes/backs off independently, and clipboard/images fan out to every ready session. Text copied on one phone is relayed via the Mac to the others (originating session skipped by hash).

## How (protocol)

BLE scan responses only fit one 8-byte tag, so the phone can't advertise per-Mac tags. Instead the phone advertises a single stable **identity tag** (derived from the first pairing's secret for backward compatibility) and the existing HELLO HMAC identifies which Mac is connecting — the phone tries each stored secret. New Macs learn the tag via a `tag` field in KEY_EXCHANGE and store it per device (`PairedDevice.advertTagHex`), falling back to the secret-derived tag for pre-existing pairings.

**Compatibility:** existing single-Mac pairings keep working unchanged after the Android update. Adding a 2nd+ Mac requires this Mac app version. Legacy single-secret installs migrate automatically.

## Also in this PR

- `build-all.sh --debug` builds a debug Mac bundle through the same bundling/Developer-ID-signing path (stable signature → keychain ACL grants persist across rebuilds), and the hardware smoke test now fails fast with instructions when pointed at a release bundle (whose `#if DEBUG` smoke CLI is compiled out).
- Mac unit tests use an injectable in-memory secret store instead of the real login keychain, which prompted for the keychain password on every test run (fresh ad-hoc signature per rebuilt test bundle).

## Reviewer notes

- The `CBL2CAPChannel` must stay retained (now per device) — releasing it closes the underlying connection.
- Pairing on either side no longer drops existing live sessions.
- Rich-media setting remains global on Android and per-device on Mac, synced last-write-wins; the Mac menu toggle applies to all connected devices.

## Testing

- All unit tests pass (146 Mac, full Android suite), including new coverage: multi-Mac store/migration/limit, candidate-secret handshake matching/rejection, ViewModel partial-connection states, advert-tag decode/fallback, per-device backoff.
- Automated BLE hardware smoke test: PASS (pair, both transfer directions, reconnect cycle).
- Verified live on real hardware: one phone connected to two Macs simultaneously ("Connected to 2 of 2 Macs"), and one Mac connected to two phones simultaneously with clipboard fan-out acked by both.