### PR TITLE
fix(android): crash when pairing with Nearby devices permission denied

### DIFF
--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -114,6 +114,7 @@ class ClipRelayService : Service(), L2capServerCallback {
     private var bleStarted = false
     @Volatile
     private var isDestroyed = false
+    private var foregroundStarted = false
     @Volatile
     private var pairingInProgress = false
     private var pendingPairingKeyPair: java.security.KeyPair? = null
@@ -206,7 +207,21 @@ class ClipRelayService : Service(), L2capServerCallback {
         loadPairingState()
         DebugSmokeProbe.reset(this)
 
-        startForeground(1001, buildNotification())
+        // On Android 14+ a connectedDevice foreground service may not enter the
+        // foreground without the Bluetooth runtime permissions — startForeground
+        // throws SecurityException if the user denied "Nearby devices". Stop the
+        // service instead of crashing the process.
+        val foregrounded = runCatching {
+            startForeground(1001, buildNotification())
+        }.onFailure { error ->
+            Log.e(TAG, "startForeground failed; stopping service", error)
+        }.isSuccess
+        if (!foregrounded) {
+            stopSelf()
+            return
+        }
+        foregroundStarted = true
+
         ContextCompat.registerReceiver(
             this,
             bluetoothStateReceiver,
@@ -225,7 +240,10 @@ class ClipRelayService : Service(), L2capServerCallback {
         isDestroyed = true
         clipboardAutoClearHandler.removeCallbacksAndMessages(null)
         clearPairingTimeout()
-        unregisterReceiver(bluetoothStateReceiver)
+        // The receiver is only registered when startForeground succeeded in onCreate.
+        if (foregroundStarted) {
+            unregisterReceiver(bluetoothStateReceiver)
+        }
         executor.shutdownNow()
         stopBleComponents()
         super.onDestroy()

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -1213,6 +1213,45 @@ fun AccessibilityDisclosureDialog(
     )
 }
 
+// ─── BLE Permission Dialog ────────────────────────────────────────────────────
+// Shown before pairing when the "Nearby devices" runtime permission is missing.
+// Explains why the permission is needed; when Android no longer shows the system
+// prompt (permanently denied), routes the user to the app settings instead.
+@Composable
+fun BlePermissionDialog(
+    permanentlyDenied: Boolean,
+    onContinue: () -> Unit,
+    onCancel: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onCancel,
+        title = { Text(stringResource(R.string.ble_permission_title)) },
+        text = {
+            Text(
+                stringResource(
+                    if (permanentlyDenied) R.string.ble_permission_denied_body
+                    else R.string.ble_permission_body
+                )
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onContinue) {
+                Text(
+                    stringResource(
+                        if (permanentlyDenied) R.string.ble_permission_open_settings
+                        else R.string.ble_permission_continue
+                    )
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onCancel) {
+                Text(stringResource(R.string.ble_permission_cancel))
+            }
+        },
+    )
+}
+
 // ─── Version Mismatch Dialog ──────────────────────────────────────────────────
 @Composable
 fun VersionMismatchDialog(onDismiss: () -> Unit) {

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -35,6 +35,11 @@ class MainActivity : AppCompatActivity() {
     private val viewModel: MainViewModel by viewModels()
     private lateinit var clipboardSettingsStore: ClipboardSettingsStore
 
+    // Pairing is gated on the BLE ("Nearby devices") runtime permission: without it
+    // the connectedDevice foreground service cannot start and pairing would fail.
+    private var showBlePermissionDialog by mutableStateOf(false)
+    private var blePermissionPermanentlyDenied by mutableStateOf(false)
+
     private val connectionReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             when (intent?.action) {
@@ -80,6 +85,21 @@ class MainActivity : AppCompatActivity() {
         val queryIntent = Intent(this, ClipRelayService::class.java)
         queryIntent.action = ClipRelayService.ACTION_QUERY_CONNECTION
         startServiceSafely(queryIntent)
+    }
+
+    private val pairPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { _ ->
+        if (BlePermissions.hasRequiredRuntimePermissions(this)) {
+            ensureServiceRunning()
+            launchQrScanner()
+        } else {
+            // Denied again — re-show the explanation. If Android will no longer
+            // show the system prompt, the dialog routes to app settings instead.
+            blePermissionPermanentlyDenied = BlePermissions.requiredRuntimePermissions()
+                .none { shouldShowRequestPermissionRationale(it) }
+            showBlePermissionDialog = true
+        }
     }
 
     private val scannerLauncher = registerForActivityResult(
@@ -137,6 +157,28 @@ class MainActivity : AppCompatActivity() {
                 VersionMismatchDialog(onDismiss = { viewModel.onVersionMismatchDismissed() })
             }
 
+            if (showBlePermissionDialog) {
+                BlePermissionDialog(
+                    permanentlyDenied = blePermissionPermanentlyDenied,
+                    onContinue = {
+                        showBlePermissionDialog = false
+                        if (blePermissionPermanentlyDenied) {
+                            startActivity(
+                                Intent(
+                                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                    Uri.parse("package:$packageName")
+                                )
+                            )
+                        } else {
+                            pairPermissionLauncher.launch(
+                                BlePermissions.requiredRuntimePermissions().toTypedArray()
+                            )
+                        }
+                    },
+                    onCancel = { showBlePermissionDialog = false }
+                )
+            }
+
             if (showAccessibilityDisclosure) {
                 AccessibilityDisclosureDialog(
                     onAllow = {
@@ -172,7 +214,14 @@ class MainActivity : AppCompatActivity() {
                     viewModel.onPairingFailedDismissed()
                 },
                 onPairClick = {
-                    scannerLauncher.launch(Intent(this, QrScannerActivity::class.java))
+                    if (BlePermissions.hasRequiredRuntimePermissions(this)) {
+                        launchQrScanner()
+                    } else {
+                        blePermissionPermanentlyDenied =
+                            BlePermissions.requiredRuntimePermissions()
+                                .none { shouldShowRequestPermissionRationale(it) }
+                        showBlePermissionDialog = true
+                    }
                 },
                 onForgetMacClick = { macId ->
                     val forgetIntent = Intent(this, ClipRelayService::class.java)
@@ -255,6 +304,10 @@ class MainActivity : AppCompatActivity() {
         PairingStore(this).loadPairedMacs().map { mac ->
             PairedMacUi(id = mac.id, name = mac.name, connected = mac.id in connectedIds)
         }
+
+    private fun launchQrScanner() {
+        scannerLauncher.launch(Intent(this, QrScannerActivity::class.java))
+    }
 
     private fun ensureServiceRunning() {
         startServiceSafely(Intent(this, ClipRelayService::class.java))

--- a/android/app/src/main/java/org/cliprelay/ui/QrScannerActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/QrScannerActivity.kt
@@ -14,6 +14,7 @@ import io.github.g00fy2.quickie.config.BarcodeFormat
 import io.github.g00fy2.quickie.config.ScannerConfig
 import org.cliprelay.R
 import org.cliprelay.pairing.PairingUriParser
+import org.cliprelay.permissions.BlePermissions
 import org.cliprelay.service.ClipRelayService
 
 class QrScannerActivity : AppCompatActivity() {
@@ -39,6 +40,14 @@ class QrScannerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Pairing needs the BLE foreground service, which cannot start without the
+        // "Nearby devices" runtime permission — bail out instead of letting the
+        // service crash after the scan.
+        if (!BlePermissions.hasRequiredRuntimePermissions(this)) {
+            Toast.makeText(this, R.string.ble_permission_required_toast, Toast.LENGTH_LONG).show()
+            finish()
+            return
+        }
         // Launch once; avoid relaunching if the activity is recreated while the scanner is open.
         if (savedInstanceState == null) {
             scanLauncher.launch(
@@ -72,7 +81,13 @@ class QrScannerActivity : AppCompatActivity() {
         // Signal the service to start pairing mode
         val intent = Intent(this, ClipRelayService::class.java)
         intent.action = ClipRelayService.ACTION_START_PAIRING
-        startForegroundService(intent)
+        if (!BlePermissions.hasRequiredRuntimePermissions(this) ||
+            runCatching { startForegroundService(intent) }.isFailure
+        ) {
+            Toast.makeText(this, R.string.ble_permission_required_toast, Toast.LENGTH_LONG).show()
+            finish()
+            return
+        }
 
         Toast.makeText(this, "Pairing…", Toast.LENGTH_SHORT).show()
         setResult(RESULT_OK)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -44,4 +44,11 @@
     <string name="accessibility_disclosure_body">ClipRelay uses Android\'s Accessibility Service to detect when you copy text, so it can automatically send your clipboard to your paired Mac.\n\nThis permission allows ClipRelay to monitor tap actions only. It does not read, collect, or store any screen content or personal data.</string>
     <string name="accessibility_disclosure_allow">Allow</string>
     <string name="accessibility_disclosure_deny">Deny</string>
+    <string name="ble_permission_title">Nearby Devices Permission</string>
+    <string name="ble_permission_body">ClipRelay connects to your Mac over Bluetooth. Android requires the \"Nearby devices\" permission to advertise and connect, so pairing cannot work without it.\n\nClipRelay only uses Bluetooth to talk to your paired Macs — it never uses it to determine your location.</string>
+    <string name="ble_permission_denied_body">The \"Nearby devices\" permission was denied. ClipRelay needs it to connect to your Mac over Bluetooth.\n\nPlease enable \"Nearby devices\" in the app settings to pair.</string>
+    <string name="ble_permission_continue">Continue</string>
+    <string name="ble_permission_open_settings">Open Settings</string>
+    <string name="ble_permission_cancel">Cancel</string>
+    <string name="ble_permission_required_toast">Nearby devices permission is required to pair</string>
 </resources>


### PR DESCRIPTION
## Problem

If the user denies the "Nearby devices" permission when first opening the app, they can keep using it — but scanning a pairing QR code then crashes the app.

Root cause: `ClipRelayService` is declared with `foregroundServiceType="connectedDevice"`. On Android 14+ such a service may not enter the foreground without the Bluetooth runtime permissions, so `startForeground()` throws `SecurityException`. `QrScannerActivity` started the service unguarded after a successful scan, and `runCatching` at call sites can't help because the exception is thrown inside the service, not at the caller.

## Changes

- **ClipRelayService**: catch `startForeground()` failure and stop the service cleanly instead of crashing the process (and skip unregistering the Bluetooth state receiver in `onDestroy` when it was never registered).
- **MainActivity**: gate the "Pair with Mac" button on the BLE permissions. When missing, a dialog explains why "Nearby devices" is needed (Bluetooth connection to the Mac, never used for location) and "Continue" re-triggers the OS permission prompt. When Android no longer shows the prompt (denied twice — implicit "don't ask again" since Android 11), the dialog switches to "Open Settings" and deep-links to the app's settings page.
- **QrScannerActivity**: refuse to scan / start pairing without the permissions, as defense-in-depth (e.g. permission revoked mid-flow).

## Verification

- `scripts/build-all.sh` — passed (both platforms).
- Android unit tests (`testDebugUnitTest --rerun-tasks`) — passed. macOS unit tests skipped: build machine has only CommandLineTools, so `XCTest` is unavailable (pre-existing environment limitation; this change is Android-only).
- `scripts/hardware-smoke-test.sh` — **PASS** on a Pixel 10 (pairing, both transfer directions, reconnect cycle).
- Manually reproduced the original bug scenario on-device: deny permission at launch → tap Pair → rationale dialog instead of crash → deny again → "Open Settings" variant → grant in settings → Pair opens the QR scanner. No `FATAL EXCEPTION` in logcat throughout.

## Reviewer notes

- The permanently-denied state is detected via `shouldShowRequestPermissionRationale()` returning false after a request — Android's only signal that the prompt is exhausted ([documented behavior](https://developer.android.com/about/versions/11/privacy/permissions)).
- Google's UX guidance discourages *unprompted* settings deep-links; here the link only appears in direct response to the user tapping Pair, a feature that cannot work without the permission, and the dialog is cancelable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)