### PR TITLE
feat(android): add toggle to hide/unhide synced clipboard data

### DIFF
--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -557,7 +557,7 @@ class ClipRelayService : Service(), L2capServerCallback {
         if (decodedText.isEmpty()) return
 
         lastInboundHash = hash
-        clipboardWriter.writeText(decodedText)
+        clipboardWriter.writeText(decodedText, markSensitive = clipboardSettingsStore.isHideSyncedClipboardEnabled())
         scheduleClipboardAutoClear(decodedText)
         sendClipboardTransferBroadcast(fromMac = true)
         DebugSmokeProbe.onInboundClipboardApplied(this, decodedText)

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardWriter.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardWriter.kt
@@ -21,11 +21,13 @@ class ClipboardWriter(context: Context) {
     private val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    fun writeText(text: String) {
+    fun writeText(text: String, markSensitive: Boolean = true) {
         val applyWrite = {
             val clip = ClipData.newPlainText(CLIP_LABEL, text)
-            clip.description.extras = PersistableBundle().apply {
-                putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
+            if (markSensitive) {
+                clip.description.extras = PersistableBundle().apply {
+                    putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
+                }
             }
             runCatching { clipboard.setPrimaryClip(clip) }
             Unit

--- a/android/app/src/main/java/org/cliprelay/settings/ClipboardSettingsStore.kt
+++ b/android/app/src/main/java/org/cliprelay/settings/ClipboardSettingsStore.kt
@@ -8,6 +8,7 @@ class ClipboardSettingsStore(context: Context) {
     companion object {
         private const val PREFS_NAME = "cliprelay_settings"
         private const val KEY_AUTO_CLEAR_SYNCED_CLIPBOARD = "auto_clear_synced_clipboard"
+        private const val KEY_HIDE_SYNCED_CLIPBOARD = "hide_synced_clipboard"
         const val KEY_AUTO_COPY_ENABLED = "auto_copy_enabled"
         const val KEY_AUTO_COPY_ONBOARDING_SHOWN = "auto_copy_onboarding_shown"
 
@@ -22,6 +23,16 @@ class ClipboardSettingsStore(context: Context) {
 
     fun setAutoClearSyncedClipboardEnabled(enabled: Boolean) {
         prefs.edit().putBoolean(KEY_AUTO_CLEAR_SYNCED_CLIPBOARD, enabled).apply()
+    }
+
+    /** When enabled (default), synced clipboard text is marked sensitive so the
+     *  system hides it from previews and editor suggestions. */
+    fun isHideSyncedClipboardEnabled(): Boolean {
+        return prefs.getBoolean(KEY_HIDE_SYNCED_CLIPBOARD, true)
+    }
+
+    fun setHideSyncedClipboardEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_HIDE_SYNCED_CLIPBOARD, enabled).apply()
     }
 
     fun isAutoCopyEnabled(): Boolean {

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -88,6 +88,7 @@ fun ClipRelayScreen(
     showBurst: Boolean,
     clipboardTransferFlow: Flow<Boolean> = emptyFlow(),
     autoClearEnabled: Boolean,
+    hideClipboardEnabled: Boolean = true,
     autoCopyEnabled: Boolean,
     autoCopyAccessibilityEnabled: Boolean = false,
     imageSyncEnabled: Boolean = false,
@@ -98,6 +99,7 @@ fun ClipRelayScreen(
     onForgetMacClick: (String) -> Unit = {},
     onBurstShown: () -> Unit,
     onAutoClearSettingChanged: (Boolean) -> Unit,
+    onHideClipboardSettingChanged: (Boolean) -> Unit = {},
     onAutoCopySettingChanged: (Boolean) -> Unit,
     onImageSyncSettingChanged: (Boolean) -> Unit = {},
     onAutoCopyFixClick: () -> Unit = {},
@@ -188,6 +190,7 @@ fun ClipRelayScreen(
                     state = state,
                     clipboardTransferFlow = clipboardTransferFlow,
                     autoClearEnabled = autoClearEnabled,
+                    hideClipboardEnabled = hideClipboardEnabled,
                     autoCopyEnabled = autoCopyEnabled,
                     autoCopyAccessibilityEnabled = autoCopyAccessibilityEnabled,
                     imageSyncEnabled = imageSyncEnabled,
@@ -197,6 +200,7 @@ fun ClipRelayScreen(
                     onPairClick = onPairClick,
                     onForgetMacClick = onForgetMacClick,
                     onAutoClearSettingChanged = onAutoClearSettingChanged,
+                    onHideClipboardSettingChanged = onHideClipboardSettingChanged,
                     onAutoCopySettingChanged = onAutoCopySettingChanged,
                     onImageSyncSettingChanged = onImageSyncSettingChanged,
                     onAutoCopyFixClick = onAutoCopyFixClick
@@ -322,6 +326,7 @@ private fun MainCard(
     state: AppState,
     clipboardTransferFlow: Flow<Boolean>,
     autoClearEnabled: Boolean,
+    hideClipboardEnabled: Boolean = true,
     autoCopyEnabled: Boolean,
     autoCopyAccessibilityEnabled: Boolean = false,
     imageSyncEnabled: Boolean = false,
@@ -331,6 +336,7 @@ private fun MainCard(
     onPairClick: () -> Unit,
     onForgetMacClick: (String) -> Unit = {},
     onAutoClearSettingChanged: (Boolean) -> Unit,
+    onHideClipboardSettingChanged: (Boolean) -> Unit = {},
     onAutoCopySettingChanged: (Boolean) -> Unit,
     onImageSyncSettingChanged: (Boolean) -> Unit = {},
     onAutoCopyFixClick: () -> Unit = {}
@@ -580,6 +586,11 @@ private fun MainCard(
                 onEnabledChange = onAutoClearSettingChanged
             )
             Spacer(modifier = Modifier.height(8.dp))
+            HideClipboardSettingRow(
+                enabled = hideClipboardEnabled,
+                onEnabledChange = onHideClipboardSettingChanged
+            )
+            Spacer(modifier = Modifier.height(8.dp))
             ImageSyncSettingRow(
                 enabled = imageSyncEnabled,
                 onEnabledChange = onImageSyncSettingChanged
@@ -812,6 +823,62 @@ private fun AutoClearSettingRow(
             Spacer(modifier = Modifier.height(2.dp))
             Text(
                 text = stringResource(R.string.auto_clear_setting_subtitle),
+                fontSize = 12.sp,
+                color = Color(0x80000000),
+                lineHeight = 16.sp
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Switch(
+            checked = enabled,
+            onCheckedChange = onEnabledChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Teal,
+                checkedTrackColor = Aqua.copy(alpha = 0.45f),
+                checkedBorderColor = Aqua.copy(alpha = 0.60f),
+                uncheckedThumbColor = Color(0xFF7A7A7A),
+                uncheckedTrackColor = Color(0x15000000),
+                uncheckedBorderColor = Color(0x40000000)
+            )
+        )
+    }
+}
+
+@Composable
+private fun HideClipboardSettingRow(
+    enabled: Boolean,
+    onEnabledChange: (Boolean) -> Unit
+) {
+    val toggleBg = if (enabled) Color(0x1400FFD5) else Color(0x08000000)
+    val toggleBorder = if (enabled) Color(0x2B00FFD5) else Color(0x14000000)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(toggleBg)
+            .border(1.dp, toggleBorder, RoundedCornerShape(18.dp))
+            .toggleable(
+                value = enabled,
+                role = Role.Switch,
+                onValueChange = onEnabledChange
+            )
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.hide_clipboard_setting_title),
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xCC000000)
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = stringResource(R.string.hide_clipboard_setting_subtitle),
                 fontSize = 12.sp,
                 color = Color(0x80000000),
                 lineHeight = 16.sp

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -140,12 +140,14 @@ class MainActivity : AppCompatActivity() {
         val autoClearEnabled = clipboardSettingsStore.isAutoClearSyncedClipboardEnabled()
         val autoCopyEnabled = clipboardSettingsStore.isAutoCopyEnabled()
         val imageSyncEnabled = pairingStore.isRichMediaEnabled()
-        viewModel.initState(loadMacsForUi(emptySet()), autoClearEnabled, autoCopyEnabled, imageSyncEnabled)
+        val hideClipboardEnabled = clipboardSettingsStore.isHideSyncedClipboardEnabled()
+        viewModel.initState(loadMacsForUi(emptySet()), autoClearEnabled, autoCopyEnabled, imageSyncEnabled, hideClipboardEnabled)
 
         setContent {
             val state by viewModel.state.collectAsState()
             val showBurst by viewModel.showBurst.collectAsState()
             val autoClearEnabled by viewModel.autoClearEnabled.collectAsState()
+            val hideClipboardEnabled by viewModel.hideClipboardEnabled.collectAsState()
             val autoCopyEnabled by viewModel.autoCopyEnabled.collectAsState()
             val autoCopyAccessibilityEnabled by viewModel.autoCopyAccessibilityEnabled.collectAsState()
             val imageSyncEnabled by viewModel.imageSyncEnabled.collectAsState()
@@ -200,6 +202,7 @@ class MainActivity : AppCompatActivity() {
                 showBurst = showBurst,
                 clipboardTransferFlow = viewModel.clipboardTransfer,
                 autoClearEnabled = autoClearEnabled,
+                hideClipboardEnabled = hideClipboardEnabled,
                 autoCopyEnabled = autoCopyEnabled,
                 autoCopyAccessibilityEnabled = autoCopyAccessibilityEnabled,
                 imageSyncEnabled = imageSyncEnabled,
@@ -243,6 +246,10 @@ class MainActivity : AppCompatActivity() {
                 onAutoClearSettingChanged = { enabled ->
                     viewModel.onAutoClearSettingChanged(enabled)
                     clipboardSettingsStore.setAutoClearSyncedClipboardEnabled(enabled)
+                },
+                onHideClipboardSettingChanged = { enabled ->
+                    viewModel.onHideClipboardSettingChanged(enabled)
+                    clipboardSettingsStore.setHideSyncedClipboardEnabled(enabled)
                 },
                 onAutoCopySettingChanged = { enabled ->
                     if (enabled && !isAccessibilityServiceEnabled()) {

--- a/android/app/src/main/java/org/cliprelay/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainViewModel.kt
@@ -43,6 +43,9 @@ class MainViewModel : ViewModel() {
     private val _autoClearEnabled = MutableStateFlow(false)
     val autoClearEnabled: StateFlow<Boolean> = _autoClearEnabled.asStateFlow()
 
+    private val _hideClipboardEnabled = MutableStateFlow(true)
+    val hideClipboardEnabled: StateFlow<Boolean> = _hideClipboardEnabled.asStateFlow()
+
     private val _autoCopyEnabled = MutableStateFlow(false)
     val autoCopyEnabled: StateFlow<Boolean> = _autoCopyEnabled.asStateFlow()
 
@@ -66,13 +69,15 @@ class MainViewModel : ViewModel() {
         macs: List<PairedMacUi>,
         autoClearEnabled: Boolean = false,
         autoCopyEnabled: Boolean = false,
-        imageSyncEnabled: Boolean = false
+        imageSyncEnabled: Boolean = false,
+        hideClipboardEnabled: Boolean = true
     ) {
         this.macs = macs
         refreshPairedState()
         _autoClearEnabled.value = autoClearEnabled
         _autoCopyEnabled.value = autoCopyEnabled
         _imageSyncEnabled.value = imageSyncEnabled
+        _hideClipboardEnabled.value = hideClipboardEnabled
     }
 
     /** Paired list or per-Mac connection flags changed (store re-read / connection broadcast). */
@@ -143,6 +148,10 @@ class MainViewModel : ViewModel() {
 
     fun onAutoClearSettingChanged(enabled: Boolean) {
         _autoClearEnabled.value = enabled
+    }
+
+    fun onHideClipboardSettingChanged(enabled: Boolean) {
+        _hideClipboardEnabled.value = enabled
     }
 
     fun onAutoCopySettingChanged(enabled: Boolean) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="qr_scan_prompt">On your Mac, open ClipRelay and choose \"Pair New Device…\"</string>
     <string name="auto_clear_setting_title">Auto-clear synced clipboard</string>
     <string name="auto_clear_setting_subtitle">Clear Mac-synced clipboard text after 60 seconds.</string>
+    <string name="hide_clipboard_setting_title">Hide synced clipboard</string>
+    <string name="hide_clipboard_setting_subtitle">Mark Mac-synced text as sensitive so Android hides it from previews.</string>
     <string name="auto_copy_setting_title">Auto-copy to Mac (experimental)</string>
     <string name="auto_copy_setting_subtitle_on">Automatically send copied text to Mac</string>
     <string name="auto_copy_setting_subtitle_off">Automatically send copied text to Mac. Requires Accessibility permission.</string>


### PR DESCRIPTION
## What

Adds a **"Hide synced clipboard"** toggle to the Android app's main card, letting users control whether incoming Mac-synced clipboard text is marked as sensitive.

## Why

Previously, all inbound clipboard text from the Mac was unconditionally marked `ClipDescription.EXTRA_IS_SENSITIVE`, so Android hid it from clipboard previews and editor suggestions. Some users want the synced content visible. This toggle exposes that choice while keeping the privacy-preserving default.

## Behavior

- **On (default):** synced text is marked sensitive → Android hides it from previews. Same as today.
- **Off:** text is written as a normal clip and shown like any other clipboard content.

The setting is persisted in SharedPreferences and read on each inbound write.

## Changes

- `ClipboardSettingsStore` — `isHideSyncedClipboardEnabled()` / `setHideSyncedClipboardEnabled()`, defaulting to `true`.
- `ClipboardWriter.writeText` — new `markSensitive` flag gating the `EXTRA_IS_SENSITIVE` extra.
- `ClipRelayService` — reads the setting and passes it on each inbound clipboard write.
- `MainViewModel` — new `hideClipboardEnabled` state flow, `initState` param, and handler.
- `MainActivity` — loads/persists the setting and wires the callback.
- `ClipRelayScreen` — new `HideClipboardSettingRow` toggle, mirroring the existing auto-clear row.
- `strings.xml` — new title/subtitle strings.

## Testing

- macOS app: builds (unaffected).
- Android APK: builds (`dist/cliprelay-debug.apk`).
- Android unit tests: pass (force-reran).
- Skipped: hardware smoke tests + APK install/restart (no Android device connected); macOS `swift test` (XCTest module unavailable under SwiftPM on this toolchain — pre-existing env limitation, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)