### PR TITLE
Replace Bluetooth-off modal with a menu bar warning indicator (#61)

### DIFF
--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -32,9 +32,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var telemetryManager: TelemetryManager?
     private var clipboardMonitor: ClipboardMonitor?
     private var awaitingNewPairingConnection = false
-    private var hasShownBluetoothAlert = false
     private var bluetoothOffDebounceTimer: Timer?
-    private static let bluetoothOffDebounceDelay: TimeInterval = 60.0
+    private var lastWakeTime: Date?
+    // A manual Bluetooth toggle surfaces the indicator immediately. The only debounce is for
+    // the brief off→on cycle right after wake (sleep automations re-enabling Bluetooth): within
+    // `wakeSettleWindow` of a wake we wait `bluetoothOffWakeDebounceDelay`, and `.poweredOn`
+    // cancels it before the badge ever shows. See issue #61.
+    private static let bluetoothOffWakeDebounceDelay: TimeInterval = 10.0
+    private static let wakeSettleWindow: TimeInterval = 20.0
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Start the Sparkle updater now that the app is fully launched.
@@ -196,12 +201,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             name: NSWorkspace.willSleepNotification,
             object: nil
         )
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(handleSystemDidWake),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
     }
 
     @objc private func handleSystemWillSleep(_ notification: Notification) {
         bluetoothOffDebounceTimer?.invalidate()
         bluetoothOffDebounceTimer = nil
         statusBarController.setBluetoothWarning(nil)
+    }
+
+    @objc private func handleSystemDidWake(_ notification: Notification) {
+        lastWakeTime = Date()
     }
 
     private func showBluetoothAlert(message: String, info: String) {
@@ -315,32 +330,45 @@ extension AppDelegate: ConnectionControllerDelegate {
             bluetoothOffDebounceTimer?.invalidate()
             bluetoothOffDebounceTimer = nil
             statusBarController.setBluetoothWarning(nil)
-            hasShownBluetoothAlert = false
         case .unauthorized:
-            statusBarController.setBluetoothWarning("Bluetooth permission denied")
-            if !hasShownBluetoothAlert {
-                hasShownBluetoothAlert = true
-                showBluetoothAlert(
-                    message: "Bluetooth access denied",
-                    info: "ClipRelay needs Bluetooth permission. Please grant access in System Settings > Privacy & Security > Bluetooth."
-                )
+            // Permission denied is a stable, genuinely actionable state: surface it
+            // immediately. Clicking the menu row opens the Privacy settings pane.
+            statusBarController.setBluetoothWarning("Allow Bluetooth access for ClipRelay") { [weak self] in
+                self?.openBluetoothSettings(privacy: true)
             }
         case .poweredOff:
-            if !hasShownBluetoothAlert && bluetoothOffDebounceTimer == nil {
+            // A manual/intentional disable surfaces immediately. The only case we debounce is
+            // the brief off→on blink right after wake (sleep automations re-enabling Bluetooth):
+            // there we wait, and `.poweredOn` cancels it before the badge ever shows. See #61.
+            guard bluetoothOffDebounceTimer == nil else { break }
+            let recentlyWoke = lastWakeTime.map { Date().timeIntervalSince($0) < Self.wakeSettleWindow } ?? false
+            if recentlyWoke {
                 bluetoothOffDebounceTimer = Timer.scheduledTimer(
-                    withTimeInterval: Self.bluetoothOffDebounceDelay, repeats: false
+                    withTimeInterval: Self.bluetoothOffWakeDebounceDelay, repeats: false
                 ) { [weak self] _ in
                     guard let self else { return }
                     self.bluetoothOffDebounceTimer = nil
-                    self.hasShownBluetoothAlert = true
-                    self.statusBarController.setBluetoothWarning("Bluetooth is turned off")
-                    self.showBluetoothAlert(
-                        message: "Bluetooth is turned off",
-                        info: "ClipRelay needs Bluetooth to sync your clipboard. Please enable Bluetooth in System Settings."
-                    )
+                    self.showBluetoothOffWarning()
                 }
+            } else {
+                showBluetoothOffWarning()
             }
         default: break
+        }
+    }
+
+    private func showBluetoothOffWarning() {
+        statusBarController.setBluetoothWarning("Bluetooth is turned off - please enable Bluetooth for ClipRelay to resume sync.") { [weak self] in
+            self?.openBluetoothSettings(privacy: false)
+        }
+    }
+
+    private func openBluetoothSettings(privacy: Bool) {
+        let target = privacy
+            ? "x-apple.systempreferences:com.apple.preference.security?Privacy_Bluetooth"
+            : "x-apple.systempreferences:com.apple.BluetoothSettings"
+        if let url = URL(string: target) {
+            NSWorkspace.shared.open(url)
         }
     }
 

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -331,6 +331,10 @@ extension AppDelegate: ConnectionControllerDelegate {
             bluetoothOffDebounceTimer = nil
             statusBarController.setBluetoothWarning(nil)
         case .unauthorized:
+            // Cancel a pending powered-off settle so it can't later overwrite this more
+            // specific warning (and its Privacy-pane link) with the generic message.
+            bluetoothOffDebounceTimer?.invalidate()
+            bluetoothOffDebounceTimer = nil
             // Permission denied is a stable, genuinely actionable state: surface it
             // immediately. Clicking the menu row opens the Privacy settings pane.
             statusBarController.setBluetoothWarning("Allow Bluetooth access for ClipRelay") { [weak self] in

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -24,6 +24,7 @@ final class StatusBarController {
     private var connectedPeers: [PeerSummary] = []
     private var trustedPeers: [PeerSummary] = []
     private var bluetoothWarning: String?
+    private var bluetoothWarningAction: (() -> Void)?
 
     private static let brandAqua = NSColor(red: 0, green: 1, blue: 0.835, alpha: 1) // #00FFD5
 
@@ -55,14 +56,83 @@ final class StatusBarController {
             button.title = "GP"
             return
         }
-        if !connectedPeers.isEmpty {
+        if bluetoothWarning != nil {
+            // A Bluetooth problem means the app is inactive. Keep the normal template glyph
+            // (so it renders the same soft gray as idle, not a heavier solid black) and
+            // overlay a yellow warning badge on top.
+            let template = base.copy() as! NSImage
+            template.isTemplate = true
+            button.image = template
+            showWarningBadge(on: button)
+        } else if !connectedPeers.isEmpty {
+            hideWarningBadge(on: button)
             let aqua = base.colorized(with: Self.brandAqua)
             aqua.isTemplate = false
             button.image = aqua
         } else {
+            hideWarningBadge(on: button)
             let template = base.copy() as! NSImage
             template.isTemplate = true
             button.image = template
+        }
+    }
+
+    private static let warningBadgeLayerName = "clipRelayWarningBadge"
+
+    /// Overlays a small yellow "!" badge on the top-right of the status item. Drawn as a
+    /// layer (not composited into the image) so the glyph keeps its template appearance and
+    /// the badge never intercepts the menu click.
+    private func showWarningBadge(on button: NSStatusBarButton) {
+        button.wantsLayer = true
+        guard let host = button.layer else { return }
+
+        let badge: CALayer
+        if let existing = host.sublayers?.first(where: { $0.name == Self.warningBadgeLayerName }) {
+            badge = existing
+        } else {
+            badge = CALayer()
+            badge.name = Self.warningBadgeLayerName
+            host.addSublayer(badge)
+        }
+
+        let pointSize: CGFloat = 9
+        let scale = button.window?.backingScaleFactor ?? 2
+        badge.contents = makeWarningBadgeImage(pixelDiameter: pointSize * scale)
+            .cgImage(forProposedRect: nil, context: nil, hints: nil)
+        badge.contentsGravity = .resizeAspect
+        badge.contentsScale = scale
+
+        // Sit over the top-right corner of the centered 18pt glyph. The button's backing
+        // layer is flipped (top-left origin), so the glyph's top edge is the smaller y.
+        let bounds = button.bounds
+        let glyph: CGFloat = 18
+        let glyphMaxX = (bounds.width + glyph) / 2
+        let glyphMinY = (bounds.height - glyph) / 2
+        badge.frame = CGRect(x: glyphMaxX - pointSize + 1, y: glyphMinY - 1,
+                             width: pointSize, height: pointSize)
+    }
+
+    private func hideWarningBadge(on button: NSStatusBarButton) {
+        button.layer?.sublayers?
+            .first { $0.name == Self.warningBadgeLayerName }?
+            .removeFromSuperlayer()
+    }
+
+    /// A yellow disc with a dark "!" — drawn proportionally so it stays crisp at any scale.
+    private func makeWarningBadgeImage(pixelDiameter: CGFloat) -> NSImage {
+        NSImage(size: NSSize(width: pixelDiameter, height: pixelDiameter), flipped: false) { rect in
+            let w = rect.width
+            NSColor.systemYellow.setFill()
+            NSBezierPath(ovalIn: rect).fill()
+
+            NSColor.black.setFill()
+            let stemW = w * 0.16
+            let stem = NSRect(x: rect.midX - stemW / 2, y: rect.midY - w * 0.03, width: stemW, height: w * 0.32)
+            NSBezierPath(roundedRect: stem, xRadius: stemW / 2, yRadius: stemW / 2).fill()
+            let dotD = w * 0.18
+            let dot = NSRect(x: rect.midX - dotD / 2, y: rect.midY - w * 0.30, width: dotD, height: dotD)
+            NSBezierPath(ovalIn: dot).fill()
+            return true
         }
     }
 
@@ -77,8 +147,10 @@ final class StatusBarController {
         renderMenu()
     }
 
-    func setBluetoothWarning(_ warning: String?) {
+    func setBluetoothWarning(_ warning: String?, action: (() -> Void)? = nil) {
         bluetoothWarning = warning
+        bluetoothWarningAction = action
+        updateStatusBarIcon()
         renderMenu()
     }
 
@@ -123,9 +195,20 @@ final class StatusBarController {
         menu.removeAllItems()
 
         if let bluetoothWarning {
-            let warningItem = NSMenuItem(title: bluetoothWarning, action: nil, keyEquivalent: "")
-            warningItem.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: "warning")
-            warningItem.isEnabled = false
+            let hasAction = bluetoothWarningAction != nil
+            let warningItem = NSMenuItem(
+                title: bluetoothWarning,
+                action: hasAction ? #selector(handleBluetoothWarningSelected) : nil,
+                keyEquivalent: ""
+            )
+            let warningSymbol = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: "warning")
+            // Two palette colors. The symbol's first layer is the exclamation, second is the
+            // triangle, so order them black then yellow for a yellow triangle + black mark.
+            warningItem.image = warningSymbol?.withSymbolConfiguration(
+                NSImage.SymbolConfiguration(paletteColors: [.black, .systemYellow])
+            )
+            warningItem.target = self
+            warningItem.isEnabled = hasAction
             menu.addItem(warningItem)
             menu.addItem(NSMenuItem.separator())
         }
@@ -301,6 +384,11 @@ final class StatusBarController {
     @objc
     private func handlePairNewDevice() {
         onPairNewDeviceRequested?()
+    }
+
+    @objc
+    private func handleBluetoothWarningSelected() {
+        bluetoothWarningAction?()
     }
 
     @objc

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -173,7 +173,10 @@ PLIST
         "$app_dir"
   else
     echo "Developer ID not found, signing ad-hoc with hardened runtime..."
-    codesign --force --sign - \
+    # --deep so the bundled Sparkle.framework is re-signed ad-hoc too. Without it the
+    # framework keeps its original Team ID and hardened runtime refuses to load it
+    # ("different Team IDs"), crashing the app on launch.
+    codesign --force --deep --sign - \
         --entitlements "$entitlements_path" \
         --options runtime \
         "$app_dir"


### PR DESCRIPTION
Closes #61.

## Problem
When Bluetooth is disabled, the Mac app popped a blocking `NSAlert` that stole focus. For users who toggle Bluetooth around sleep via automation (the case in #61), it reappeared on essentially every wake — disruptive for an often-intentional state.

## Change
Replace the modal with a passive, non-interrupting indicator:

- **Menu bar glyph** keeps its normal template appearance and gains a small **yellow `!` badge** at the top-right. The badge is drawn as a layer overlay rather than composited into the image, so the glyph isn't darkened to solid black and the badge never intercepts the menu click.
- **Dropdown** shows an actionable, **clickable** warning row — "Bluetooth is turned off - please enable Bluetooth for ClipRelay to resume sync." — with a yellow triangle + black exclamation. Clicking opens the correct Settings pane (Bluetooth, or Privacy > Bluetooth for the permission-denied case).
- **No modal** for either powered-off or unauthorized; the old "show once" flag is removed.

### Wake-aware timing
A manual Bluetooth toggle now surfaces the badge **immediately**. A short settle is kept **only** within ~20s of wake, to absorb the brief off→on blink from sleep automations — it's cancelled the moment Bluetooth powers back on, so the badge never flashes on wake. The previous flat 60s debounce (originally there to delay the modal) is gone.

## Also included
`fix(build): add --deep to ad-hoc macOS signing branch` — the ad-hoc fallback in `build-all.sh` didn't `--deep`-sign, so the bundled `Sparkle.framework` kept its original Team ID and hardened runtime refused to load it ("different Team IDs"), crashing ad-hoc builds (CI / cert-less machines) on launch. Mirrors the Developer-ID branch.

## Testing
- `swift test` — 146 passing
- `build-all.sh --mac-only` builds + signs cleanly; app verified running
- Note: the new badge/menu indicator is visual and only appears with Bluetooth off; reviewers can confirm by toggling Bluetooth.