### PR TITLE
feat: shareable deep BLE/pairing diagnostics (extends #58 share logs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - After every major code change (new feature, bug fix, refactor), restart both apps so the user can immediately verify the fix:
   - **Mac**: Kill any running ClipRelay process (`pkill -f ClipRelay`) and relaunch with `open dist/ClipRelay.app`
   - **Android**: Install the new APK (`adb install -r dist/cliprelay-debug.apk`), force-stop the app (`adb shell am force-stop org.cliprelay`), and relaunch (`adb shell am start -n org.cliprelay/.ui.MainActivity`)
+    - If install fails with `INSTALL_FAILED_VERSION_DOWNGRADE` or `INSTALL_FAILED_UPDATE_INCOMPATIBLE` (the device has a higher-`versionCode` or release/Play-Store-signed build, and the local debug APK is `versionCode` 1 with the debug signature), just **uninstall first, then install**: `adb uninstall org.cliprelay && adb install dist/cliprelay-debug.apk`. The `-d` (allow-downgrade) flag does NOT help — it only works for debuggable installs, and it can't bridge a signature mismatch. Uninstalling wipes the app's data (pairing/settings), so the user will need to re-pair — which is fine, since they typically re-pair to test anyway.
 - Do not skip this step or tell the user to do it manually.
 
 ## macOS Notarization

--- a/android/app/src/main/java/org/cliprelay/ble/L2capServer.kt
+++ b/android/app/src/main/java/org/cliprelay/ble/L2capServer.kt
@@ -5,6 +5,7 @@ package org.cliprelay.ble
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothServerSocket
 import android.bluetooth.BluetoothSocket
+import android.util.Log
 import java.io.IOException
 
 interface L2capServerCallback {
@@ -16,6 +17,10 @@ class L2capServer(
     private val adapter: BluetoothAdapter,
     private val callback: L2capServerCallback
 ) {
+    companion object {
+        private const val TAG = "L2capServer"
+    }
+
     private var serverSocket: BluetoothServerSocket? = null
     private var acceptThread: Thread? = null
 
@@ -30,14 +35,17 @@ class L2capServer(
         val socket = adapter.listenUsingInsecureL2capChannel()
         serverSocket = socket
         val psm = socket.psm
+        Log.i(TAG, "L2CAP server listening (psm=$psm), waiting for central to connect")
 
         acceptThread = Thread({
             while (!Thread.currentThread().isInterrupted) {
                 try {
                     val client = socket.accept() // blocks until connection
+                    Log.i(TAG, "Accepted incoming L2CAP connection from ${client.remoteDevice?.address ?: "unknown"}")
                     callback.onClientConnected(client)
                 } catch (e: IOException) {
                     if (!Thread.currentThread().isInterrupted) {
+                        Log.w(TAG, "L2CAP accept error: ${e.message}")
                         callback.onAcceptError(e)
                     }
                     break
@@ -54,5 +62,6 @@ class L2capServer(
         try { serverSocket?.close() } catch (_: IOException) {}
         acceptThread = null
         serverSocket = null
+        Log.i(TAG, "L2CAP server stopped")
     }
 }

--- a/android/app/src/main/java/org/cliprelay/feedback/LogShareExporter.kt
+++ b/android/app/src/main/java/org/cliprelay/feedback/LogShareExporter.kt
@@ -1,52 +1,53 @@
 package org.cliprelay.feedback
 
-import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.os.Process
-import androidx.core.content.FileProvider
-import java.io.File
+import org.cliprelay.pairing.PairingStore
+import org.cliprelay.settings.ClipboardSettingsStore
 import java.time.Instant
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 object LogShareExporter {
-    private const val LOG_DIR = "shared_logs"
-    private const val LOG_FILE_PREFIX = "cliprelay-android-logs"
     private const val LOG_LINE_LIMIT = "2000"
-    private val fileTimestampFormatter =
-        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss", Locale.US).withZone(ZoneOffset.UTC)
+
+    // Shared as plain text via the system share sheet (ACTION_SEND + EXTRA_TEXT)
+    // rather than a .txt attachment — text is far easier to paste into a chat,
+    // email, or issue on Android. The extra travels through a Binder transaction
+    // (~1 MB process-wide budget), so cap the body well under that to avoid
+    // TransactionTooLargeException.
+    private const val MAX_LOG_CHARS = 100_000
 
     fun createShareIntent(context: Context, bleState: String): Intent {
-        val now = Instant.now()
-        val logFile = writeLogFile(context, now, bleState, captureLogcat())
-        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", logFile)
+        val text = buildShareText(
+            diagnosticsContext = collectContext(context, bleState),
+            generatedAt = Instant.now(),
+            logOutput = captureLogcat(),
+        )
         return Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"
             putExtra(Intent.EXTRA_SUBJECT, "ClipRelay Android logs")
-            putExtra(Intent.EXTRA_STREAM, uri)
-            clipData = ClipData.newUri(context.contentResolver, "ClipRelay Android logs", uri)
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            putExtra(Intent.EXTRA_TEXT, text)
         }
     }
 
-    internal fun writeLogFile(
-        context: Context,
-        now: Instant,
-        bleState: String,
-        logOutput: String
-    ): File {
-        val shareDir = File(context.cacheDir, LOG_DIR).apply { mkdirs() }
-        val file = File(shareDir, buildFileName(now))
-        file.writeText(buildFileContents(SupportLinks.diagnosticsContext(bleState), now, logOutput))
-        return file
+    /** App / device / flag context prepended to every shared log. */
+    private fun collectContext(context: Context, bleState: String): List<Pair<String, String>> {
+        val settings = ClipboardSettingsStore(context)
+        val pairing = PairingStore(context)
+        val flags = listOf(
+            "autoCopy" to settings.isAutoCopyEnabled(),
+            "hideSyncedClipboard" to settings.isHideSyncedClipboardEnabled(),
+            "autoClearSyncedClipboard" to settings.isAutoClearSyncedClipboardEnabled(),
+            "imageSync" to pairing.isRichMediaEnabled(),
+        ).joinToString(", ") { "${it.first}=${it.second}" }
+        return SupportLinks.diagnosticsContext(bleState) + listOf(
+            "Paired Macs" to pairing.loadPairedMacs().size.toString(),
+            "Flags" to flags,
+        )
     }
 
-    internal fun buildFileName(now: Instant): String =
-        "$LOG_FILE_PREFIX-${fileTimestampFormatter.format(now)}.txt"
-
-    internal fun buildFileContents(
+    internal fun buildShareText(
         diagnosticsContext: List<Pair<String, String>>,
         generatedAt: Instant,
         logOutput: String
@@ -60,7 +61,16 @@ object LogShareExporter {
         }
         appendLine()
         appendLine("---- LOGCAT ----")
-        appendLine(logOutput.ifBlank { "No recent ClipRelay logs were available for this process." })
+        appendLine(trimToBudget(logOutput).ifBlank { "No recent ClipRelay logs were available for this process." })
+    }
+
+    /** Keep the most recent lines within [MAX_LOG_CHARS], dropping the partial head line. */
+    internal fun trimToBudget(log: String): String {
+        if (log.length <= MAX_LOG_CHARS) return log
+        val tail = log.substring(log.length - MAX_LOG_CHARS)
+        val firstNewline = tail.indexOf('\n')
+        val clean = if (firstNewline >= 0) tail.substring(firstNewline + 1) else tail
+        return "[… older log lines truncated to fit the share size limit …]\n$clean"
     }
 
     private fun captureLogcat(): String = runCatching {

--- a/android/app/src/main/java/org/cliprelay/feedback/LogShareExporter.kt
+++ b/android/app/src/main/java/org/cliprelay/feedback/LogShareExporter.kt
@@ -1,0 +1,88 @@
+package org.cliprelay.feedback
+
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.os.Process
+import androidx.core.content.FileProvider
+import java.io.File
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+object LogShareExporter {
+    private const val LOG_DIR = "shared_logs"
+    private const val LOG_FILE_PREFIX = "cliprelay-android-logs"
+    private const val LOG_LINE_LIMIT = "2000"
+    private val fileTimestampFormatter =
+        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss", Locale.US).withZone(ZoneOffset.UTC)
+
+    fun createShareIntent(context: Context, bleState: String): Intent {
+        val now = Instant.now()
+        val logFile = writeLogFile(context, now, bleState, captureLogcat())
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", logFile)
+        return Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_SUBJECT, "ClipRelay Android logs")
+            putExtra(Intent.EXTRA_STREAM, uri)
+            clipData = ClipData.newUri(context.contentResolver, "ClipRelay Android logs", uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+
+    internal fun writeLogFile(
+        context: Context,
+        now: Instant,
+        bleState: String,
+        logOutput: String
+    ): File {
+        val shareDir = File(context.cacheDir, LOG_DIR).apply { mkdirs() }
+        val file = File(shareDir, buildFileName(now))
+        file.writeText(buildFileContents(SupportLinks.diagnosticsContext(bleState), now, logOutput))
+        return file
+    }
+
+    internal fun buildFileName(now: Instant): String =
+        "$LOG_FILE_PREFIX-${fileTimestampFormatter.format(now)}.txt"
+
+    internal fun buildFileContents(
+        diagnosticsContext: List<Pair<String, String>>,
+        generatedAt: Instant,
+        logOutput: String
+    ): String = buildString {
+        appendLine("ClipRelay Android diagnostics")
+        appendLine("Generated: ${DateTimeFormatter.ISO_INSTANT.format(generatedAt)}")
+        appendLine("Included logs: current ClipRelay process logcat snapshot (up to $LOG_LINE_LIMIT lines)")
+        appendLine()
+        diagnosticsContext.forEach { (label, value) ->
+            appendLine("$label: $value")
+        }
+        appendLine()
+        appendLine("---- LOGCAT ----")
+        appendLine(logOutput.ifBlank { "No recent ClipRelay logs were available for this process." })
+    }
+
+    private fun captureLogcat(): String = runCatching {
+        val process = ProcessBuilder(
+            "logcat",
+            "-d",
+            "-v",
+            "threadtime",
+            "--pid=${Process.myPid()}",
+            "-t",
+            LOG_LINE_LIMIT
+        )
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText().trimEnd() }
+        val exitCode = process.waitFor()
+        if (exitCode == 0) {
+            output
+        } else {
+            "logcat exited with code $exitCode.\n$output"
+        }
+    }.getOrElse { error ->
+        "Unable to capture logcat: ${error.message ?: error.javaClass.simpleName}"
+    }
+}

--- a/android/app/src/main/java/org/cliprelay/feedback/SupportLinks.kt
+++ b/android/app/src/main/java/org/cliprelay/feedback/SupportLinks.kt
@@ -13,8 +13,11 @@ object SupportLinks {
         "Device" to "${Build.MANUFACTURER} ${Build.MODEL}",
     )
 
+    fun diagnosticsContext(bleState: String): List<Pair<String, String>> =
+        deviceContext() + ("BLE State" to bleState)
+
     fun gitHubIssueUrl(bleState: String): String {
-        val lines = (deviceContext() + ("BLE State" to bleState))
+        val lines = diagnosticsContext(bleState)
             .joinToString("\n") { "- **${it.first}:** ${it.second}" }
         val body = "\n\n---\n$lines"
         return Uri.parse("https://github.com/geekflyer/cliprelay/issues/new").buildUpon()
@@ -25,7 +28,7 @@ object SupportLinks {
     }
 
     fun emailUrl(bleState: String): String {
-        val lines = (deviceContext() + ("BLE State" to bleState))
+        val lines = diagnosticsContext(bleState)
             .joinToString("\n") { "${it.first}: ${it.second}" }
         val body = "\n\n---\n$lines"
         return "mailto:info@cliprelay.org" +

--- a/android/app/src/main/java/org/cliprelay/feedback/SupportLinks.kt
+++ b/android/app/src/main/java/org/cliprelay/feedback/SupportLinks.kt
@@ -8,7 +8,8 @@ import org.cliprelay.BuildConfig
 
 object SupportLinks {
     private fun deviceContext(): List<Pair<String, String>> = listOf(
-        "App Version" to "${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_HASH})",
+        "App Version" to "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}, ${BuildConfig.GIT_HASH})" +
+            if (BuildConfig.DEBUG) " [debug]" else "",
         "OS" to "Android ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})",
         "Device" to "${Build.MANUFACTURER} ${Build.MODEL}",
     )

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -105,6 +105,7 @@ fun ClipRelayScreen(
     onAutoCopyFixClick: () -> Unit = {},
     onHelpClick: () -> Unit = {},
     onSupportLinkClick: (String) -> Unit = {},
+    onShareLogsClick: (String) -> Unit = {},
 ) {
     val isConnected = state is AppState.Paired && state.anyConnected
     val isPaired = state !is AppState.Unpaired
@@ -216,6 +217,7 @@ fun ClipRelayScreen(
                 },
                 onHelpClick = onHelpClick,
                 onSupportLinkClick = onSupportLinkClick,
+                onShareLogsClick = onShareLogsClick,
             )
             }
         }
@@ -1182,7 +1184,13 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawMacIcon(tint: C
 
 // ─── Footer ──────────────────────────────────────────────────────────────────
 @Composable
-private fun FooterSection(isPaired: Boolean, bleState: String = "unknown", onHelpClick: () -> Unit, onSupportLinkClick: (String) -> Unit) {
+private fun FooterSection(
+    isPaired: Boolean,
+    bleState: String = "unknown",
+    onHelpClick: () -> Unit,
+    onSupportLinkClick: (String) -> Unit,
+    onShareLogsClick: (String) -> Unit
+) {
     var showSupportDialog by remember { mutableStateOf(false) }
 
     Column(
@@ -1228,17 +1236,29 @@ private fun FooterSection(isPaired: Boolean, bleState: String = "unknown", onHel
                 showSupportDialog = false
                 onSupportLinkClick(url)
             },
+            onShareLogsClick = {
+                showSupportDialog = false
+                onShareLogsClick(bleState)
+            },
         )
     }
 }
 
 @Composable
-private fun SupportDialog(bleState: String, onDismiss: () -> Unit, onLinkClick: (String) -> Unit) {
+private fun SupportDialog(
+    bleState: String,
+    onDismiss: () -> Unit,
+    onLinkClick: (String) -> Unit,
+    onShareLogsClick: () -> Unit
+) {
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Feedback & Support") },
         text = {
             Column {
+                TextButton(onClick = onShareLogsClick) {
+                    Text(stringResource(R.string.support_share_logs), modifier = Modifier.fillMaxWidth())
+                }
                 TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.gitHubIssueUrl(bleState)) }) {
                     Text("Report Issue on GitHub", modifier = Modifier.fillMaxWidth())
                 }

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -24,11 +24,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
+import org.cliprelay.R
+import org.cliprelay.feedback.LogShareExporter
 import org.cliprelay.pairing.PairingStore
 import org.cliprelay.permissions.BlePermissions
 import org.cliprelay.service.ClipboardAccessibilityService
 import org.cliprelay.service.ClipRelayService
 import org.cliprelay.settings.ClipboardSettingsStore
+import kotlin.concurrent.thread
 
 class MainActivity : AppCompatActivity() {
 
@@ -275,6 +278,9 @@ class MainActivity : AppCompatActivity() {
                 onSupportLinkClick = { url ->
                     startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
                 },
+                onShareLogsClick = { bleState ->
+                    shareLogs(bleState)
+                },
             )
         }
     }
@@ -371,6 +377,33 @@ class MainActivity : AppCompatActivity() {
         }
         if (missing.isNotEmpty()) {
             permissionLauncher.launch(missing.toTypedArray())
+        }
+    }
+
+    private fun shareLogs(bleState: String) {
+        thread(name = "share-logs") {
+            val result = runCatching {
+                LogShareExporter.createShareIntent(applicationContext, bleState)
+            }
+            runOnUiThread {
+                result.onSuccess { shareIntent ->
+                    val chooser = Intent.createChooser(
+                        shareIntent,
+                        getString(R.string.share_logs_chooser_title)
+                    ).apply {
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        clipData = shareIntent.clipData
+                    }
+                    startActivity(chooser)
+                }.onFailure { error ->
+                    val reason = error.message ?: error.javaClass.simpleName
+                    Toast.makeText(
+                        this,
+                        getString(R.string.share_logs_failed, reason),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -395,10 +395,7 @@ class MainActivity : AppCompatActivity() {
                     val chooser = Intent.createChooser(
                         shareIntent,
                         getString(R.string.share_logs_chooser_title)
-                    ).apply {
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                        clipData = shareIntent.clipData
-                    }
+                    )
                     startActivity(chooser)
                 }.onFailure { error ->
                     val reason = error.message ?: error.javaClass.simpleName

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import org.cliprelay.R
 import org.cliprelay.feedback.LogShareExporter
 import org.cliprelay.pairing.PairingStore
@@ -31,7 +32,9 @@ import org.cliprelay.permissions.BlePermissions
 import org.cliprelay.service.ClipboardAccessibilityService
 import org.cliprelay.service.ClipRelayService
 import org.cliprelay.settings.ClipboardSettingsStore
-import kotlin.concurrent.thread
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class MainActivity : AppCompatActivity() {
 
@@ -381,11 +384,13 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun shareLogs(bleState: String) {
-        thread(name = "share-logs") {
+        // lifecycleScope auto-cancels if the activity is destroyed during the
+        // capture, so the UI callback never touches a finishing activity.
+        lifecycleScope.launch(Dispatchers.IO) {
             val result = runCatching {
                 LogShareExporter.createShareIntent(applicationContext, bleState)
             }
-            runOnUiThread {
+            withContext(Dispatchers.Main) {
                 result.onSuccess { shareIntent ->
                     val chooser = Intent.createChooser(
                         shareIntent,
@@ -398,7 +403,7 @@ class MainActivity : AppCompatActivity() {
                 }.onFailure { error ->
                     val reason = error.message ?: error.javaClass.simpleName
                     Toast.makeText(
-                        this,
+                        this@MainActivity,
                         getString(R.string.share_logs_failed, reason),
                         Toast.LENGTH_LONG
                     ).show()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -53,4 +53,7 @@
     <string name="ble_permission_open_settings">Open Settings</string>
     <string name="ble_permission_cancel">Cancel</string>
     <string name="ble_permission_required_toast">Nearby devices permission is required to pair</string>
+    <string name="support_share_logs">Share Logs</string>
+    <string name="share_logs_chooser_title">Share ClipRelay logs</string>
+    <string name="share_logs_failed">Could not prepare logs to share: %1$s</string>
 </resources>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <cache-path name="shared_images" path="shared_images/" />
-    <cache-path name="shared_logs" path="shared_logs/" />
 </paths>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <cache-path name="shared_images" path="shared_images/" />
+    <cache-path name="shared_logs" path="shared_logs/" />
 </paths>

--- a/android/app/src/test/java/org/cliprelay/feedback/LogShareExporterTest.kt
+++ b/android/app/src/test/java/org/cliprelay/feedback/LogShareExporterTest.kt
@@ -1,6 +1,7 @@
 package org.cliprelay.feedback
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
@@ -8,28 +9,50 @@ import java.time.Instant
 class LogShareExporterTest {
 
     @Test
-    fun `build file name uses utc timestamp`() {
-        val name = LogShareExporter.buildFileName(Instant.parse("2026-04-11T15:42:05Z"))
-
-        assertEquals("cliprelay-android-logs-20260411-154205.txt", name)
-    }
-
-    @Test
-    fun `build file contents includes diagnostics and logs`() {
-        val contents = LogShareExporter.buildFileContents(
+    fun `share text includes diagnostics context and logs`() {
+        val text = LogShareExporter.buildShareText(
             diagnosticsContext = listOf(
-                "App Version" to "1.2.3 (abc123)",
-                "BLE State" to "connected"
+                "App Version" to "0.7.0 (1, abc123) [debug]",
+                "BLE State" to "connected",
+                "Paired Macs" to "1",
+                "Flags" to "autoCopy=true, imageSync=false",
             ),
             generatedAt = Instant.parse("2026-04-11T15:42:05Z"),
             logOutput = "04-11 15:42:05.000 ClipRelayService: ready"
         )
 
-        assertTrue(contents.contains("ClipRelay Android diagnostics"))
-        assertTrue(contents.contains("Generated: 2026-04-11T15:42:05Z"))
-        assertTrue(contents.contains("App Version: 1.2.3 (abc123)"))
-        assertTrue(contents.contains("BLE State: connected"))
-        assertTrue(contents.contains("---- LOGCAT ----"))
-        assertTrue(contents.contains("ClipRelayService: ready"))
+        assertTrue(text.contains("ClipRelay Android diagnostics"))
+        assertTrue(text.contains("Generated: 2026-04-11T15:42:05Z"))
+        assertTrue(text.contains("App Version: 0.7.0 (1, abc123) [debug]"))
+        assertTrue(text.contains("Paired Macs: 1"))
+        assertTrue(text.contains("Flags: autoCopy=true, imageSync=false"))
+        assertTrue(text.contains("---- LOGCAT ----"))
+        assertTrue(text.contains("ClipRelayService: ready"))
+    }
+
+    @Test
+    fun `share text notes when no logs are available`() {
+        val text = LogShareExporter.buildShareText(
+            diagnosticsContext = emptyList(),
+            generatedAt = Instant.parse("2026-04-11T15:42:05Z"),
+            logOutput = ""
+        )
+        assertTrue(text.contains("No recent ClipRelay logs were available for this process."))
+    }
+
+    @Test
+    fun `trimToBudget keeps recent lines and drops the oldest`() {
+        val big = "OLDEST_LINE\n" + ("x".repeat(100) + "\n").repeat(2000) // ~202k chars
+        val trimmed = LogShareExporter.trimToBudget(big)
+
+        assertTrue("should be bounded", trimmed.length <= 100_080)
+        assertTrue("marks truncation", trimmed.startsWith("[… older log lines truncated"))
+        assertFalse("drops the oldest line", trimmed.contains("OLDEST_LINE"))
+    }
+
+    @Test
+    fun `trimToBudget returns input unchanged when within budget`() {
+        val small = "04-11 15:42:05.000 line one\n04-11 15:42:06.000 line two"
+        assertEquals(small, LogShareExporter.trimToBudget(small))
     }
 }

--- a/android/app/src/test/java/org/cliprelay/feedback/LogShareExporterTest.kt
+++ b/android/app/src/test/java/org/cliprelay/feedback/LogShareExporterTest.kt
@@ -1,0 +1,35 @@
+package org.cliprelay.feedback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class LogShareExporterTest {
+
+    @Test
+    fun `build file name uses utc timestamp`() {
+        val name = LogShareExporter.buildFileName(Instant.parse("2026-04-11T15:42:05Z"))
+
+        assertEquals("cliprelay-android-logs-20260411-154205.txt", name)
+    }
+
+    @Test
+    fun `build file contents includes diagnostics and logs`() {
+        val contents = LogShareExporter.buildFileContents(
+            diagnosticsContext = listOf(
+                "App Version" to "1.2.3 (abc123)",
+                "BLE State" to "connected"
+            ),
+            generatedAt = Instant.parse("2026-04-11T15:42:05Z"),
+            logOutput = "04-11 15:42:05.000 ClipRelayService: ready"
+        )
+
+        assertTrue(contents.contains("ClipRelay Android diagnostics"))
+        assertTrue(contents.contains("Generated: 2026-04-11T15:42:05Z"))
+        assertTrue(contents.contains("App Version: 1.2.3 (abc123)"))
+        assertTrue(contents.contains("BLE State: connected"))
+        assertTrue(contents.contains("---- LOGCAT ----"))
+        assertTrue(contents.contains("ClipRelayService: ready"))
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/DiagnosticLog.swift
+++ b/macos/ClipRelayMac/Sources/App/DiagnosticLog.swift
@@ -1,0 +1,97 @@
+// Append-only diagnostic log persisted to a file under Application Support.
+//
+// `os.Logger` output is invisible to the unified log / `log show` in our SPM
+// release builds, so users (and the maintainer) cannot see why BLE pairing or
+// reconnection fails on shipped builds. This logger mirrors the critical BLE
+// and pairing events to a rotating file that the menu-bar "Share Logs" action
+// can read back, regardless of how os_log is configured.
+
+import Foundation
+import os
+
+final class DiagnosticLog {
+    static let shared = DiagnosticLog()
+
+    /// All writes (and the consistent read in `currentLogText()`) are serialized here.
+    private let queue = DispatchQueue(label: "org.cliprelay.diagnostics")
+    /// Mirror to os.Logger too, so Console still works during local development.
+    private let logger = Logger(subsystem: "org.cliprelay", category: "Diagnostics")
+
+    /// Rotate once the active file passes this size; one previous file is kept,
+    /// so the shared log is bounded to roughly twice this.
+    private let maxBytes: UInt64 = 512_000
+
+    private let fileURL: URL?
+    private let previousFileURL: URL?
+    private let timestampFormatter: ISO8601DateFormatter
+
+    private init() {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        self.timestampFormatter = formatter
+
+        let directory = (try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ))?.appendingPathComponent("ClipRelay", isDirectory: true)
+
+        if let directory {
+            try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        self.fileURL = directory?.appendingPathComponent("diagnostics.log", isDirectory: false)
+        self.previousFileURL = directory?.appendingPathComponent("diagnostics.1.log", isDirectory: false)
+
+        // Stamp every session with app + OS context so a shared log is self-describing.
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+        log("ClipRelay \(version) (\(build)) — \(osVersion) — diagnostics session start", category: "App")
+    }
+
+    /// Record one diagnostic line. Safe to call from any thread; file I/O is async.
+    func log(_ message: String, category: String = "App") {
+        logger.notice("[\(category, privacy: .public)] \(message, privacy: .public)")
+        let line = "\(timestampFormatter.string(from: Date())) [\(category)] \(message)\n"
+        queue.async { [weak self] in
+            self?.append(line)
+        }
+    }
+
+    /// The full diagnostic history (rotated + current), oldest first. Returns an
+    /// empty string when nothing has been logged yet.
+    func currentLogText() -> String {
+        queue.sync {
+            let previous = previousFileURL.flatMap { try? String(contentsOf: $0, encoding: .utf8) } ?? ""
+            let current = fileURL.flatMap { try? String(contentsOf: $0, encoding: .utf8) } ?? ""
+            return previous + current
+        }
+    }
+
+    // MARK: - File writing (queue-only)
+
+    private func append(_ line: String) {
+        guard let fileURL, let data = line.data(using: .utf8) else { return }
+        rotateIfNeeded()
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: fileURL.path) {
+            fm.createFile(atPath: fileURL.path, contents: data)
+            return
+        }
+        guard let handle = try? FileHandle(forWritingTo: fileURL) else { return }
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        try? handle.write(contentsOf: data)
+    }
+
+    private func rotateIfNeeded() {
+        guard let fileURL, let previousFileURL else { return }
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+              let size = (attributes[.size] as? NSNumber)?.uint64Value, size > maxBytes else { return }
+        let fm = FileManager.default
+        try? fm.removeItem(at: previousFileURL)
+        try? fm.moveItem(at: fileURL, to: previousFileURL)
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
+++ b/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
@@ -1,27 +1,20 @@
 import Foundation
 
 enum LogShareExporter {
-    private static let shareDirectoryName = "ClipRelaySharedLogs"
+    // Shared as plain text via NSSharingServicePicker rather than a .txt file —
+    // text drops straight into Mail/Messages/Notes or the pasteboard. The
+    // diagnostic log is already bounded by rotation; cap each section's tail so
+    // a debug-build unified-log dump can't bloat the share.
+    private static let maxDiagnosticChars = 400_000
+    private static let maxUnifiedLogChars = 200_000
 
-    static func exportLogs(deviceContext: [(String, String)]) throws -> URL {
-        let now = Date()
-        let shareDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(shareDirectoryName, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: shareDirectory,
-            withIntermediateDirectories: true,
-            attributes: nil
-        )
-
-        let fileURL = shareDirectory.appendingPathComponent(buildFileName(for: now), isDirectory: false)
-        let contents = buildFileContents(
+    static func exportLogs(deviceContext: [(String, String)]) -> String {
+        buildShareText(
             deviceContext: deviceContext,
-            generatedAt: now,
-            diagnosticLog: DiagnosticLog.shared.currentLogText(),
-            logs: captureUnifiedLogs()
+            generatedAt: Date(),
+            diagnosticLog: tail(DiagnosticLog.shared.currentLogText(), maxChars: maxDiagnosticChars),
+            logs: tail(captureUnifiedLogs(), maxChars: maxUnifiedLogChars)
         )
-        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
-        return fileURL
     }
 
     private static func captureUnifiedLogs() -> String {
@@ -66,15 +59,19 @@ enum LogShareExporter {
         return output.isEmpty ? "No recent ClipRelay unified logs were available." : output
     }
 
-    static func buildFileName(for date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyyMMdd-HHmmss"
-        return "cliprelay-mac-logs-\(formatter.string(from: date)).txt"
+    /// Keep the most recent `maxChars`, dropping the now-partial leading line.
+    static func tail(_ string: String, maxChars: Int) -> String {
+        guard string.count > maxChars else { return string }
+        let start = string.index(string.endIndex, offsetBy: -maxChars)
+        let trimmed = string[start...]
+        if let newline = trimmed.firstIndex(of: "\n") {
+            return "[… older lines truncated to fit the share size limit …]\n"
+                + trimmed[trimmed.index(after: newline)...]
+        }
+        return String(trimmed)
     }
 
-    static func buildFileContents(
+    static func buildShareText(
         deviceContext: [(String, String)],
         generatedAt: Date,
         diagnosticLog: String,

--- a/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
+++ b/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
@@ -17,6 +17,7 @@ enum LogShareExporter {
         let contents = buildFileContents(
             deviceContext: deviceContext,
             generatedAt: now,
+            diagnosticLog: DiagnosticLog.shared.currentLogText(),
             logs: captureUnifiedLogs()
         )
         try contents.write(to: fileURL, atomically: true, encoding: .utf8)
@@ -35,7 +36,7 @@ enum LogShareExporter {
             "--last",
             "24h",
             "--predicate",
-            "subsystem == \"org.cliprelay\"",
+            "subsystem == \"org.cliprelay\" OR process == \"ClipRelay\"",
         ]
         process.standardOutput = stdout
         process.standardError = stderr
@@ -65,7 +66,7 @@ enum LogShareExporter {
         return output.isEmpty ? "No recent ClipRelay unified logs were available." : output
     }
 
-    private static func buildFileName(for date: Date) -> String {
+    static func buildFileName(for date: Date) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
@@ -73,19 +74,24 @@ enum LogShareExporter {
         return "cliprelay-mac-logs-\(formatter.string(from: date)).txt"
     }
 
-    private static func buildFileContents(
+    static func buildFileContents(
         deviceContext: [(String, String)],
         generatedAt: Date,
+        diagnosticLog: String,
         logs: String
     ) -> String {
         let formatter = ISO8601DateFormatter()
         let contextLines = deviceContext.map { "\($0.0): \($0.1)" }.joined(separator: "\n")
+        let diagnostics = diagnosticLog.trimmingCharacters(in: .whitespacesAndNewlines)
         return """
         ClipRelay macOS diagnostics
         Generated: \(formatter.string(from: generatedAt))
-        Included logs: ClipRelay unified log snapshot from the last 24 hours
+        Included logs: ClipRelay diagnostic log (BLE/pairing trace) + unified log snapshot from the last 24 hours
 
         \(contextLines)
+
+        ---- DIAGNOSTIC LOG (BLE / pairing) ----
+        \(diagnostics.isEmpty ? "No diagnostic log entries were recorded yet." : diagnostics)
 
         ---- UNIFIED LOGS ----
         \(logs)

--- a/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
+++ b/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
@@ -42,7 +42,6 @@ enum LogShareExporter {
 
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return "Unable to capture unified logs: \(error.localizedDescription)"
         }
@@ -51,6 +50,7 @@ enum LogShareExporter {
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let errorOutput = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        process.waitUntilExit()
 
         guard process.terminationStatus == 0 else {
             return """

--- a/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
+++ b/macos/ClipRelayMac/Sources/App/LogShareExporter.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+enum LogShareExporter {
+    private static let shareDirectoryName = "ClipRelaySharedLogs"
+
+    static func exportLogs(deviceContext: [(String, String)]) throws -> URL {
+        let now = Date()
+        let shareDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(shareDirectoryName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: shareDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let fileURL = shareDirectory.appendingPathComponent(buildFileName(for: now), isDirectory: false)
+        let contents = buildFileContents(
+            deviceContext: deviceContext,
+            generatedAt: now,
+            logs: captureUnifiedLogs()
+        )
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL
+    }
+
+    private static func captureUnifiedLogs() -> String {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        process.arguments = [
+            "show",
+            "--style",
+            "compact",
+            "--last",
+            "24h",
+            "--predicate",
+            "subsystem == \"org.cliprelay\"",
+        ]
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return "Unable to capture unified logs: \(error.localizedDescription)"
+        }
+
+        let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let errorOutput = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            return """
+            `log show` exited with status \(process.terminationStatus).
+
+            \(errorOutput)
+
+            \(output)
+            """.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return output.isEmpty ? "No recent ClipRelay unified logs were available." : output
+    }
+
+    private static func buildFileName(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return "cliprelay-mac-logs-\(formatter.string(from: date)).txt"
+    }
+
+    private static func buildFileContents(
+        deviceContext: [(String, String)],
+        generatedAt: Date,
+        logs: String
+    ) -> String {
+        let formatter = ISO8601DateFormatter()
+        let contextLines = deviceContext.map { "\($0.0): \($0.1)" }.joined(separator: "\n")
+        return """
+        ClipRelay macOS diagnostics
+        Generated: \(formatter.string(from: generatedAt))
+        Included logs: ClipRelay unified log snapshot from the last 24 hours
+
+        \(contextLines)
+
+        ---- UNIFIED LOGS ----
+        \(logs)
+        """
+    }
+}

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -442,15 +442,9 @@ final class StatusBarController {
     private func handleShareLogs() {
         let context = deviceContext()
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let result = Result(catching: { try LogShareExporter.exportLogs(deviceContext: context) })
+            let text = LogShareExporter.exportLogs(deviceContext: context)
             DispatchQueue.main.async {
-                guard let self else { return }
-                switch result {
-                case .success(let fileURL):
-                    self.presentSharingPicker(for: fileURL)
-                case .failure(let error):
-                    self.presentShareLogsError(message: error.localizedDescription)
-                }
+                self?.presentSharingPicker(for: text)
             }
         }
     }
@@ -484,22 +478,16 @@ final class StatusBarController {
         ]
     }
 
-    private func presentSharingPicker(for fileURL: URL) {
+    private func presentSharingPicker(for text: String) {
         guard let button = statusItem.button else {
-            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+            // No anchor for the picker — fall back to copying the logs.
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
             return
         }
-        let picker = NSSharingServicePicker(items: [fileURL])
+        let picker = NSSharingServicePicker(items: [text])
         sharingPicker = picker
         picker.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-    }
-
-    private func presentShareLogsError(message: String) {
-        let alert = NSAlert()
-        alert.messageText = "Could not prepare ClipRelay logs"
-        alert.informativeText = message
-        alert.alertStyle = .warning
-        alert.runModal()
     }
 
     @objc

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -33,6 +33,7 @@ final class StatusBarController {
 
     private var baseStatusBarImage: NSImage?
     private var syncPulseTimer: Timer?
+    private var sharingPicker: NSSharingServicePicker?
 
     init(updaterController: SPUStandardUpdaterController) {
         self.updaterController = updaterController
@@ -274,6 +275,9 @@ final class StatusBarController {
         let emailItem = NSMenuItem(title: "Email Support\u{2026}", action: #selector(handleOpenEmail), keyEquivalent: "")
         emailItem.target = self
         supportMenu.addItem(emailItem)
+        let shareLogsItem = NSMenuItem(title: "Share Logs\u{2026}", action: #selector(handleShareLogs), keyEquivalent: "")
+        shareLogsItem.target = self
+        supportMenu.addItem(shareLogsItem)
         supportMenu.addItem(NSMenuItem.separator())
         let discussionsItem = NSMenuItem(title: "Community Discussions\u{2026}", action: #selector(handleOpenDiscussions), keyEquivalent: "")
         discussionsItem.target = self
@@ -435,6 +439,23 @@ final class StatusBarController {
     }
 
     @objc
+    private func handleShareLogs() {
+        let context = deviceContext()
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let result = Result(catching: { try LogShareExporter.exportLogs(deviceContext: context) })
+            DispatchQueue.main.async {
+                guard let self else { return }
+                switch result {
+                case .success(let fileURL):
+                    self.presentSharingPicker(for: fileURL)
+                case .failure(let error):
+                    self.presentShareLogsError(message: error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    @objc
     private func handleOpenDiscussions() {
         if let url = URL(string: "https://github.com/geekflyer/cliprelay/discussions") {
             NSWorkspace.shared.open(url)
@@ -461,6 +482,24 @@ final class StatusBarController {
             ("Device", model),
             ("BLE State", bleState),
         ]
+    }
+
+    private func presentSharingPicker(for fileURL: URL) {
+        guard let button = statusItem.button else {
+            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+            return
+        }
+        let picker = NSSharingServicePicker(items: [fileURL])
+        sharingPicker = picker
+        picker.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+    }
+
+    private func presentShareLogsError(message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Could not prepare ClipRelay logs"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.runModal()
     }
 
     @objc

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -458,7 +458,7 @@ final class StatusBarController {
 
     private func deviceContext() -> [(String, String)] {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-        let gitHash = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
         let os = ProcessInfo.processInfo.operatingSystemVersion
         let osString = "macOS \(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
         var model = "Unknown Mac"
@@ -470,11 +470,23 @@ final class StatusBarController {
             }
         }
         let bleState = bleStateProvider?() ?? "unknown"
+        #if DEBUG
+        let buildType = "debug"
+        #else
+        let buildType = "release"
+        #endif
+        let flags = [
+            "imageSync=\(isImageSyncEnabled?() ?? false)",
+            "autoUpdate=\(updaterController.updater.automaticallyChecksForUpdates)",
+            "betaChannel=\(isBetaChannelEnabled)",
+        ].joined(separator: ", ")
         return [
-            ("App Version", "\(version) (\(gitHash))"),
+            ("App Version", "\(version) (\(build)) [\(buildType)]"),
             ("OS", osString),
             ("Device", model),
             ("BLE State", bleState),
+            ("Paired Devices", "\(trustedPeers.count) (\(connectedPeers.count) connected)"),
+            ("Flags", flags),
         ]
     }
 

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -207,6 +207,40 @@ class ConnectionController: NSObject {
 
     private func log(_ message: String) {
         logger.notice("\(message, privacy: .public)")
+        // Also persist to the shareable diagnostic file — os.Logger output is
+        // invisible in release builds, so this is the only trace users can send.
+        DiagnosticLog.shared.log(message, category: "Connection")
+    }
+
+    /// Full NSError detail. `localizedDescription` alone hides the CoreBluetooth
+    /// domain/code we need to tell apart L2CAP open failures (e.g. encryption
+    /// insufficient vs. peer removed pairing vs. unsupported).
+    private func describe(_ error: Error?) -> String {
+        guard let error else { return "none" }
+        let ns = error as NSError
+        var detail = "\(ns.domain) code=\(ns.code): \(ns.localizedDescription)"
+        if !ns.userInfo.isEmpty {
+            detail += " userInfo=\(ns.userInfo)"
+        }
+        return detail
+    }
+
+    /// Human-readable Bluetooth state for shared logs — a bare rawValue like
+    /// "BT state: 4" is opaque to a user reading their exported log.
+    /// poweredOff = OS Bluetooth disabled; unauthorized = app lacks permission
+    /// (Bluetooth may still be on).
+    private func describe(_ state: CBManagerState) -> String {
+        let name: String
+        switch state {
+        case .poweredOn: name = "poweredOn"
+        case .poweredOff: name = "poweredOff"
+        case .unauthorized: name = "unauthorized"
+        case .unsupported: name = "unsupported"
+        case .resetting: name = "resetting"
+        case .unknown: name = "unknown"
+        @unknown default: name = "unknown"
+        }
+        return "\(name) (\(state.rawValue))"
     }
 
     // MARK: - Device list
@@ -589,7 +623,7 @@ extension ConnectionController {
 extension ConnectionController: CBCentralManagerDelegate {
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        log("BT state: \(central.state.rawValue)")
+        log("BT state: \(describe(central.state))")
         if central.state == .poweredOn {
             // Re-cancel peripherals from before the power cycle. cancelPeripheralConnection
             // during BT-off is a no-op, so internal CB connection bookkeeping can accumulate
@@ -608,7 +642,7 @@ extension ConnectionController: CBCentralManagerDelegate {
             ensureScanning()
         } else {
             teardownAll(
-                reason: "BT state \(central.state.rawValue)",
+                reason: "BT state \(describe(central.state))",
                 preservePairingContext: pairingTag != nil
             )
         }
@@ -663,6 +697,7 @@ extension ConnectionController: CBCentralManagerDelegate {
         if peripheral === pairingPeripheral, case .connecting(_, let psm) = pairingPhase {
             pairingPhase = .l2capOpening(peripheral)
             pairingConnectingStartTime = Date()  // reset for L2CAP open timeout
+            log("Pairing: connected, opening L2CAP channel psm=\(psm)")
             peripheral.openL2CAPChannel(psm)
             return
         }
@@ -674,6 +709,7 @@ extension ConnectionController: CBCentralManagerDelegate {
         }
         device.state = .l2capOpening
         device.connectingStartTime = Date()  // reset for L2CAP open timeout
+        log("Connected \(device.token.prefix(8))…, opening L2CAP channel psm=\(psm)")
         peripheral.openL2CAPChannel(psm)
     }
 
@@ -682,7 +718,7 @@ extension ConnectionController: CBCentralManagerDelegate {
         didFailToConnect peripheral: CBPeripheral,
         error: Error?
     ) {
-        log("didFailToConnect: \(error?.localizedDescription ?? "unknown")")
+        log("didFailToConnect: \(describe(error))")
         central.cancelPeripheralConnection(peripheral)
         if peripheral === pairingPeripheral {
             abortPairingAttempt()
@@ -698,7 +734,7 @@ extension ConnectionController: CBCentralManagerDelegate {
         didDisconnectPeripheral peripheral: CBPeripheral,
         error: Error?
     ) {
-        log("didDisconnect: \(error?.localizedDescription ?? "clean")")
+        log("didDisconnect: \(error == nil ? "clean" : describe(error))")
         if peripheral === pairingPeripheral {
             abortPairingAttempt()
             return
@@ -719,7 +755,7 @@ extension ConnectionController: CBPeripheralDelegate {
         let isPairing = peripheral === pairingPeripheral
 
         if let error {
-            log("L2CAP open error: \(error.localizedDescription)")
+            log("L2CAP open error (\(isPairing ? "pairing" : "reconnect")): \(describe(error))")
             if isPairing {
                 abortPairingAttempt()
             } else if let device = device(of: peripheral) {
@@ -737,6 +773,8 @@ extension ConnectionController: CBPeripheralDelegate {
             }
             return
         }
+
+        log("L2CAP channel opened (\(isPairing ? "pairing" : "reconnect")) — starting session")
 
         if isPairing {
             guard case .l2capOpening = pairingPhase else {

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/LogShareExporterTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/LogShareExporterTests.swift
@@ -2,36 +2,45 @@ import XCTest
 @testable import ClipRelay
 
 final class LogShareExporterTests: XCTestCase {
-    func testBuildFileNameUsesUTCTimestamp() {
-        let date = ISO8601DateFormatter().date(from: "2026-04-11T15:42:05Z")!
-        XCTAssertEqual(LogShareExporter.buildFileName(for: date), "cliprelay-mac-logs-20260411-154205.txt")
-    }
-
-    func testBuildFileContentsIncludesDiagnosticAndUnifiedSections() {
-        let contents = LogShareExporter.buildFileContents(
+    func testBuildShareTextIncludesDiagnosticAndUnifiedSections() {
+        let text = LogShareExporter.buildShareText(
             deviceContext: [("App Version", "0.7.0 (abc123)"), ("BLE State", "connected")],
             generatedAt: Date(),
             diagnosticLog: "2026-04-11T15:42:05Z [Connection] L2CAP open error (pairing): CBErrorDomain code=14",
             logs: "log show output here"
         )
 
-        XCTAssertTrue(contents.contains("ClipRelay macOS diagnostics"))
-        XCTAssertTrue(contents.contains("App Version: 0.7.0 (abc123)"))
-        XCTAssertTrue(contents.contains("BLE State: connected"))
-        XCTAssertTrue(contents.contains("---- DIAGNOSTIC LOG (BLE / pairing) ----"))
-        XCTAssertTrue(contents.contains("L2CAP open error (pairing): CBErrorDomain code=14"))
-        XCTAssertTrue(contents.contains("---- UNIFIED LOGS ----"))
-        XCTAssertTrue(contents.contains("log show output here"))
+        XCTAssertTrue(text.contains("ClipRelay macOS diagnostics"))
+        XCTAssertTrue(text.contains("App Version: 0.7.0 (abc123)"))
+        XCTAssertTrue(text.contains("BLE State: connected"))
+        XCTAssertTrue(text.contains("---- DIAGNOSTIC LOG (BLE / pairing) ----"))
+        XCTAssertTrue(text.contains("L2CAP open error (pairing): CBErrorDomain code=14"))
+        XCTAssertTrue(text.contains("---- UNIFIED LOGS ----"))
+        XCTAssertTrue(text.contains("log show output here"))
     }
 
-    func testBuildFileContentsHandlesEmptyDiagnosticLog() {
-        let contents = LogShareExporter.buildFileContents(
+    func testBuildShareTextHandlesEmptyDiagnosticLog() {
+        let text = LogShareExporter.buildShareText(
             deviceContext: [],
             generatedAt: Date(),
             diagnosticLog: "   \n  ",
             logs: ""
         )
 
-        XCTAssertTrue(contents.contains("No diagnostic log entries were recorded yet."))
+        XCTAssertTrue(text.contains("No diagnostic log entries were recorded yet."))
+    }
+
+    func testTailKeepsRecentContentAndDropsOldest() {
+        let big = "OLDEST_LINE\n" + String(repeating: "x\n", count: 250_000) // ~500k chars
+        let trimmed = LogShareExporter.tail(big, maxChars: 400_000)
+
+        XCTAssertLessThanOrEqual(trimmed.count, 400_080)
+        XCTAssertTrue(trimmed.hasPrefix("[… older lines truncated"))
+        XCTAssertFalse(trimmed.contains("OLDEST_LINE"))
+    }
+
+    func testTailReturnsInputWhenWithinBudget() {
+        let small = "line1\nline2"
+        XCTAssertEqual(LogShareExporter.tail(small, maxChars: 400_000), small)
     }
 }

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/LogShareExporterTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/LogShareExporterTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import ClipRelay
+
+final class LogShareExporterTests: XCTestCase {
+    func testBuildFileNameUsesUTCTimestamp() {
+        let date = ISO8601DateFormatter().date(from: "2026-04-11T15:42:05Z")!
+        XCTAssertEqual(LogShareExporter.buildFileName(for: date), "cliprelay-mac-logs-20260411-154205.txt")
+    }
+
+    func testBuildFileContentsIncludesDiagnosticAndUnifiedSections() {
+        let contents = LogShareExporter.buildFileContents(
+            deviceContext: [("App Version", "0.7.0 (abc123)"), ("BLE State", "connected")],
+            generatedAt: Date(),
+            diagnosticLog: "2026-04-11T15:42:05Z [Connection] L2CAP open error (pairing): CBErrorDomain code=14",
+            logs: "log show output here"
+        )
+
+        XCTAssertTrue(contents.contains("ClipRelay macOS diagnostics"))
+        XCTAssertTrue(contents.contains("App Version: 0.7.0 (abc123)"))
+        XCTAssertTrue(contents.contains("BLE State: connected"))
+        XCTAssertTrue(contents.contains("---- DIAGNOSTIC LOG (BLE / pairing) ----"))
+        XCTAssertTrue(contents.contains("L2CAP open error (pairing): CBErrorDomain code=14"))
+        XCTAssertTrue(contents.contains("---- UNIFIED LOGS ----"))
+        XCTAssertTrue(contents.contains("log show output here"))
+    }
+
+    func testBuildFileContentsHandlesEmptyDiagnosticLog() {
+        let contents = LogShareExporter.buildFileContents(
+            deviceContext: [],
+            generatedAt: Date(),
+            diagnosticLog: "   \n  ",
+            logs: ""
+        )
+
+        XCTAssertTrue(contents.contains("No diagnostic log entries were recorded yet."))
+    }
+}


### PR DESCRIPTION
## Summary

Makes "Share Logs" actually useful for debugging BLE pairing/reconnect failures (e.g. #76). Builds on **#58** (rebased onto `main`) and closes the gap that made #58's macOS export come back empty.

The problem: ClipRelay's macOS logs go through `os.Logger`, which is **invisible to the unified log / `log show` in our SPM release builds**. So #58's macOS "Share Logs" (which shells out to `log show --predicate subsystem == "org.cliprelay"`) returned nothing on shipped builds — verified: 0 lines over 3h spanning a successful pairing. That's exactly the data we need for #76, where the Mac connects but `openL2CAPChannel` never completes and the link drops after ~1s.

## What's in here

**macOS**
- **`DiagnosticLog`** — an append-only, rotating file under `~/Library/Application Support/ClipRelay/` that survives release builds. `ConnectionController.log()` mirrors every connection/pairing event into it.
- **Full `NSError`** (domain + code + userInfo) on `didOpenL2CAPChannel` failure, `didFailToConnect`, and `didDisconnect` — `localizedDescription` alone hides the CoreBluetooth code that distinguishes the failure modes (encryption-insufficient vs. peer-removed-pairing vs. unsupported).
- Explicit logging at the `openL2CAPChannel` call site + channel-opened success, and **human-readable Bluetooth state** (`poweredOff (4)`, `unauthorized (3)`, …).
- `LogShareExporter` now leads with this diagnostic log and broadens the unified-log predicate to the ClipRelay process. New `LogShareExporterTests`.

**Android**
- `L2capServer` now logs the listening PSM, accepted connections, and accept errors, so the in-process logcat snapshot shows the peripheral's view (e.g. "listening psm=X" then silence when the central never connects).

**Version**: intentionally not bumped here — versioning is handled separately via `scripts/release.sh`.

## Why this unblocks #76

On a failing pair, the exported log will now carry the decisive line — `L2CAP open error (pairing): CBErrorDomain code=… : …` — instead of an empty unified-log section. (The reporter is on macOS 15.7.7; could not reproduce locally on 26.5.1, which is itself a strong version-specific-CoreBluetooth signal.)

## Test plan

- `scripts/build-all.sh --debug` — both platforms build (mac bundle links `DiagnosticLog`).
- `scripts/test-all.sh` — 149 macOS tests + Android unit tests pass (3 new macOS exporter tests).
- **Functional**: launched the new build; `diagnostics.log` captured a full real reconnect trace (`BT state: poweredOn (5)` → `opening L2CAP channel psm=131` → `channel opened` → `Session ready — Pixel 10 Pro XL`) on a build where `log show` shows nothing.
- Not run: on-device hardware smoke test (`hardware-smoke-test.sh`) — the wireless adb device dropped off mid-session.

## Note

Supersedes #58 (its two commits are included here, rebased) — #58 can be closed in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
