### PR TITLE
diag: log BLE advert sightings + pairing/advertised tags

### DIFF
--- a/android/app/src/main/java/org/cliprelay/ble/Advertiser.kt
+++ b/android/app/src/main/java/org/cliprelay/ble/Advertiser.kt
@@ -100,7 +100,8 @@ class Advertiser(private val context: Context, private val serviceUuid: ParcelUu
         val advertiseCallback = object : AdvertiseCallback() {
             override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
                 retryAttempt = 0
-                Log.w(TAG, "BLE advertise started")
+                val tagHex = deviceTag?.joinToString("") { "%02x".format(it) } ?: "null"
+                Log.w(TAG, "BLE advertise started (deviceTag=$tagHex, psm=$psm)")
             }
 
             override fun onStartFailure(errorCode: Int) {

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -212,6 +212,36 @@ class ConnectionController: NSObject {
         DiagnosticLog.shared.log(message, category: "Connection")
     }
 
+    static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Per-tag throttle for `logAdvertSighting`. Queue-only (didDiscover runs on `queue`).
+    private var lastAdvertLog: [String: Date] = [:]
+
+    /// Log every ClipRelay advertisement we actually receive (throttled per tag),
+    /// matching or not. Distinguishes "scanning but never sees the phone" (stale
+    /// scan / RF) from "sees it but the tag doesn't match" (tag-scheme bug):
+    /// a failed pair with NO sighting line ⇒ the advert never reached us; a
+    /// sighting line tagged `no-match` while we're scanning for a different
+    /// pairing tag ⇒ mismatch.
+    private func logAdvertSighting(deviceTag: Data, psm: CBL2CAPPSM, rssi: NSNumber) {
+        let tagHex = Self.hex(deviceTag)
+        let now = Date()
+        guard now.timeIntervalSince(lastAdvertLog[tagHex] ?? .distantPast) > 3.0 else { return }
+        lastAdvertLog[tagHex] = now
+        let kind: String
+        if pairingTag == deviceTag {
+            kind = "pairing-match"
+        } else if pairingManager.loadDevices().contains(where: { pairingManager.scanTag(for: $0) == deviceTag }) {
+            kind = "paired-match"
+        } else {
+            kind = "no-match"
+        }
+        let scanningFor = pairingTag.map { " scanningForPairingTag=\(Self.hex($0))" } ?? ""
+        log("Advert seen tag=\(tagHex) psm=\(psm) rssi=\(rssi) [\(kind)]\(scanningFor)")
+    }
+
     /// Full NSError detail. `localizedDescription` alone hides the CoreBluetooth
     /// domain/code we need to tell apart L2CAP open failures (e.g. encryption
     /// insufficient vs. peer removed pairing vs. unsupported).
@@ -482,6 +512,8 @@ extension ConnectionController {
         queue.async { [self] in
             pairingPrivateKey = privateKey
             pairingTag = tag
+            lastAdvertLog.removeAll()  // fresh advert-sighting log for this pairing window
+            log("Pairing started — scanning for pairing tag \(Self.hex(tag))")
             pairingPhase = .scanning
             ensureScanning()
         }
@@ -662,6 +694,8 @@ extension ConnectionController: CBCentralManagerDelegate {
               let deviceTag = Self.extractDeviceTag(from: manufacturerData),
               let psm = Self.extractPSM(from: manufacturerData)
         else { return }
+
+        logAdvertSighting(deviceTag: deviceTag, psm: psm, rssi: RSSI)
 
         // Active pairing request takes priority
         if let pairingTag, pairingTag == deviceTag {


### PR DESCRIPTION
## Why
The 0.6.2 Mac diagnostic log from a failed pair showed **only** `Scanning` health-check ticks during the whole pairing window — no `Pairing target discovered`, no connect, no L2CAP error. Since 0.6.2 logs all of those, that's conclusive: **the Mac never discovered the phone** (the failure is upstream of `openL2CAPChannel`).

But the current logging can't tell **why**:
- **Stale scan / RF** — CoreBluetooth stopped delivering `didDiscover`, so the advert never reached us, or
- **Tag mismatch** — the advert *did* arrive but its tag ≠ what we scan for, so it was silently dropped (we only log *matching* discoveries).

This adds the probes that decide it.

## What
- **macOS** ([`ConnectionController`](macos/ClipRelayMac/Sources/BLE/ConnectionController.swift)):
  - On `startPairing`: `Pairing started — scanning for pairing tag <hex>`.
  - In `didDiscover`: log **every** ClipRelay advertisement actually received (throttled to once per tag / 3s) — `Advert seen tag=<hex> psm=<n> rssi=<n> [pairing-match|paired-match|no-match] scanningForPairingTag=<hex>`.
- **Android** ([`Advertiser`](android/app/src/main/java/org/cliprelay/ble/Advertiser.kt)): the `BLE advertise started` line now includes `deviceTag=<hex>` + `psm`.

## How to read it on the next failed pair
- **No `Advert seen` line at all** while Android logged `BLE advertise started` → **stale scan / RF** (the advert never reached CoreBluetooth).
- **`Advert seen … [no-match]`** with `scanningForPairingTag=X` where the Android `deviceTag` ≠ X → **tag-scheme mismatch**.

Verified live: the probe immediately logged `Advert seen tag=… psm=133 … [no-match]`, correctly throttled.

Standalone diagnostic change on top of #80 (now merged). No behavior change — logging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)