### PR TITLE
fix(macos): broad BLE scan so the central reliably reads the L2CAP PSM

### DIFF
--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -242,23 +242,22 @@ class ConnectionController: NSObject {
         log("Advert seen tag=\(tagHex) psm=\(psm) rssi=\(rssi) [\(kind)]\(scanningFor)")
     }
 
-    /// Per-peripheral throttle for `logAdvertMissingManufacturerData`. Queue-only.
-    private var lastMissingMfrLog: [UUID: Date] = [:]
+    /// Per-peripheral throttle for `logUnusableAdvert`. Queue-only.
+    private var lastUnusableAdvertLog: [UUID: Date] = [:]
 
-    /// We discovered a ClipRelay device's primary advertisement (service UUID)
-    /// but the scan-response manufacturer data carrying the device tag + PSM was
-    /// absent. This is the exact failure where macOS can never read the PSM and
-    /// so never connects. Broad scanning (see `ensureScanning`) is meant to
-    /// avoid it — a recurring line here means the scan response still isn't
-    /// reaching CoreBluetooth even without a service filter. Throttled per
-    /// peripheral.
-    private func logAdvertMissingManufacturerData(peripheral: CBPeripheral, rssi: NSNumber) {
+    /// We saw a packet from a ClipRelay device we can't act on, plus why. The
+    /// two reasons must stay distinct in diagnostics: "scan response not
+    /// delivered" (the central never learns the PSM — the failure broad scanning
+    /// targets) vs. a ClipRelay payload that arrived but carried an unusable
+    /// PSM (a phone advertising before its L2CAP server allocated one).
+    /// Throttled per peripheral.
+    private func logUnusableAdvert(peripheral: CBPeripheral, rssi: NSNumber, reason: String) {
         let id = peripheral.identifier
         let now = Date()
-        guard now.timeIntervalSince(lastMissingMfrLog[id] ?? .distantPast) > 3.0 else { return }
-        lastMissingMfrLog[id] = now
+        guard now.timeIntervalSince(lastUnusableAdvertLog[id] ?? .distantPast) > 3.0 else { return }
+        lastUnusableAdvertLog[id] = now
         let scanningFor = pairingTag.map { " scanningForPairingTag=\(Self.hex($0))" } ?? ""
-        log("Advert seen (ClipRelay service UUID) but NO manufacturer data — scan response not delivered, can't read PSM rssi=\(rssi)\(scanningFor)")
+        log("Advert from \(id.uuidString.prefix(8))… unusable: \(reason) rssi=\(rssi)\(scanningFor)")
     }
 
     /// Full NSError detail. `localizedDescription` alone hides the CoreBluetooth
@@ -547,8 +546,8 @@ extension ConnectionController {
         queue.async { [self] in
             pairingPrivateKey = privateKey
             pairingTag = tag
-            lastAdvertLog.removeAll()       // fresh advert-sighting log for this pairing window
-            lastMissingMfrLog.removeAll()   // …and a fresh missing-scan-response log
+            lastAdvertLog.removeAll()         // fresh advert-sighting log for this pairing window
+            lastUnusableAdvertLog.removeAll() // …and a fresh unusable-advert log
             log("Pairing started — scanning for pairing tag \(Self.hex(tag))")
             pairingPhase = .scanning
             ensureScanning()
@@ -734,12 +733,21 @@ extension ConnectionController: CBCentralManagerDelegate {
               let deviceTag = Self.extractDeviceTag(from: manufacturerData),
               let psm = Self.extractPSM(from: manufacturerData)
         else {
-            // No usable ClipRelay manufacturer data in this packet. If the
-            // primary advert still carries our service UUID, the scan response
-            // wasn't delivered — the exact failure where macOS can't read the
-            // PSM. Log it; a later duplicate callback usually carries the data.
-            if (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.contains(Self.serviceUUID) == true {
-                logAdvertMissingManufacturerData(peripheral: peripheral, rssi: RSSI)
+            // Couldn't read a tag+PSM. Separate the two reasons so diagnostics
+            // stay precise.
+            let mfrData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
+            if let mfrData, Self.isClipRelayManufacturerData(mfrData) {
+                // ClipRelay payload present but tag/PSM unusable (PSM=0): the
+                // phone is advertising before its L2CAP server allocated a PSM.
+                logUnusableAdvert(peripheral: peripheral, rssi: RSSI,
+                                  reason: "ClipRelay manufacturer data present but PSM=0 (L2CAP server not ready)")
+            } else if (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.contains(Self.serviceUUID) == true {
+                // Primary advert (service UUID) seen but scan-response
+                // manufacturer data absent — the scan response wasn't delivered,
+                // so we can't read the PSM. A later duplicate callback usually
+                // carries it.
+                logUnusableAdvert(peripheral: peripheral, rssi: RSSI,
+                                  reason: "NO manufacturer data — scan response not delivered, can't read PSM")
             }
             return
         }

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -242,6 +242,25 @@ class ConnectionController: NSObject {
         log("Advert seen tag=\(tagHex) psm=\(psm) rssi=\(rssi) [\(kind)]\(scanningFor)")
     }
 
+    /// Per-peripheral throttle for `logAdvertMissingManufacturerData`. Queue-only.
+    private var lastMissingMfrLog: [UUID: Date] = [:]
+
+    /// We discovered a ClipRelay device's primary advertisement (service UUID)
+    /// but the scan-response manufacturer data carrying the device tag + PSM was
+    /// absent. This is the exact failure where macOS can never read the PSM and
+    /// so never connects. Broad scanning (see `ensureScanning`) is meant to
+    /// avoid it — a recurring line here means the scan response still isn't
+    /// reaching CoreBluetooth even without a service filter. Throttled per
+    /// peripheral.
+    private func logAdvertMissingManufacturerData(peripheral: CBPeripheral, rssi: NSNumber) {
+        let id = peripheral.identifier
+        let now = Date()
+        guard now.timeIntervalSince(lastMissingMfrLog[id] ?? .distantPast) > 3.0 else { return }
+        lastMissingMfrLog[id] = now
+        let scanningFor = pairingTag.map { " scanningForPairingTag=\(Self.hex($0))" } ?? ""
+        log("Advert seen (ClipRelay service UUID) but NO manufacturer data — scan response not delivered, can't read PSM rssi=\(rssi)\(scanningFor)")
+    }
+
     /// Full NSError detail. `localizedDescription` alone hides the CoreBluetooth
     /// domain/code we need to tell apart L2CAP open failures (e.g. encryption
     /// insufficient vs. peer removed pairing vs. unsupported).
@@ -329,8 +348,14 @@ class ConnectionController: NSObject {
             || devices.values.contains { $0.state.isIdle && !$0.suspended }
         if needScan && !centralManager.isScanning {
             log("Scanning (paired: \(devices.count), pairing: \(pairingTag != nil))")
+            // Scan broadly (no service filter) and match in didDiscover. A
+            // service-UUID-filtered scan makes some Android BLE stacks withhold
+            // the scan-response manufacturer data (device tag + PSM) from
+            // CoreBluetooth: the central discovers the primary advert but never
+            // reads the PSM, so it can never connect. A broad scan delivers the
+            // scan response reliably; we filter on the manufacturer data below.
             centralManager.scanForPeripherals(
-                withServices: [Self.serviceUUID],
+                withServices: nil,
                 options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
             )
         } else if !needScan && centralManager.isScanning {
@@ -468,6 +493,16 @@ class ConnectionController: NSObject {
 
     // MARK: - Manufacturer Data Extraction
 
+    /// True if this manufacturer-data blob is a ClipRelay advert: company ID
+    /// 0xFFFF (the SIG test/dev id, little-endian `FF FF`) followed by the
+    /// 10-byte tag+PSM payload. Needed now that we scan broadly — without the
+    /// service-UUID filter, didDiscover also fires for unrelated devices whose
+    /// own manufacturer data must not be misread as a tag+PSM.
+    static func isClipRelayManufacturerData(_ data: Data) -> Bool {
+        guard data.count >= 12 else { return false }
+        return data[data.startIndex] == 0xFF && data[data.startIndex + 1] == 0xFF
+    }
+
     static func extractDeviceTag(from manufacturerData: Data) -> Data? {
         guard manufacturerData.count >= 10 else { return nil }
         return manufacturerData[2..<10]
@@ -512,7 +547,8 @@ extension ConnectionController {
         queue.async { [self] in
             pairingPrivateKey = privateKey
             pairingTag = tag
-            lastAdvertLog.removeAll()  // fresh advert-sighting log for this pairing window
+            lastAdvertLog.removeAll()       // fresh advert-sighting log for this pairing window
+            lastMissingMfrLog.removeAll()   // …and a fresh missing-scan-response log
             log("Pairing started — scanning for pairing tag \(Self.hex(tag))")
             pairingPhase = .scanning
             ensureScanning()
@@ -690,10 +726,23 @@ extension ConnectionController: CBCentralManagerDelegate {
         advertisementData: [String: Any],
         rssi RSSI: NSNumber
     ) {
+        // We scan broadly (see ensureScanning), so didDiscover fires for every
+        // BLE device. The tag + PSM live in the scan-response manufacturer data
+        // (company 0xFFFF); that payload alone identifies a ClipRelay device.
         guard let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data,
+              Self.isClipRelayManufacturerData(manufacturerData),
               let deviceTag = Self.extractDeviceTag(from: manufacturerData),
               let psm = Self.extractPSM(from: manufacturerData)
-        else { return }
+        else {
+            // No usable ClipRelay manufacturer data in this packet. If the
+            // primary advert still carries our service UUID, the scan response
+            // wasn't delivered — the exact failure where macOS can't read the
+            // PSM. Log it; a later duplicate callback usually carries the data.
+            if (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.contains(Self.serviceUUID) == true {
+                logAdvertMissingManufacturerData(peripheral: peripheral, rssi: RSSI)
+            }
+            return
+        }
 
         logAdvertSighting(deviceTag: deviceTag, psm: psm, rssi: RSSI)
 

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/ConnectionControllerTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/ConnectionControllerTests.swift
@@ -101,6 +101,29 @@ final class ConnectionControllerTests: XCTestCase {
         XCTAssertNil(ConnectionController.extractPSM(from: data))
     }
 
+    // MARK: - ClipRelay Manufacturer Data Filter Tests
+
+    func testIsClipRelayManufacturerDataAcceptsValidPayload() {
+        let data = Data([0xFF, 0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x83])
+        XCTAssertTrue(ConnectionController.isClipRelayManufacturerData(data))
+    }
+
+    func testIsClipRelayManufacturerDataRejectsOtherCompanyID() {
+        // Apple company ID (0x004C, little-endian 0x4C 0x00) with a full-length
+        // payload must not be mistaken for a ClipRelay tag+PSM under broad scan.
+        let data = Data([0x4C, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x83])
+        XCTAssertFalse(ConnectionController.isClipRelayManufacturerData(data))
+    }
+
+    func testIsClipRelayManufacturerDataRejectsShortData() {
+        let data = Data([0xFF, 0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00])
+        XCTAssertFalse(ConnectionController.isClipRelayManufacturerData(data))
+    }
+
+    func testIsClipRelayManufacturerDataRejectsEmptyData() {
+        XCTAssertFalse(ConnectionController.isClipRelayManufacturerData(Data()))
+    }
+
     // MARK: - State Tests
 
     func testInitialStateIsDisconnected() {


### PR DESCRIPTION
## Problem

Some Android BLE stacks make CoreBluetooth **withhold the scan-response manufacturer data** (device tag + PSM) when the Mac scans with a service-UUID filter (`scanForPeripherals(withServices: [serviceUUID], …)`).

ClipRelay's Android peripheral puts the service UUID in the **primary** advertisement but the `[deviceTag][PSM]` payload in the **scan response** (the 31-byte primary-advert budget can't hold both a 128-bit UUID and the manufacturer data). When the scan response isn't delivered, `didDiscover` either never fires usefully or fires with no manufacturer data, so the central never reads the PSM, never calls `openL2CAPChannel`, and pairing/reconnect silently times out.

This matches the conclusive 0.6.2 diagnostic logs from #76: `Scanning` ticks with **no** "Pairing target discovered" line — the Mac was scanning but never acting on the phone. It's intermittent and device/stack-dependent (e.g. confirmed on Honor ROD2-W09), which is why most users pair fine and a few never can, and why a retry sometimes works.

## Fix

- **Scan broadly** (`withServices: nil`) and filter in `didDiscover`. A broad active scan delivers the scan-response manufacturer data reliably.
- Add `isClipRelayManufacturerData()` (company id `0xFFFF` check) so unrelated devices' manufacturer data isn't misread as a tag+PSM now that the OS-level service filter is gone.

## Diagnostic probe

The advert-sighting log added in #81 sits **after** the manufacturer-data guard, so the "discovered but no scan response" case was invisible — it looked like a stale scan. This adds `logAdvertMissingManufacturerData()`: when a ClipRelay **primary** advert (service UUID present) is discovered with **no** manufacturer data, it logs that directly. That line distinguishes "scan-response-not-delivered" from "scan genuinely sees nothing."

## Not included (follow-ups)

- Pairing timeout bump (20s → ~60s)
- Auto-replacing a stale pairing record when re-pairing the same identity tag
- Moving tag+PSM into the primary advert on Android (bigger change — service UUID would have to move to the scan response)

## Testing

- `swift build` + full Mac suite green (154 tests, incl. 4 new `isClipRelayManufacturerData` filter tests).
- Mac-only change; no Android source touched.
- ⚠️ Not yet validated on the actual failing hardware — needs a real failed-pair repro with Share Logs to confirm the broad scan delivers the scan response there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)