### PR TITLE
fix(android): raise pairing timeout 20s → 60s

### DIFF
--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -82,7 +82,12 @@ class ClipRelayService : Service(), L2capServerCallback {
         private const val TAG = "ClipRelayService"
         private const val MAX_CLIPBOARD_BYTES = 102_400
         private const val CLIPBOARD_DEBOUNCE_MS = 200L
-        private const val PAIRING_TIMEOUT_MS = 20_000L
+        // Matches the 60s handshake-level pairing timeout in Session
+        // (pairingTimeoutMs). A 20s cap here used to abort handshakes the
+        // session layer was still pursuing; 60s also gives the Mac central more
+        // advertising events to catch a scan response when its Wi-Fi/BT radio is
+        // in a power-save state that drops the occasional SCAN_RSP.
+        private const val PAIRING_TIMEOUT_MS = 60_000L
     }
 
     // BLE components


### PR DESCRIPTION
## What

Bumps `ClipRelayService.PAIRING_TIMEOUT_MS` from `20_000L` to `60_000L`.

## Why

**1. Fixes a layer inconsistency.** The session-level pairing timeout ([`Session.pairingTimeoutMs`](android/app/src/main/java/org/cliprelay/protocol/Session.kt#L65)) is already **60s**, but the service-level timeout was **20s** — so the service could abort a handshake the session layer was still willing to pursue for another 40s. The two are now aligned.

**2. Adds resilience to the scan-response-delivery failure** behind the "never pairs" reports (#76). Android advertises the service UUID in the primary advert but the `[deviceTag][PSM]` in the **scan-response** manufacturer data. When the Mac central's shared Wi-Fi/BT radio is in a power-save state — reproducibly worse with **Wi-Fi off** — it intermittently misses the active `SCAN_RSP` that carries the PSM. A longer pairing window gives the central more `LOW_LATENCY` (~100 ms) advertising events to eventually catch one.

## Scope / relationship to other work

This is a **probabilistic mitigation**, not a root-cause fix. It complements the central-side **broad-scan** fix in #83 (which makes CoreBluetooth surface scan responses it *does* receive). The **deterministic** fix — moving `deviceTag`+`PSM` into the **primary** advertisement so no scan response is needed at all — remains a possible follow-up if the radio misses turn out to be systematic (sustained power-save) rather than intermittent. The decisive test is a Wi-Fi-off repro + Share Logs: eventual `[pairing-match]` ⇒ this is enough; solid `unusable: NO manufacturer data` for the whole window ⇒ do the primary-advert move.

## Cost

The only downside is a longer worst-case spinner before the failure card on a genuinely-failed pair (20s → 60s).

## Testing

- `./scripts/build-all.sh --android-only` ✓
- `./gradlew testDebugUnitTest` ✓
- ⚠️ Not yet redeployed to hardware (wireless adb dropped); behavior change is a single constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)