### PR TITLE
fix(android): put device tag + PSM in the primary advert (UUID → scan response)

### DIFF
--- a/android/app/src/main/java/org/cliprelay/ble/Advertiser.kt
+++ b/android/app/src/main/java/org/cliprelay/ble/Advertiser.kt
@@ -73,17 +73,18 @@ class Advertiser(private val context: Context, private val serviceUuid: ParcelUu
             .setConnectable(true)
             .build()
 
-        // Primary advertisement: service UUID only (for central scan filtering).
-        // Must stay under 31 bytes: 3 (flags) + 18 (128-bit UUID) = 21 bytes.
-        val advertiseData = AdvertiseData.Builder()
-            .setIncludeDeviceName(false)
-            .addServiceUuid(serviceUuid)
-            .build()
-
-        // Scan response: device tag + PSM as manufacturer data.
-        // We intentionally do NOT include the local device name since BLE scan responses have a
-        // strict 31-byte budget and long Bluetooth names can prevent advertising from starting.
-        val scanResponseBuilder = AdvertiseData.Builder()
+        // Primary advertisement: device tag + PSM as manufacturer data.
+        // This is deliberately in the PRIMARY advert (ADV_IND), not the scan
+        // response: the central receives the primary advert passively, whereas
+        // the scan response requires an active SCAN_REQ/SCAN_RSP exchange that
+        // some macOS radios drop for tens of seconds under Wi-Fi/BT power-save —
+        // which made pairing/reconnect crawl. With the payload here, the central
+        // gets everything it needs from the packet it already receives reliably.
+        // The macOS central scans broadly (withServices: nil) and matches on this
+        // 0xFFFF manufacturer payload, so it no longer needs the service UUID in
+        // the primary advert. Budget: 3 (flags) + 14 (mfr data: 2 header + 2
+        // company id + 10 payload) = 17 bytes, well under the 31-byte limit.
+        val advertiseBuilder = AdvertiseData.Builder()
             .setIncludeDeviceName(false)
         val tag = deviceTag
         if (tag != null) {
@@ -93,9 +94,20 @@ class Advertiser(private val context: Context, private val serviceUuid: ParcelUu
             payload[tag.size] = (psm shr 8).toByte()
             payload[tag.size + 1] = (psm and 0xFF).toByte()
             // 0xFFFF = Bluetooth SIG reserved for testing/development
-            scanResponseBuilder.addManufacturerData(0xFFFF, payload)
+            advertiseBuilder.addManufacturerData(0xFFFF, payload)
         }
-        val scanResponse = scanResponseBuilder.build()
+        val advertiseData = advertiseBuilder.build()
+
+        // Scan response: service UUID. The current macOS central no longer needs
+        // it (it matches on the manufacturer payload above), but we keep
+        // advertising it for debuggability and any future service-based
+        // discovery. We intentionally do NOT include the local device name since
+        // scan responses have a strict 31-byte budget and long Bluetooth names
+        // can prevent advertising from starting. 128-bit UUID = 18 bytes.
+        val scanResponse = AdvertiseData.Builder()
+            .setIncludeDeviceName(false)
+            .addServiceUuid(serviceUuid)
+            .build()
 
         val advertiseCallback = object : AdvertiseCallback() {
             override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -726,8 +726,10 @@ extension ConnectionController: CBCentralManagerDelegate {
         rssi RSSI: NSNumber
     ) {
         // We scan broadly (see ensureScanning), so didDiscover fires for every
-        // BLE device. The tag + PSM live in the scan-response manufacturer data
-        // (company 0xFFFF); that payload alone identifies a ClipRelay device.
+        // BLE device. The tag + PSM are in the 0xFFFF manufacturer data, which
+        // CoreBluetooth surfaces here regardless of whether the peripheral
+        // advertises it in the primary advert or the scan response; that payload
+        // alone identifies a ClipRelay device.
         guard let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data,
               Self.isClipRelayManufacturerData(manufacturerData),
               let deviceTag = Self.extractDeviceTag(from: manufacturerData),


### PR DESCRIPTION
## What

Swaps the two BLE advertising payloads:
- **Primary advert (ADV_IND):** now carries the `[deviceTag][PSM]` `0xFFFF` manufacturer data (was: service UUID).
- **Scan response:** now carries the 128-bit service UUID (was: the manufacturer data).

## Why

The central receives the **primary advert passively**, but the **scan response requires an active `SCAN_REQ`/`SCAN_RSP` exchange** that some macOS radios drop for tens of seconds under Wi-Fi/BT power-save (worse with Wi-Fi off). A slow Mac's field logs (0.6.4) showed it receiving the phone's primary advert reliably — ~every 3s — while the scan response carrying the PSM was missed for **10–33 seconds** at a stretch:

```
00:16:21  Advert from 76FCCAF1… unusable: NO manufacturer data — scan response not delivered   ← primary advert, ~every 3s
   … 11 of these over 33 seconds …
00:16:54  Advert seen tag=51b8… psm=155 [pairing-match]                                          ← one scan response finally lands
```

Pairings on that Mac ranged 4–33s and several were abandoned. Putting `[tag][PSM]` in the primary advert means the central gets everything from the packet it already receives reliably → discovery drops to ~instant even in that degraded state. The 31-byte legacy budget can't hold both the 128-bit UUID and the manufacturer data, so the UUID moves to the scan response.

## No macOS change required

Since #83 the central scans broadly (`withServices: nil`) and matches on the `0xFFFF` manufacturer payload via `isClipRelayManufacturerData`. CoreBluetooth merges the primary advert + scan response, so the central reads the payload regardless of which packet carries it. A **0.6.4+ Mac handles both** the old (scan-response) and new (primary-advert) layouts — it's already forward-compatible.

## Compatibility

| | Old Mac (≤0.6.3, UUID-filtered scan) | New Mac (0.6.4+, broad scan) |
|---|---|---|
| Old Android (payload in scan resp) | ✅ | ✅ (today's behavior) |
| **New Android (payload in primary)** | ❌ breaks | ✅ better |

Only **new-Android ↔ old-Mac** breaks (that Mac filters on the UUID in the primary advert, which moved). Macs auto-update via Sparkle and 0.6.4 shipped first, so that population is small and shrinking. The direction that matters in practice — **new Mac + old Android** — is unaffected (stays on today's behavior until the phone updates).

## Minor follow-up (not in this PR)

On a new Mac, the `logUnusableAdvert` probe keys off the service UUID in the primary advert; updated phones will mostly stop hitting that "unusable" diagnostic line (they go straight to the success path). Cosmetic only.

## Testing

- `./scripts/build-all.sh` (Mac + Android) ✓
- `./gradlew testDebugUnitTest` ✓
- ⚠️ Not yet validated on the slow Mac — the decisive test is a pair/reconnect on that machine showing discovery in ~seconds instead of tens of seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)