### PR TITLE
docs(macos): make didDiscover manufacturer-data comment layout-agnostic

### DIFF
--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -726,8 +726,10 @@ extension ConnectionController: CBCentralManagerDelegate {
         rssi RSSI: NSNumber
     ) {
         // We scan broadly (see ensureScanning), so didDiscover fires for every
-        // BLE device. The tag + PSM live in the scan-response manufacturer data
-        // (company 0xFFFF); that payload alone identifies a ClipRelay device.
+        // BLE device. The tag + PSM are in the 0xFFFF manufacturer data, which
+        // CoreBluetooth surfaces here regardless of whether the peripheral
+        // advertises it in the primary advert or the scan response; that payload
+        // alone identifies a ClipRelay device.
         guard let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data,
               Self.isClipRelayManufacturerData(manufacturerData),
               let deviceTag = Self.extractDeviceTag(from: manufacturerData),


### PR DESCRIPTION
Addresses the cosmetic note from the [#85](https://github.com/geekflyer/cliprelay/pull/85) review.

The `didDiscover` comment said the tag + PSM *"live in the scan-response manufacturer data."* That's accurate today, but goes stale the moment #85 (which moves the payload into the primary advert) merges. Since CoreBluetooth merges the primary advert and scan response into a single `advertisementData` dict, the central reads the `0xFFFF` payload regardless of which packet carries it — so the comment is reworded to say exactly that. Correct under **both** the current (scan-response) and post-#85 (primary-advert) layouts.

Comment-only, no behavior change. `swift build` ✓.