### PR TITLE
build(android): bundle native debug symbols into release AAB

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -91,6 +91,13 @@ android {
                 "proguard-rules.pro"
             )
 
+            // Bundle native debug symbols (ML Kit .so libs from quickie) into the AAB
+            // so Play Console can symbolicate native crashes/ANRs. Kills the
+            // "you've not uploaded debug symbols" warning. FULL = names + line numbers.
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
+
             if (releaseSigningConfigured) {
                 signingConfig = signingConfigs.getByName("release")
             }


### PR DESCRIPTION
## What

Add `ndk.debugSymbolLevel = "FULL"` to the Android `release` buildType so AGP packages native debug symbols into the AAB.

## Why

`quickie-bundled` (QR scanning) pulls in ML Kit barcode native `.so` libs. Since adding it, every Play Store publish warns:

> This App Bundle contains native code, and you've not uploaded debug symbols. We recommend you upload a symbol file to make your crashes and ANRs easier to analyze and debug.

With `debugSymbolLevel = "FULL"`, the symbols (method names + line numbers) are embedded in the AAB on build — Play Console symbolicates native crashes/ANRs automatically, no manual upload, warning gone.

## Reviewer notes

- Symbols are stripped from the APKs delivered to devices, so **no user download-size impact** (the AAB is larger, not the install).
- `FULL` = names + line numbers. Switch to `"SYMBOL_TABLE"` if a smaller AAB is preferred (method names only).
- Only affects `release`; debug builds unchanged. Verified `:app:assembleDebug` still parses/builds clean. A real `bundleRelease` on next publish confirms the warning clears.
- Does **not** touch the separately-reported Play review-time slowdown — that traces to the new CAMERA permission (intrinsic to QR scanning), not the native symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)