### PR TITLE
fix(android): intermittent 0.7.0 pairing failure — null tag → empty primary advert

### DIFF
--- a/android/app/src/main/java/org/cliprelay/ble/Advertiser.kt
+++ b/android/app/src/main/java/org/cliprelay/ble/Advertiser.kt
@@ -84,19 +84,26 @@ class Advertiser(private val context: Context, private val serviceUuid: ParcelUu
         // 0xFFFF manufacturer payload, so it no longer needs the service UUID in
         // the primary advert. Budget: 3 (flags) + 14 (mfr data: 2 header + 2
         // company id + 10 payload) = 17 bytes, well under the 31-byte limit.
-        val advertiseBuilder = AdvertiseData.Builder()
-            .setIncludeDeviceName(false)
+        // The tag+PSM ride in the PRIMARY advert (see above). With a null tag the
+        // primary advert would be EMPTY and the central can't see us at all — it
+        // matches on this 0xFFFF payload, and the service UUID now lives only in
+        // the scan response. So never advertise without a tag: retry until the
+        // session/service sets it (callers restart() once the tag lands).
         val tag = deviceTag
-        if (tag != null) {
-            // Pack: [device_tag: 8 bytes][psm: 2 bytes big-endian]
-            val payload = ByteArray(tag.size + 2)
-            System.arraycopy(tag, 0, payload, 0, tag.size)
-            payload[tag.size] = (psm shr 8).toByte()
-            payload[tag.size + 1] = (psm and 0xFF).toByte()
-            // 0xFFFF = Bluetooth SIG reserved for testing/development
-            advertiseBuilder.addManufacturerData(0xFFFF, payload)
+        if (tag == null) {
+            scheduleRetry("deviceTag not set yet")
+            return
         }
-        val advertiseData = advertiseBuilder.build()
+        // Pack: [device_tag: 8 bytes][psm: 2 bytes big-endian]
+        val payload = ByteArray(tag.size + 2)
+        System.arraycopy(tag, 0, payload, 0, tag.size)
+        payload[tag.size] = (psm shr 8).toByte()
+        payload[tag.size + 1] = (psm and 0xFF).toByte()
+        // 0xFFFF = Bluetooth SIG reserved for testing/development
+        val advertiseData = AdvertiseData.Builder()
+            .setIncludeDeviceName(false)
+            .addManufacturerData(0xFFFF, payload)
+            .build()
 
         // Scan response: service UUID. The current macOS central no longer needs
         // it (it matches on the manufacturer payload above), but we keep

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -377,6 +377,13 @@ class ClipRelayService : Service(), L2capServerCallback {
         val serviceUUID = java.util.UUID.fromString("c10b0001-1234-5678-9abc-def012345678")
 
         val started = runCatching {
+            // Replace any prior BLE session first — a lingering advertiser keeps
+            // broadcasting a stale PSM and can block the new one (single LE slot).
+            advertiser?.stop()
+            advertiser = null
+            l2capServer?.stop()
+            l2capServer = null
+
             // 1. Start L2CAP server, get PSM
             val l2cap = L2capServer(adapter, this)
             val psm = l2cap.start()


### PR DESCRIPTION
## What

Fixes an **intermittent** pairing failure on 0.7.0: some users/devices can't pair (others are fine — it's timing-dependent).

Field log, **Pixel 7 Pro on 0.7.0**, every attempt in that session:
```
ClipRelayService: BLE advertising started (psm=130, deviceTag=cb6305f852bcfc83)
Advertiser: BLE advertise started (deviceTag=null, psm=130)   ← null on air
ClipRelayService: Pairing timed out after 60000ms
```

## Root cause
#85 moved the tag+PSM into the **primary** advert and the service UUID into the scan response. The builder still gated the manufacturer payload on `if (tag != null)`, so a **null tag → EMPTY primary advert** (no mfr data, and no UUID there anymore). The macOS central broad-scans and matches on the `0xFFFF` payload, so an empty primary advert is **invisible** → never discovered → 60s timeout.

The null tag is a race: `startBle()` builds a fresh `Advertiser`/`L2capServer` without stopping the previous ones, so a lingering launch-time advertiser (null tag + stale PSM) can keep broadcasting and block the new one (single LE advertiser slot). Whether it bites depends on advertiser/scan timing — hence intermittent, device-dependent.

## Fix
- **Advertiser:** `deviceTag == null` → `scheduleRetry()` + return instead of advertising an empty primary. Callers already `restart()` once the tag is set.
- **startBle():** stop + clear the prior advertiser/L2CAP before starting new ones.

## Test
- `build-all.sh --android-only` ✓, `gradlew testDebugUnitTest` ✓
- ⚠️ Hardware repro pending (wireless adb dropped). Verify: pair on 0.7.0+this → logcat shows `Advertiser: BLE advertise started (deviceTag=<hex>, …)` (non-null) and pairing completes.

Worth a 0.7.1.