### PR TITLE
feat(macos): Don't Sync Passwords & Secrets — skip concealed clipboard copies

### DIFF
--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -91,12 +91,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusBarController.isImageSyncEnabled = { [weak self] in
             self?.connectionController?.isImageSyncEnabled ?? false
         }
-        statusBarController.onToggleSkipSecrets = {
-            ClipboardMonitor.skipSecretsEnabled.toggle()
-        }
-        statusBarController.isSkipSecretsEnabled = {
-            ClipboardMonitor.skipSecretsEnabled
-        }
         statusBarController.isDeviceConnected = { [weak self] in
             self?.connectionController?.isConnected ?? false
         }

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -91,6 +91,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusBarController.isImageSyncEnabled = { [weak self] in
             self?.connectionController?.isImageSyncEnabled ?? false
         }
+        statusBarController.onToggleSkipSecrets = {
+            ClipboardMonitor.skipSecretsEnabled.toggle()
+        }
+        statusBarController.isSkipSecretsEnabled = {
+            ClipboardMonitor.skipSecretsEnabled
+        }
         statusBarController.isDeviceConnected = { [weak self] in
             self?.connectionController?.isConnected ?? false
         }

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -13,6 +13,8 @@ final class StatusBarController {
     var isLaunchAtLoginEnabled: (() -> Bool)?
     var onToggleImageSync: (() -> Void)?
     var isImageSyncEnabled: (() -> Bool)?
+    var onToggleSkipSecrets: (() -> Void)?
+    var isSkipSecretsEnabled: (() -> Bool)?
     var isDeviceConnected: (() -> Bool)?
     var bleStateProvider: (() -> String)?
 
@@ -252,6 +254,23 @@ final class StatusBarController {
         }
         menu.addItem(imageSyncItem)
 
+        let skipSecretsItem = NSMenuItem(
+            title: "Don\u{2019}t Sync Passwords & Secrets",
+            action: #selector(handleToggleSkipSecrets),
+            keyEquivalent: ""
+        )
+        skipSecretsItem.target = self
+        skipSecretsItem.toolTip = """
+        When on, clipboard copies that an app marks as secret (concealed) are not sent to \
+        your phone — so passwords stay on this Mac. Works with password managers that flag \
+        copies as concealed, such as Bitwarden, 1Password and KeePassXC. \
+        Note: copies made from browser extensions aren't flagged and will still sync.
+        """
+        if isSkipSecretsEnabled?() == true {
+            skipSecretsItem.state = .on
+        }
+        menu.addItem(skipSecretsItem)
+
         menu.addItem(NSMenuItem.separator())
 
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
@@ -408,6 +427,12 @@ final class StatusBarController {
     }
 
     @objc
+    private func handleToggleSkipSecrets() {
+        onToggleSkipSecrets?()
+        renderMenu()
+    }
+
+    @objc
     private func handleVisitWebsite() {
         if let url = URL(string: "https://cliprelay.org") {
             NSWorkspace.shared.open(url)
@@ -491,6 +516,7 @@ final class StatusBarController {
         #endif
         let flags = [
             "imageSync=\(isImageSyncEnabled?() ?? false)",
+            "skipSecrets=\(isSkipSecretsEnabled?() ?? true)",
             "autoUpdate=\(updaterController.updater.automaticallyChecksForUpdates)",
             "betaChannel=\(isBetaChannelEnabled)",
         ].joined(separator: ", ")

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -13,8 +13,6 @@ final class StatusBarController {
     var isLaunchAtLoginEnabled: (() -> Bool)?
     var onToggleImageSync: (() -> Void)?
     var isImageSyncEnabled: (() -> Bool)?
-    var onToggleSkipSecrets: (() -> Void)?
-    var isSkipSecretsEnabled: (() -> Bool)?
     var isDeviceConnected: (() -> Bool)?
     var bleStateProvider: (() -> String)?
 
@@ -266,7 +264,7 @@ final class StatusBarController {
         copies as concealed, such as Bitwarden, 1Password and KeePassXC. \
         Note: copies made from browser extensions aren't flagged and will still sync.
         """
-        if isSkipSecretsEnabled?() == true {
+        if ClipboardMonitor.skipSecretsEnabled {
             skipSecretsItem.state = .on
         }
         menu.addItem(skipSecretsItem)
@@ -428,7 +426,7 @@ final class StatusBarController {
 
     @objc
     private func handleToggleSkipSecrets() {
-        onToggleSkipSecrets?()
+        ClipboardMonitor.skipSecretsEnabled.toggle()
         renderMenu()
     }
 
@@ -471,8 +469,9 @@ final class StatusBarController {
             DispatchQueue.main.async {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(text, forType: .string)
-                // The clipboard monitor caps synced text at 100 KB, so the full
-                // log dump stays local and is not pushed to paired devices.
+                // Mark the copy concealed so the skip-secrets filter keeps the log dump
+                // local; the 100 KB sync cap only catches dumps that outgrow it.
+                NSPasteboard.general.setString("", forType: ClipboardMonitor.concealedType)
                 Self.notifyLogsCopied(byteCount: text.utf8.count)
             }
         }
@@ -516,7 +515,7 @@ final class StatusBarController {
         #endif
         let flags = [
             "imageSync=\(isImageSyncEnabled?() ?? false)",
-            "skipSecrets=\(isSkipSecretsEnabled?() ?? true)",
+            "skipSecrets=\(ClipboardMonitor.skipSecretsEnabled)",
             "autoUpdate=\(updaterController.updater.automaticallyChecksForUpdates)",
             "betaChannel=\(isBetaChannelEnabled)",
         ].joined(separator: ", ")

--- a/macos/ClipRelayMac/Sources/Clipboard/ClipboardMonitor.swift
+++ b/macos/ClipRelayMac/Sources/Clipboard/ClipboardMonitor.swift
@@ -65,7 +65,13 @@ final class ClipboardMonitor {
         lastChangeCount = pasteboard.changeCount
 
         // Don't sync password-manager / secret copies that mark themselves concealed (#70).
-        if Self.skipSecretsEnabled, Self.isConcealed(pasteboard.types) { return }
+        // Check every item's types: pasteboard.types only reflects the first item.
+        if Self.skipSecretsEnabled,
+           Self.isConcealed((pasteboard.types ?? []) + (pasteboard.pasteboardItems ?? []).flatMap(\.types)) {
+            // Clear the dedup hash so re-copying the previous content still syncs.
+            lastHash = nil
+            return
+        }
 
         // Images take priority over text
         if let (imageData, contentType) = pasteboardImage(pasteboard) {

--- a/macos/ClipRelayMac/Sources/Clipboard/ClipboardMonitor.swift
+++ b/macos/ClipRelayMac/Sources/Clipboard/ClipboardMonitor.swift
@@ -15,6 +15,23 @@ final class ClipboardMonitor {
         return milliseconds / 1000
     }()
 
+    /// De-facto standard marker password managers (Bitwarden, 1Password, …) put on the
+    /// pasteboard for secret copies. See nspasteboard.org and issue #70.
+    static let concealedType = NSPasteboard.PasteboardType("org.nspasteboard.ConcealedType")
+
+    static let skipSecretsDefaultsKey = "skipPasswordsAndSecrets"
+
+    /// When on, concealed (password-manager) copies are not synced. Defaults to on.
+    static var skipSecretsEnabled: Bool {
+        get { UserDefaults.standard.object(forKey: skipSecretsDefaultsKey) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: skipSecretsDefaultsKey) }
+    }
+
+    /// True if the pasteboard carries the concealed marker. Pure for testability.
+    static func isConcealed(_ types: [NSPasteboard.PasteboardType]?) -> Bool {
+        types?.contains(concealedType) ?? false
+    }
+
     private let pasteboard = NSPasteboard.general
     private let onChange: (String) -> Void
     private let pollInterval: TimeInterval
@@ -46,6 +63,9 @@ final class ClipboardMonitor {
     private func poll() {
         guard pasteboard.changeCount != lastChangeCount else { return }
         lastChangeCount = pasteboard.changeCount
+
+        // Don't sync password-manager / secret copies that mark themselves concealed (#70).
+        if Self.skipSecretsEnabled, Self.isConcealed(pasteboard.types) { return }
 
         // Images take priority over text
         if let (imageData, contentType) = pasteboardImage(pasteboard) {

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/ClipboardMonitorTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/ClipboardMonitorTests.swift
@@ -1,0 +1,28 @@
+import AppKit
+import XCTest
+@testable import ClipRelay
+
+final class ClipboardMonitorTests: XCTestCase {
+    func testConcealedDetection() {
+        XCTAssertTrue(ClipboardMonitor.isConcealed([ClipboardMonitor.concealedType]))
+        XCTAssertTrue(ClipboardMonitor.isConcealed([.string, ClipboardMonitor.concealedType]))
+        XCTAssertFalse(ClipboardMonitor.isConcealed([.string, .png]))
+        XCTAssertFalse(ClipboardMonitor.isConcealed([]))
+        XCTAssertFalse(ClipboardMonitor.isConcealed(nil))
+    }
+
+    func testSkipSecretsDefaultsOn() {
+        let key = ClipboardMonitor.skipSecretsDefaultsKey
+        let original = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let original { UserDefaults.standard.set(original, forKey: key) }
+            else { UserDefaults.standard.removeObject(forKey: key) }
+        }
+
+        UserDefaults.standard.removeObject(forKey: key)
+        XCTAssertTrue(ClipboardMonitor.skipSecretsEnabled, "should default to on")
+
+        ClipboardMonitor.skipSecretsEnabled = false
+        XCTAssertFalse(ClipboardMonitor.skipSecretsEnabled)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a **"Don't Sync Passwords & Secrets"** toggle to the Mac menu bar (default **on**). When enabled, clipboard copies carrying the de-facto `org.nspasteboard.ConcealedType` marker (see [nspasteboard.org](https://nspasteboard.org/)) are not synced to paired phones. This covers password managers that flag their copies — Bitwarden (desktop app), 1Password, KeePassXC, and others.

Closes #70

## Implementation
- `ClipboardMonitor.poll()` skips the pasteboard change when the setting is on and any pasteboard item declares the concealed type (checked per-item — `pasteboard.types` only reflects the first item). The dedup hash is cleared on skip so re-copying the previous content still syncs.
- Setting is a `UserDefaults`-backed static (`skipPasswordsAndSecrets`), read directly by `StatusBarController` (same pattern as the beta-channel toggle). Menu item sits under *Image Sync* with a hover tooltip explaining behavior and limitations, and the state is included in the diagnostic-logs flags.
- Bonus fix surfaced by review: *Copy Diagnostic Logs* now marks its own clipboard write as concealed — previously a log dump under 100 KB would sync to the phone despite the in-code comment claiming otherwise.

## Known limitations (documented in tooltip where user-relevant)
- Copies from **browser extensions** (e.g. Bitwarden extension) are not flagged concealed by the source and will still sync ([bitwarden/clients#17404](https://github.com/bitwarden/clients/issues/17404)).
- Polling is inherently racy: a source app that writes the secret and adds the marker in separate pasteboard transactions could in principle be caught mid-write by a poll tick (sub-ms window per 0.5 s tick).
- A secret cached in `pendingClipboard` while the toggle was off can still be delivered on reconnect after the toggle is turned on.
- Turning the toggle **off** does not retroactively sync the currently-copied secret; re-copy it.

## Testing
- New `ClipboardMonitorTests` cover the concealed-type predicate and the default-on setting.
- Full suite: 159 tests pass; `scripts/build-all.sh` green (macOS + Android).
- Manually verified on-device: concealed copies stay local, toggle + tooltip render correctly. Hardware smoke tests skipped (no Android device connected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)