### PR TITLE
fix(macos): drop reconnect-replay clipboard cache when skip-secrets turns on

### DIFF
--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -88,6 +88,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusBarController.onToggleImageSync = { [weak self] in
             self?.connectionController?.toggleImageSync()
         }
+        statusBarController.onSkipSecretsEnabled = { [weak self] in
+            // Text cached for reconnect-replay while the filter was off may be a
+            // secret — drop it so it can't bypass the filter on reconnect.
+            self?.connectionController?.clearPendingClipboard()
+        }
         statusBarController.isImageSyncEnabled = { [weak self] in
             self?.connectionController?.isImageSyncEnabled ?? false
         }

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -12,6 +12,8 @@ final class StatusBarController {
     var onToggleLaunchAtLogin: (() -> Void)?
     var isLaunchAtLoginEnabled: (() -> Bool)?
     var onToggleImageSync: (() -> Void)?
+    /// Fired when "Don't Sync Passwords & Secrets" flips to ON.
+    var onSkipSecretsEnabled: (() -> Void)?
     var isImageSyncEnabled: (() -> Bool)?
     var isDeviceConnected: (() -> Bool)?
     var bleStateProvider: (() -> String)?
@@ -427,6 +429,9 @@ final class StatusBarController {
     @objc
     private func handleToggleSkipSecrets() {
         ClipboardMonitor.skipSecretsEnabled.toggle()
+        if ClipboardMonitor.skipSecretsEnabled {
+            onSkipSecretsEnabled?()
+        }
         renderMenu()
     }
 

--- a/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
+++ b/macos/ClipRelayMac/Sources/BLE/ConnectionController.swift
@@ -689,6 +689,22 @@ extension ConnectionController {
         }
     }
 
+    /// Drops the reconnect-replay cache. Called when "Don't Sync Passwords & Secrets"
+    /// is turned on: text cached while the filter was off may be a secret, and
+    /// replaying it on reconnect would bypass the filter.
+    func clearPendingClipboard() {
+        queue.async { [self] in
+            guard pendingClipboard != nil else { return }
+            pendingClipboard = nil
+            log("Cleared cached clipboard (skip-secrets enabled)")
+        }
+    }
+
+    /// Test-only synchronous view of the replay cache.
+    var hasPendingClipboard: Bool {
+        queue.sync { pendingClipboard != nil }
+    }
+
     func sendImage(_ data: Data, contentType: String) {
         queue.async { [self] in
             let hash = Session.sha256Hex(data)

--- a/macos/ClipRelayMac/Tests/ClipRelayTests/ConnectionControllerTests.swift
+++ b/macos/ClipRelayMac/Tests/ClipRelayTests/ConnectionControllerTests.swift
@@ -210,4 +210,12 @@ final class ConnectionControllerTests: XCTestCase {
         controller.sendClipboard("hello")
         controller.sendClipboard("hello") // double send should not crash
     }
+
+    func testClearPendingClipboardDropsReplayCache() {
+        let controller = makeController()
+        controller.sendClipboard("hunter2") // no device ready → cached for replay
+        XCTAssertTrue(controller.hasPendingClipboard)
+        controller.clearPendingClipboard()
+        XCTAssertFalse(controller.hasPendingClipboard)
+    }
 }


### PR DESCRIPTION
## Problem

`ConnectionController` caches the last outbound clipboard in `pendingClipboard` when no device is ready and replays it in `handleSessionReady` on reconnect. This replay bypassed the skip-secrets filter from #97 temporally: a secret copied while "Don't Sync Passwords & Secrets" was off would still be delivered when the phone reconnects after the user turns the setting on.

## Fix

Clear the replay cache the moment the toggle flips to on:

- `ConnectionController.clearPendingClipboard()` drops the cache on the connection queue (plus a test-only `hasPendingClipboard` accessor).
- `StatusBarController.onSkipSecretsEnabled` callback fires only when the toggle flips to ON.
- `AppDelegate` wires the callback to `clearPendingClipboard()`.

Re-evaluating the skip condition at replay time isn't possible with the current design — the concealed marker is a pasteboard type, not stored alongside the cached bytes. Clearing on toggle is the minimal correct fix. Only text is cached for replay (no pending image cache), and the cache is in-memory, so the pre-upgrade scenario resolves itself on app restart.

## Testing

- New unit test `testClearPendingClipboardDropsReplayCache`: caches text while disconnected, clears, asserts the cache is gone.
- `scripts/build-all.sh` — pass.
- `scripts/test-all.sh` — 160 Mac tests + all Android unit suites, 0 failures.
- Hardware smoke tests skipped (no Android device connected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)