### PR TITLE
feat(android): show connection status in service notification

### DIFF
--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -5,6 +5,7 @@ package org.cliprelay.service
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
@@ -997,6 +998,7 @@ class ClipRelayService : Service(), L2capServerCallback {
         intent.putStringArrayListExtra(EXTRA_CONNECTED_IDS, ArrayList())
         if (deviceName != null) intent.putExtra(EXTRA_DEVICE_NAME, deviceName)
         sendBroadcast(intent)
+        updateNotification()
     }
 
     /** Broadcast the full per-Mac connection state (ids of Macs with a ready session). */
@@ -1015,6 +1017,7 @@ class ClipRelayService : Service(), L2capServerCallback {
         intent.putStringArrayListExtra(EXTRA_CONNECTED_IDS, ids)
         firstName?.let { intent.putExtra(EXTRA_DEVICE_NAME, it) }
         sendBroadcast(intent)
+        updateNotification()
     }
 
     /** Share-sheet target label: single Mac shows its name, several show a collective label. */
@@ -1052,11 +1055,39 @@ class ClipRelayService : Service(), L2capServerCallback {
         )
         manager.createNotificationChannel(channel)
 
+        val tapIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, org.cliprelay.ui.MainActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
         return NotificationCompat.Builder(this, channelId)
             .setContentTitle(getString(R.string.app_name))
-            .setContentText(getString(R.string.service_notification_text))
+            .setContentText(notificationText())
             .setSmallIcon(android.R.drawable.stat_sys_data_bluetooth)
             .setOngoing(true)
+            .setContentIntent(tapIntent)
             .build()
+    }
+
+    private fun notificationText(): String {
+        val macs = pairingStore.loadPairedMacs()
+        if (macs.isEmpty()) return getString(R.string.notification_not_paired)
+        val ready = readySessions()
+        val connected = macs.filter { mac -> ready.any { it.secretHex == mac.secretHex } }
+        return when (connected.size) {
+            0 -> getString(R.string.notification_waiting)
+            1 -> getString(
+                R.string.notification_connected_one,
+                connected[0].name ?: ready[0].session?.remoteName ?: "Mac"
+            )
+            else -> getString(R.string.notification_connected_many, connected.size)
+        }
+    }
+
+    private fun updateNotification() {
+        if (!foregroundStarted) return
+        getSystemService(NotificationManager::class.java).notify(1001, buildNotification())
     }
 }

--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -1078,10 +1078,13 @@ class ClipRelayService : Service(), L2capServerCallback {
         val connected = macs.filter { mac -> ready.any { it.secretHex == mac.secretHex } }
         return when (connected.size) {
             0 -> getString(R.string.notification_waiting)
-            1 -> getString(
-                R.string.notification_connected_one,
-                connected[0].name ?: ready[0].session?.remoteName ?: "Mac"
-            )
+            1 -> {
+                val match = ready.firstOrNull { it.secretHex == connected[0].secretHex }
+                getString(
+                    R.string.notification_connected_one,
+                    connected[0].name ?: match?.session?.remoteName ?: "Mac"
+                )
+            }
             else -> getString(R.string.notification_connected_many, connected.size)
         }
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,10 @@
 <resources>
     <string name="app_name">ClipRelay</string>
     <string name="service_channel_name">Clipboard Sync</string>
-    <string name="service_notification_text">BLE clipboard sync is active</string>
+    <string name="notification_not_paired">Not paired yet — tap to set up</string>
+    <string name="notification_waiting">Waiting for your Mac…</string>
+    <string name="notification_connected_one">Connected to %1$s</string>
+    <string name="notification_connected_many">Connected to %1$d Macs</string>
     <string name="main_title">ClipRelay</string>
     <string name="main_subtitle">Clipboard sync stays on while this app is installed and permissions are granted.</string>
     <string name="status_label">Service</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="app_name">ClipRelay</string>
     <string name="service_channel_name">Clipboard Sync</string>
     <string name="notification_not_paired">Not paired yet — tap to set up</string>
-    <string name="notification_waiting">Waiting for your Mac…</string>
+    <string name="notification_waiting">Searching for your Mac…</string>
     <string name="notification_connected_one">Connected to %1$s</string>
     <string name="notification_connected_many">Connected to %1$d Macs</string>
     <string name="main_title">ClipRelay</string>


### PR DESCRIPTION
## Summary
- Replace static "BLE clipboard sync is active" notification text with state-aware copy:
  - Not paired: "Not paired yet — tap to set up"
  - Paired, no connection: "Waiting for your Mac…"
  - One Mac connected: "Connected to <Mac name>"
  - Multiple: "Connected to N Macs"
- Tapping the notification now opens the app (content intent on MainActivity).
- Notification refreshes on every connection-state change (both broadcast paths: connect, disconnect, Bluetooth toggle, pair, unpair).

## Testing
- `scripts/build-all.sh` — both platforms build.
- `scripts/test-all.sh` — 160 Swift tests pass, Android unit tests pass.
- Hardware smoke test / on-device verification skipped — no Android device connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)