### PR TITLE
feat(android): scrollability affordances, footer redesign, edge-to-edge

### DIFF
--- a/android/app/src/main/java/org/cliprelay/ui/AutoCopyOnboardingActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/AutoCopyOnboardingActivity.kt
@@ -70,6 +70,7 @@ class AutoCopyOnboardingActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableLightEdgeToEdge()
         settingsStore = ClipboardSettingsStore(this)
 
         setContent {

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -25,10 +25,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
@@ -169,12 +170,10 @@ fun ClipRelayScreen(
         // Scrollable so the footer stays reachable when the Mac list grows the
         // card beyond the screen. When everything fits, SpaceBetween with a
         // min-height of the viewport reproduces the old centered layout.
-        // Bottom inset handled inside the scroll column so content scrolls
-        // behind the transparent gesture bar (edge-to-edge).
+        // Insets handled inside the scroll column so content scrolls behind
+        // the transparent status and gesture bars (edge-to-edge).
         BoxWithConstraints(
-            modifier = Modifier
-                .fillMaxSize()
-                .statusBarsPadding()
+            modifier = Modifier.fillMaxSize()
         ) {
             val viewportHeight = maxHeight
             val scrollState = rememberScrollState()
@@ -187,6 +186,9 @@ fun ClipRelayScreen(
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Spacer(
+                    modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars)
+                )
                 Spacer(modifier = Modifier.height(12.dp))
                 StatusChip(state = state)
             }

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -174,10 +174,11 @@ fun ClipRelayScreen(
                 .navigationBarsPadding()
         ) {
             val viewportHeight = maxHeight
+            val scrollState = rememberScrollState()
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
+                    .verticalScroll(scrollState)
                     .heightIn(min = viewportHeight),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.SpaceBetween
@@ -221,7 +222,31 @@ fun ClipRelayScreen(
                     }
                 )
             }
-            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "ClipRelay v${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_HASH})",
+                style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+            }
+
+            // Bottom fade: clipped card content melts to white when more is below.
+            AnimatedVisibility(
+                visible = scrollState.canScrollForward,
+                modifier = Modifier.align(Alignment.BottomCenter),
+                enter = fadeIn(tween(200)),
+                exit = fadeOut(tween(200))
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(64.dp)
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(Color.Transparent, Color.White)
+                            )
+                        )
+                )
             }
         }
 
@@ -1241,12 +1266,6 @@ private fun FooterSection(
                 modifier = Modifier.padding(vertical = 4.dp)
             )
         }
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = "ClipRelay v${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_HASH})",
-            style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
-            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
-        )
     }
 
     if (showSupportDialog) {

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -167,9 +167,10 @@ fun ClipRelayScreen(
                 )
             }
     ) {
-        // Scrollable so the footer stays reachable when the Mac list grows the
-        // card beyond the screen. When everything fits, SpaceBetween with a
-        // min-height of the viewport reproduces the old centered layout.
+        // Scrollable so the card (which contains the footer buttons) stays fully
+        // reachable when the Mac list grows it beyond the screen; the clipped
+        // card edge doubles as the scroll affordance. When everything fits,
+        // SpaceBetween with a min-height of the viewport centers the layout.
         // Insets handled inside the scroll column so content scrolls behind
         // the transparent status and gesture bars (edge-to-edge).
         BoxWithConstraints(

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -1304,9 +1304,6 @@ private fun SupportDialog(
         title = { Text("Feedback & Support") },
         text = {
             Column {
-                TextButton(onClick = onShareLogsClick) {
-                    Text(stringResource(R.string.support_share_logs), modifier = Modifier.fillMaxWidth())
-                }
                 TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.gitHubIssueUrl(bleState)) }) {
                     Text("Report Issue on GitHub", modifier = Modifier.fillMaxWidth())
                 }
@@ -1315,6 +1312,9 @@ private fun SupportDialog(
                 }
                 TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.DISCUSSIONS_URL) }) {
                     Text("Community Discussions", modifier = Modifier.fillMaxWidth())
+                }
+                TextButton(onClick = onShareLogsClick) {
+                    Text(stringResource(R.string.support_share_logs), modifier = Modifier.fillMaxWidth())
                 }
             }
         },

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -22,8 +22,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -167,11 +169,12 @@ fun ClipRelayScreen(
         // Scrollable so the footer stays reachable when the Mac list grows the
         // card beyond the screen. When everything fits, SpaceBetween with a
         // min-height of the viewport reproduces the old centered layout.
+        // Bottom inset handled inside the scroll column so content scrolls
+        // behind the transparent gesture bar (edge-to-edge).
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding()
-                .navigationBarsPadding()
         ) {
             val viewportHeight = maxHeight
             val scrollState = rememberScrollState()
@@ -227,6 +230,9 @@ fun ClipRelayScreen(
                 style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
                 color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 12.dp)
+            )
+            Spacer(
+                modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars)
             )
             }
 

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -174,11 +174,10 @@ fun ClipRelayScreen(
                 .navigationBarsPadding()
         ) {
             val viewportHeight = maxHeight
-            val scrollState = rememberScrollState()
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .verticalScroll(scrollState)
+                    .verticalScroll(rememberScrollState())
                     .heightIn(min = viewportHeight),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.SpaceBetween
@@ -205,41 +204,24 @@ fun ClipRelayScreen(
                     onHideClipboardSettingChanged = onHideClipboardSettingChanged,
                     onAutoCopySettingChanged = onAutoCopySettingChanged,
                     onImageSyncSettingChanged = onImageSyncSettingChanged,
-                    onAutoCopyFixClick = onAutoCopyFixClick
-                )
-            }
-            FooterSection(
-                isPaired = isPaired,
-                bleState = when {
-                    isConnected -> "connected"
-                    state is AppState.Paired -> "searching"
-                    state is AppState.Pairing -> "searching"
-                    else -> "unpaired"
-                },
-                onHelpClick = onHelpClick,
-                onSupportLinkClick = onSupportLinkClick,
-                onShareLogsClick = onShareLogsClick,
-            )
-            }
-
-            // Bottom fade scrim: signals more content (help/feedback footer)
-            // below the fold when the Mac list grows the card past the viewport.
-            AnimatedVisibility(
-                visible = scrollState.canScrollForward,
-                modifier = Modifier.align(Alignment.BottomCenter),
-                enter = fadeIn(tween(200)),
-                exit = fadeOut(tween(200))
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(48.dp)
-                        .background(
-                            Brush.verticalGradient(
-                                listOf(Color.Transparent, Color(0x26000000))
-                            )
+                    onAutoCopyFixClick = onAutoCopyFixClick,
+                    footer = {
+                        FooterSection(
+                            isPaired = isPaired,
+                            bleState = when {
+                                isConnected -> "connected"
+                                state is AppState.Paired -> "searching"
+                                state is AppState.Pairing -> "searching"
+                                else -> "unpaired"
+                            },
+                            onHelpClick = onHelpClick,
+                            onSupportLinkClick = onSupportLinkClick,
+                            onShareLogsClick = onShareLogsClick,
                         )
+                    }
                 )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
             }
         }
 
@@ -362,7 +344,8 @@ private fun MainCard(
     onHideClipboardSettingChanged: (Boolean) -> Unit = {},
     onAutoCopySettingChanged: (Boolean) -> Unit,
     onImageSyncSettingChanged: (Boolean) -> Unit = {},
-    onAutoCopyFixClick: () -> Unit = {}
+    onAutoCopyFixClick: () -> Unit = {},
+    footer: @Composable () -> Unit = {}
 ) {
     val isPaired = state !is AppState.Unpaired
     val isConnected = state is AppState.Paired && state.anyConnected
@@ -625,6 +608,7 @@ private fun MainCard(
                 onEnabledChange = onAutoCopySettingChanged,
                 onFixClick = onAutoCopyFixClick
             )
+            footer()
         }
     }
 }
@@ -1216,7 +1200,9 @@ private fun FooterSection(
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.padding(horizontal = 28.dp, vertical = 16.dp)
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp)
     ) {
         if (isPaired) {
             Button(

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -174,10 +174,11 @@ fun ClipRelayScreen(
                 .navigationBarsPadding()
         ) {
             val viewportHeight = maxHeight
+            val scrollState = rememberScrollState()
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
+                    .verticalScroll(scrollState)
                     .heightIn(min = viewportHeight),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.SpaceBetween
@@ -219,6 +220,26 @@ fun ClipRelayScreen(
                 onSupportLinkClick = onSupportLinkClick,
                 onShareLogsClick = onShareLogsClick,
             )
+            }
+
+            // Bottom fade scrim: signals more content (help/feedback footer)
+            // below the fold when the Mac list grows the card past the viewport.
+            AnimatedVisibility(
+                visible = scrollState.canScrollForward,
+                modifier = Modifier.align(Alignment.BottomCenter),
+                enter = fadeIn(tween(200)),
+                exit = fadeOut(tween(200))
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(40.dp)
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(Color.Transparent, bgBottom)
+                            )
+                        )
+                )
             }
         }
 

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -233,10 +233,10 @@ fun ClipRelayScreen(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(40.dp)
+                        .height(48.dp)
                         .background(
                             Brush.verticalGradient(
-                                listOf(Color.Transparent, bgBottom)
+                                listOf(Color.Transparent, Color(0x26000000))
                             )
                         )
                 )

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -1238,8 +1238,22 @@ private fun FooterSection(
             }
             Spacer(modifier = Modifier.height(8.dp))
         }
-        TextButton(onClick = { showSupportDialog = true }) {
-            Text("Feedback & Support", fontSize = 13.sp)
+        Button(
+            onClick = { showSupportDialog = true },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(28.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0x1400FFD5),
+                contentColor = Teal
+            ),
+            elevation = ButtonDefaults.buttonElevation(0.dp, 0.dp, 0.dp)
+        ) {
+            Text(
+                text = "💬 Feedback & Support",
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
         }
         Spacer(modifier = Modifier.height(4.dp))
         Text(

--- a/android/app/src/main/java/org/cliprelay/ui/EdgeToEdge.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/EdgeToEdge.kt
@@ -1,0 +1,16 @@
+package org.cliprelay.ui
+
+import android.graphics.Color
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
+
+// Edge-to-edge is enforced on API 35+; this extends it to older devices.
+// The UI is always light regardless of system theme, so force dark
+// system-bar icons instead of the theme-following default.
+fun ComponentActivity.enableLightEdgeToEdge() {
+    enableEdgeToEdge(
+        statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
+        navigationBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+    )
+}

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -14,7 +14,9 @@ import android.os.Bundle
 import android.os.PowerManager
 import android.provider.Settings
 import android.widget.Toast
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -147,6 +149,19 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Edge-to-edge is enforced on API 35+; this extends it to older devices.
+        // The UI is always light regardless of system theme, so force dark
+        // system-bar icons instead of the theme-following default.
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(
+                android.graphics.Color.TRANSPARENT,
+                android.graphics.Color.TRANSPARENT
+            ),
+            navigationBarStyle = SystemBarStyle.light(
+                android.graphics.Color.TRANSPARENT,
+                android.graphics.Color.TRANSPARENT
+            )
+        )
 
         requestRuntimePermissions()
         ensureServiceRunning()

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -14,9 +14,7 @@ import android.os.Bundle
 import android.os.PowerManager
 import android.provider.Settings
 import android.widget.Toast
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -149,19 +147,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Edge-to-edge is enforced on API 35+; this extends it to older devices.
-        // The UI is always light regardless of system theme, so force dark
-        // system-bar icons instead of the theme-following default.
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.light(
-                android.graphics.Color.TRANSPARENT,
-                android.graphics.Color.TRANSPARENT
-            ),
-            navigationBarStyle = SystemBarStyle.light(
-                android.graphics.Color.TRANSPARENT,
-                android.graphics.Color.TRANSPARENT
-            )
-        )
+        enableLightEdgeToEdge()
 
         requestRuntimePermissions()
         ensureServiceRunning()


### PR DESCRIPTION
## Summary

Makes it obvious the main screen scrolls, and modernizes the layout:

- **Footer inside the card**: How to share / Feedback & Support pills moved into the main card, so when the Mac list grows the card past the viewport, the card is clipped mid-content — a natural scroll cue. Version string stays below the card.
- **White bottom fade** while more content is below (animates out at scroll end).
- **Feedback & Support** restyled as a pill button matching How to share, with 💬.
- **Support dialog reordered**: GitHub issue → Email → Discussions → Share logs.
- **Edge-to-edge**: content scrolls behind the transparent status and gesture bars; `enableLightEdgeToEdge()` helper extends this to Android 12–14 (API 35+ already enforces it) and forces dark system-bar icons since the UI is always light. Applied to MainActivity and the auto-copy onboarding.

## Verification

- Verified on device (Pixel, Android 16) with screenshots in all scroll states, incl. forced overflow via font scale 1.8.
- `swift test` (160 pass) + Android unit tests pass; BLE hardware smoke test passed after the first UI commit; later commits are UI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)