### PR TITLE
fix(android): don't crash when no app can handle support link

### DIFF
--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -3,6 +3,7 @@ package org.cliprelay.ui
 // Main activity: handles permissions, QR scanning results, and hosts the Compose UI.
 
 import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -289,7 +290,11 @@ class MainActivity : AppCompatActivity() {
                     onboardingLauncher.launch(Intent(this, AutoCopyOnboardingActivity::class.java))
                 },
                 onSupportLinkClick = { url ->
-                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                    try {
+                        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                    } catch (e: ActivityNotFoundException) {
+                        Toast.makeText(this, "No app available to open this link", Toast.LENGTH_SHORT).show()
+                    }
                 },
                 onShareLogsClick = { bleState ->
                     shareLogs(bleState)


### PR DESCRIPTION
## What

Wrap the Feedback & Support link handler in `MainActivity` in a `try/catch (ActivityNotFoundException)` and show a short toast ("No app available to open this link") instead of crashing.

## Why

The dialog routes four URLs through a bare `startActivity(Intent(ACTION_VIEW, ...))`: GitHub issues, `mailto:`, GitHub Discussions, and the Play Store listing. On a device with no handler for the scheme — most realistically no email client installed for `mailto:` — `startActivity` throws `ActivityNotFoundException` and crashes the app.

## Verification

- Android unit tests: pass
- Full test suite (`scripts/test-all.sh`): 160 Swift tests + Android tests pass
- `scripts/build-all.sh`: pass
- Hardware BLE smoke tests on Pixel 10 Pro XL: PASS (both transfer directions + reconnect cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)