### PR TITLE
feat(android): nudge users on old versions via Play In-App Updates

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -185,6 +185,9 @@ dependencies {
     implementation("com.google.android.material:material:1.12.0")
     // Quickie: CameraX + bundled ML Kit QR scanner, no Google Play services required.
     implementation("io.github.g00fy2.quickie:quickie-bundled:1.12.0")
+    // Play In-App Updates: nudges users on old versions to upgrade. Silently
+    // no-ops on devices where the app wasn't installed from the Play Store.
+    implementation("com.google.android.play:app-update-ktx:2.1.0")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     implementation("androidx.activity:activity-ktx:1.9.3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -192,6 +192,8 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.9.3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+    // ProcessLifecycleOwner: detect whole-app background for silent update install.
+    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.json:json:20240303")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -192,8 +192,6 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.9.3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
-    // ProcessLifecycleOwner: detect whole-app background for silent update install.
-    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.json:json:20240303")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -86,6 +86,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/android/app/src/main/java/org/cliprelay/service/BootCompletedReceiver.kt
+++ b/android/app/src/main/java/org/cliprelay/service/BootCompletedReceiver.kt
@@ -1,6 +1,8 @@
 package org.cliprelay.service
 
-// Starts the ClipRelay foreground service automatically after device boot.
+// Starts the ClipRelay foreground service automatically after device boot or
+// after the app is updated (Play auto-update or in-app update), so clipboard
+// sync resumes without waiting for the user to reopen the app.
 
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -16,7 +18,9 @@ class BootCompletedReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent?) {
         val action = intent?.action ?: return
-        if (action != Intent.ACTION_BOOT_COMPLETED) {
+        if (action != Intent.ACTION_BOOT_COMPLETED &&
+            action != Intent.ACTION_MY_PACKAGE_REPLACED
+        ) {
             return
         }
 

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -1339,28 +1339,6 @@ fun BlePermissionDialog(
     )
 }
 
-// ─── Update Ready Dialog ──────────────────────────────────────────────────────
-@Composable
-fun UpdateReadyDialog(onRestart: () -> Unit, onLater: () -> Unit) {
-    AlertDialog(
-        onDismissRequest = onLater,
-        title = { Text("Update Ready") },
-        text = {
-            Text("A new version of ClipRelay has been downloaded. Restart the app to finish updating.")
-        },
-        confirmButton = {
-            TextButton(onClick = onRestart) {
-                Text("Restart")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onLater) {
-                Text("Later")
-            }
-        }
-    )
-}
-
 // ─── Version Mismatch Dialog ──────────────────────────────────────────────────
 @Composable
 fun VersionMismatchDialog(onDismiss: () -> Unit) {

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -1339,6 +1339,28 @@ fun BlePermissionDialog(
     )
 }
 
+// ─── Update Ready Dialog ──────────────────────────────────────────────────────
+@Composable
+fun UpdateReadyDialog(onRestart: () -> Unit, onLater: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onLater,
+        title = { Text("Update Ready") },
+        text = {
+            Text("A new version of ClipRelay has been downloaded. Restart the app to finish updating.")
+        },
+        confirmButton = {
+            TextButton(onClick = onRestart) {
+                Text("Restart")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onLater) {
+                Text("Later")
+            }
+        }
+    )
+}
+
 // ─── Version Mismatch Dialog ──────────────────────────────────────────────────
 @Composable
 fun VersionMismatchDialog(onDismiss: () -> Unit) {

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -24,6 +24,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
@@ -53,14 +56,23 @@ class MainActivity : AppCompatActivity() {
     private var blePermissionPermanentlyDenied by mutableStateOf(false)
 
     // Play In-App Updates (flexible flow): Play shows its own update sheet and
-    // downloads in the background; we only surface the "restart to finish" step.
+    // downloads in the background. Once downloaded, the update installs silently
+    // the next time the whole app leaves the foreground (no restart prompt);
+    // BootCompletedReceiver restarts the sync service after the install.
     private val appUpdateManager by lazy { AppUpdateManagerFactory.create(this) }
-    private var showUpdateReadyDialog by mutableStateOf(false)
+    private var updateDownloaded = false
     private val updateFlowLauncher = registerForActivityResult(
         ActivityResultContracts.StartIntentSenderForResult()
     ) { /* User accepted or declined Play's update sheet — nothing to do either way. */ }
     private val installStateListener = InstallStateUpdatedListener { state ->
-        if (state.installStatus() == InstallStatus.DOWNLOADED) showUpdateReadyDialog = true
+        if (state.installStatus() == InstallStatus.DOWNLOADED) updateDownloaded = true
+    }
+    // ProcessLifecycleOwner, not Activity.onStop: the activity also stops when the
+    // QR scanner or onboarding opens, and installing there would kill mid-pairing.
+    private val backgroundInstallObserver = object : DefaultLifecycleObserver {
+        override fun onStop(owner: LifecycleOwner) {
+            if (updateDownloaded) appUpdateManager.completeUpdate()
+        }
     }
 
     private val connectionReceiver = object : BroadcastReceiver() {
@@ -192,13 +204,6 @@ class MainActivity : AppCompatActivity() {
                 VersionMismatchDialog(onDismiss = { viewModel.onVersionMismatchDismissed() })
             }
 
-            if (showUpdateReadyDialog) {
-                UpdateReadyDialog(
-                    onRestart = { appUpdateManager.completeUpdate() },
-                    onLater = { showUpdateReadyDialog = false }
-                )
-            }
-
             if (showBlePermissionDialog) {
                 BlePermissionDialog(
                     permanentlyDenied = blePermissionPermanentlyDenied,
@@ -325,11 +330,13 @@ class MainActivity : AppCompatActivity() {
         if (savedInstanceState == null) handlePairingDeepLink(intent)
 
         appUpdateManager.registerListener(installStateListener)
+        ProcessLifecycleOwner.get().lifecycle.addObserver(backgroundInstallObserver)
         // savedInstanceState guard: don't re-show Play's update sheet on rotation.
         if (savedInstanceState == null) checkForAppUpdate()
     }
 
     override fun onDestroy() {
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(backgroundInstallObserver)
         appUpdateManager.unregisterListener(installStateListener)
         super.onDestroy()
     }
@@ -345,8 +352,8 @@ class MainActivity : AppCompatActivity() {
                     AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE)
                 )
             } else if (info.installStatus() == InstallStatus.DOWNLOADED) {
-                // Update finished downloading in a previous session — offer the restart.
-                showUpdateReadyDialog = true
+                // Update finished downloading in a previous session — install on next background.
+                updateDownloaded = true
             }
         }
         // On failure (no Play Store, offline): stay silent.

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -25,6 +25,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
 import org.cliprelay.R
 import org.cliprelay.feedback.LogShareExporter
 import org.cliprelay.pairing.PairingStore
@@ -45,6 +51,17 @@ class MainActivity : AppCompatActivity() {
     // the connectedDevice foreground service cannot start and pairing would fail.
     private var showBlePermissionDialog by mutableStateOf(false)
     private var blePermissionPermanentlyDenied by mutableStateOf(false)
+
+    // Play In-App Updates (flexible flow): Play shows its own update sheet and
+    // downloads in the background; we only surface the "restart to finish" step.
+    private val appUpdateManager by lazy { AppUpdateManagerFactory.create(this) }
+    private var showUpdateReadyDialog by mutableStateOf(false)
+    private val updateFlowLauncher = registerForActivityResult(
+        ActivityResultContracts.StartIntentSenderForResult()
+    ) { /* User accepted or declined Play's update sheet — nothing to do either way. */ }
+    private val installStateListener = InstallStateUpdatedListener { state ->
+        if (state.installStatus() == InstallStatus.DOWNLOADED) showUpdateReadyDialog = true
+    }
 
     private val connectionReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -175,6 +192,13 @@ class MainActivity : AppCompatActivity() {
                 VersionMismatchDialog(onDismiss = { viewModel.onVersionMismatchDismissed() })
             }
 
+            if (showUpdateReadyDialog) {
+                UpdateReadyDialog(
+                    onRestart = { appUpdateManager.completeUpdate() },
+                    onLater = { showUpdateReadyDialog = false }
+                )
+            }
+
             if (showBlePermissionDialog) {
                 BlePermissionDialog(
                     permanentlyDenied = blePermissionPermanentlyDenied,
@@ -299,6 +323,33 @@ class MainActivity : AppCompatActivity() {
 
         // A cliprelay://pair link may have launched us (e.g. from a system QR scanner).
         if (savedInstanceState == null) handlePairingDeepLink(intent)
+
+        appUpdateManager.registerListener(installStateListener)
+        // savedInstanceState guard: don't re-show Play's update sheet on rotation.
+        if (savedInstanceState == null) checkForAppUpdate()
+    }
+
+    override fun onDestroy() {
+        appUpdateManager.unregisterListener(installStateListener)
+        super.onDestroy()
+    }
+
+    private fun checkForAppUpdate() {
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+            if (info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+            ) {
+                appUpdateManager.startUpdateFlowForResult(
+                    info,
+                    updateFlowLauncher,
+                    AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE)
+                )
+            } else if (info.installStatus() == InstallStatus.DOWNLOADED) {
+                // Update finished downloading in a previous session — offer the restart.
+                showUpdateReadyDialog = true
+            }
+        }
+        // On failure (no Play Store, offline): stay silent.
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -24,15 +24,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
-import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
-import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
 import org.cliprelay.R
 import org.cliprelay.feedback.LogShareExporter
@@ -55,25 +50,14 @@ class MainActivity : AppCompatActivity() {
     private var showBlePermissionDialog by mutableStateOf(false)
     private var blePermissionPermanentlyDenied by mutableStateOf(false)
 
-    // Play In-App Updates (flexible flow): Play shows its own update sheet and
-    // downloads in the background. Once downloaded, the update installs silently
-    // the next time the whole app leaves the foreground (no restart prompt);
-    // BootCompletedReceiver restarts the sync service after the install.
+    // Play In-App Updates (immediate flow): Play runs the whole update fullscreen —
+    // download, install, automatic app restart — so the user never keeps using a
+    // stale version after accepting. BootCompletedReceiver restarts the sync
+    // service after the install.
     private val appUpdateManager by lazy { AppUpdateManagerFactory.create(this) }
-    private var updateDownloaded = false
     private val updateFlowLauncher = registerForActivityResult(
         ActivityResultContracts.StartIntentSenderForResult()
-    ) { /* User accepted or declined Play's update sheet — nothing to do either way. */ }
-    private val installStateListener = InstallStateUpdatedListener { state ->
-        if (state.installStatus() == InstallStatus.DOWNLOADED) updateDownloaded = true
-    }
-    // ProcessLifecycleOwner, not Activity.onStop: the activity also stops when the
-    // QR scanner or onboarding opens, and installing there would kill mid-pairing.
-    private val backgroundInstallObserver = object : DefaultLifecycleObserver {
-        override fun onStop(owner: LifecycleOwner) {
-            if (updateDownloaded) appUpdateManager.completeUpdate()
-        }
-    }
+    ) { /* User accepted or declined Play's update screen — nothing to do either way. */ }
 
     private val connectionReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -329,34 +313,32 @@ class MainActivity : AppCompatActivity() {
         // A cliprelay://pair link may have launched us (e.g. from a system QR scanner).
         if (savedInstanceState == null) handlePairingDeepLink(intent)
 
-        appUpdateManager.registerListener(installStateListener)
-        ProcessLifecycleOwner.get().lifecycle.addObserver(backgroundInstallObserver)
-        // savedInstanceState guard: don't re-show Play's update sheet on rotation.
-        if (savedInstanceState == null) checkForAppUpdate()
+        // savedInstanceState guard: don't re-show Play's update screen on rotation.
+        if (savedInstanceState == null) checkForAppUpdate(resumeOnly = false)
     }
 
-    override fun onDestroy() {
-        ProcessLifecycleOwner.get().lifecycle.removeObserver(backgroundInstallObserver)
-        appUpdateManager.unregisterListener(installStateListener)
-        super.onDestroy()
-    }
-
-    private fun checkForAppUpdate() {
+    /**
+     * Start (or, on resume, re-attach to) Play's immediate update flow. With
+     * [resumeOnly], only re-enter a flow the user already accepted — never start
+     * a new prompt, so backing out of the update isn't met with an instant re-ask.
+     * On failure (no Play Store, offline): stays silent.
+     */
+    private fun checkForAppUpdate(resumeOnly: Boolean) {
         appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
-            if (info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
-                info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
-            ) {
+            val shouldLaunch = when (info.updateAvailability()) {
+                UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS -> true
+                UpdateAvailability.UPDATE_AVAILABLE ->
+                    !resumeOnly && info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+                else -> false
+            }
+            if (shouldLaunch) {
                 appUpdateManager.startUpdateFlowForResult(
                     info,
                     updateFlowLauncher,
-                    AppUpdateOptions.defaultOptions(AppUpdateType.FLEXIBLE)
+                    AppUpdateOptions.defaultOptions(AppUpdateType.IMMEDIATE)
                 )
-            } else if (info.installStatus() == InstallStatus.DOWNLOADED) {
-                // Update finished downloading in a previous session — install on next background.
-                updateDownloaded = true
             }
         }
-        // On failure (no Play Store, offline): stay silent.
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -367,6 +349,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        // If the user backed out mid-install (e.g. switched apps during Play's
+        // update screen), re-attach to the in-progress update.
+        checkForAppUpdate(resumeOnly = true)
         val filter = IntentFilter(ClipRelayService.ACTION_CONNECTION_STATE).also {
             it.addAction(ClipRelayService.ACTION_PAIRING_COMPLETE)
             it.addAction(ClipRelayService.ACTION_PAIRING_STATUS)


### PR DESCRIPTION
## What

Users running stale versions now get updated in-app instead of silently falling behind (and leaving bad reviews):

- On cold app open, query Play for a newer version (`app-update-ktx`). If one exists, launch Play's **immediate update flow**: fullscreen download + install + automatic restart into the new version. One tap ("Update") total; declining defers to the next cold open.
- `onResume` re-attaches to an in-progress update if the user switched apps mid-install (`resumeOnly` guard prevents re-prompting users who declined).
- `BootCompletedReceiver` now also handles `ACTION_MY_PACKAGE_REPLACED` and restarts the sync foreground service after any package update. This also fixes a pre-existing gap: regular Play auto-updates killed the sync service and nothing restarted it until the user next opened the app.

## Why

Bad Play Store reviews traced to users running old versions. Play handles version comparison and the entire update UI — no server or version endpoint needed.

## Notes for review

- Evolved through flexible-flow variants in the first two commits; final state (immediate flow) is the simplest — no install listener, no lifecycle observer. Review the diff as a whole.
- Fail-silent by design: sideloads, missing Play Store, or offline → `appUpdateInfo` listener never fires, zero behavior change.
- `savedInstanceState == null` guard keeps rotation from re-launching the update prompt.
- Verified: full build, 160 Swift + Android unit tests, release/R8 build (Play AIDL classes survive minification), BLE hardware smoke test PASS on a real device, and `MY_PACKAGE_REPLACED` service auto-restart confirmed via `adb install -r` (fires the same broadcast as a real update).
- Not verifiable locally: the Play-served update UI itself — Play only serves updates to Play-installed builds. Test path: internal testing track, then publish a higher versionCode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)