### PR TITLE
Add Homebrew cask install option (#92)

### DIFF
--- a/Casks/cliprelay.rb
+++ b/Casks/cliprelay.rb
@@ -1,0 +1,24 @@
+cask "cliprelay" do
+  version "0.7.3"
+  sha256 "2955e84cd456d2add4923183d79be8328286d494c8ab2887a808eae5aabdb4e4"
+
+  url "https://github.com/geekflyer/cliprelay/releases/download/mac/v#{version}/ClipRelay-#{version}.dmg"
+  name "ClipRelay"
+  desc "Clipboard sharing with Android devices over Bluetooth"
+  homepage "https://cliprelay.org/"
+
+  livecheck do
+    url "https://updates.cliprelay.org/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "ClipRelay.app"
+
+  zap trash: [
+    "~/Library/Application Support/ClipRelay",
+    "~/Library/Preferences/org.cliprelay.mac.plist",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Copy on one device, paste on the other. ClipRelay syncs your clipboard between A
 - **Image sync** *(experimental)* — transfer images (PNG/JPEG, up to 10 MB) between devices over a temporary local WiFi connection, with BLE for signaling. Both devices must be on the same WiFi network.
 - **Auto-copy on Android** *(experimental)* — automatically detects when you copy text on Android and syncs it to your Mac, no manual sharing needed. Uses Android's accessibility service.
 
+## Install
+
+**Mac** — [download the app](https://cliprelay.org/#download), or with [Homebrew](https://brew.sh):
+
+```sh
+brew tap geekflyer/cliprelay https://github.com/geekflyer/cliprelay
+brew install --cask cliprelay
+```
+
+The app auto-updates itself after install (via Sparkle), so `brew upgrade` is not needed.
+
+**Android** — get it on [Google Play](https://play.google.com/store/apps/details?id=org.cliprelay).
+
 ## Screenshots
 
 <p align="center">


### PR DESCRIPTION
## Summary

Addresses #92 — makes the Mac app installable via Homebrew without maintaining a separate tap repo.

- Adds `Casks/cliprelay.rb` at the repo root, which makes this repo itself a valid Homebrew tap:
  ```sh
  brew tap geekflyer/cliprelay https://github.com/geekflyer/cliprelay
  brew install --cask cliprelay
  ```
- Adds an **Install** section to the README (Homebrew, direct download, Google Play).

## Cask details

- Points at the notarized DMG asset of the `mac/v0.7.3` GitHub release; sha256 computed from the published asset.
- `auto_updates true` — Sparkle updates the app in place, so brew won't complain about version drift and users don't need `brew upgrade`.
- `livecheck` follows the Sparkle appcast at `updates.cliprelay.org`, so `brew livecheck` / bump tooling can detect new versions.
- `depends_on macos: ">= :ventura"` matches the SPM platform target (macOS 13).
- `zap` cleans Application Support and the `org.cliprelay.mac` preferences plist on `brew uninstall --zap`.

Submission to the official `homebrew/cask` repo can follow later once the repo clears their notability bar (~75 stars); this tap works today.

## Verification

- `brew style Casks/cliprelay.rb` passes (one bare-file lint artifact about frozen-string-literal comments, which in-tap casks don't carry).
- sha256 verified by downloading the published release asset.
- No app code touched — build/test suites and hardware smoke tests not applicable (docs + packaging only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)