### PR TITLE
Fix Homebrew cask deprecation + document brew trust step

### DIFF
--- a/Casks/cliprelay.rb
+++ b/Casks/cliprelay.rb
@@ -13,7 +13,7 @@ cask "cliprelay" do
   end
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "ClipRelay.app"
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ Copy on one device, paste on the other. ClipRelay syncs your clipboard between A
 
 ```sh
 brew tap geekflyer/cliprelay https://github.com/geekflyer/cliprelay
+brew trust geekflyer/cliprelay
 brew install --cask cliprelay
 ```
+
+(`brew trust` is required on newer Homebrew versions, which refuse to load casks from third-party taps until trusted.)
 
 The app auto-updates itself after install (via Sparkle), so `brew upgrade` is not needed.
 


### PR DESCRIPTION
Follow-up to #106 — first real install surfaced two issues:

1. **Deprecation warning**: `depends_on macos: ">= :ventura"` uses the now-deprecated string comparison format. The bare symbol form `depends_on macos: :ventura` is the replacement (defaults to `>=`). Verified against the local tap clone: cask loads with no warning and reports `Required: macOS >= 13`.

2. **Untrusted tap refusal**: newer Homebrew refuses to load casks from third-party taps until the user runs `brew trust`. Added the one-time `brew trust geekflyer/cliprelay` step to the README install instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)