### PR TITLE
Mac: visible entry UI on manual launch/reopen (notch-hidden menu bar icon)

### DIFF
--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -138,10 +138,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         // Escape hatch when the menu bar icon is hidden (e.g. under the notch):
-        // reopening the app from Finder/Launchpad opens pairing directly.
+        // reopening the app from Finder/Launchpad opens pairing directly when
+        // unpaired, otherwise shows the status menu at the mouse location.
         NSApp.activate(ignoringOtherApps: true)
-        if pairingManager.loadDevices().isEmpty && !awaitingNewPairingConnection {
-            startPairing()
+        if pairingManager.loadDevices().isEmpty {
+            if !awaitingNewPairingConnection {
+                startPairing()
+            }
+        } else {
+            statusBarController.popUpMenuAtMouse()
         }
         return true
     }

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -136,6 +136,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         telemetryManager?.start()
     }
 
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // Escape hatch when the menu bar icon is hidden (e.g. under the notch):
+        // reopening the app from Finder/Launchpad opens pairing directly.
+        NSApp.activate(ignoringOtherApps: true)
+        if pairingManager.loadDevices().isEmpty && !awaitingNewPairingConnection {
+            startPairing()
+        }
+        return true
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         bluetoothOffDebounceTimer?.invalidate()
         NSWorkspace.shared.notificationCenter.removeObserver(self)

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -1,6 +1,7 @@
 // Core app delegate: wires together BLE, clipboard, pairing, and UI subsystems.
 
 import AppKit
+import Carbon
 import CoreBluetooth
 import CryptoKit
 import os
@@ -134,12 +135,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return .noPeering
         }
         telemetryManager?.start()
+
+        // A manual launch (Finder/Spotlight/Dock) should always show visible UI,
+        // because the menu bar icon can be hidden (e.g. under the notch). Login
+        // autostart stays silent.
+        if !launchedAsLoginItem {
+            // Defer one runloop turn so the status item exists before the menu pops.
+            DispatchQueue.main.async { [weak self] in
+                self?.showEntryUI()
+            }
+        }
     }
 
-    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        // Escape hatch when the menu bar icon is hidden (e.g. under the notch):
-        // reopening the app from Finder/Launchpad opens pairing directly when
-        // unpaired, otherwise shows the status menu at the mouse location.
+    /// True when this launch came from the login item (autostart), detected via
+    /// the kAELaunchedAsLogInItem property on the opening AppleEvent. Must be
+    /// read during applicationDidFinishLaunching while the event is current.
+    private var launchedAsLoginItem: Bool {
+        guard let event = NSAppleEventManager.shared().currentAppleEvent else { return false }
+        return event.eventID == AEEventID(kAEOpenApplication)
+            && event.paramDescriptor(forKeyword: AEKeyword(keyAEPropData))?.enumCodeValue
+                == OSType(keyAELaunchedAsLogInItem)
+    }
+
+    /// Entry UI for launches/reopens where the user acted deliberately:
+    /// unpaired opens pairing, paired shows the status menu at the cursor.
+    private func showEntryUI() {
         NSApp.activate(ignoringOtherApps: true)
         if pairingManager.loadDevices().isEmpty {
             if !awaitingNewPairingConnection {
@@ -148,6 +168,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             statusBarController.popUpMenuAtMouse()
         }
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // Escape hatch when the menu bar icon is hidden (e.g. under the notch):
+        // reopening the app from Finder/Launchpad shows the entry UI.
+        showEntryUI()
         return true
     }
 

--- a/macos/ClipRelayMac/Sources/App/AppDelegate.swift
+++ b/macos/ClipRelayMac/Sources/App/AppDelegate.swift
@@ -33,6 +33,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var telemetryManager: TelemetryManager?
     private var clipboardMonitor: ClipboardMonitor?
     private var awaitingNewPairingConnection = false
+    private var launchedAsLoginItem = false
     private var bluetoothOffDebounceTimer: Timer?
     private var lastWakeTime: Date?
     // A manual Bluetooth toggle surfaces the indicator immediately. The only debounce is for
@@ -43,6 +44,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let wakeSettleWindow: TimeInterval = 20.0
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        launchedAsLoginItem = Self.isLaunchedAsLoginItem()
         // Start the Sparkle updater now that the app is fully launched.
         // Creating the controller with startingUpdater:false in init() and
         // deferring start to here avoids a race where the updater's scheduled
@@ -148,9 +150,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// True when this launch came from the login item (autostart), detected via
-    /// the kAELaunchedAsLogInItem property on the opening AppleEvent. Must be
-    /// read during applicationDidFinishLaunching while the event is current.
-    private var launchedAsLoginItem: Bool {
+    /// the kAELaunchedAsLogInItem property on the opening AppleEvent. The event
+    /// is only current during applicationDidFinishLaunching, so the result is
+    /// captured there into `launchedAsLoginItem`.
+    private static func isLaunchedAsLoginItem() -> Bool {
         guard let event = NSAppleEventManager.shared().currentAppleEvent else { return false }
         return event.eventID == AEEventID(kAEOpenApplication)
             && event.paramDescriptor(forKeyword: AEKeyword(keyAEPropData))?.enumCodeValue

--- a/macos/ClipRelayMac/Sources/App/StatusBarController.swift
+++ b/macos/ClipRelayMac/Sources/App/StatusBarController.swift
@@ -194,6 +194,13 @@ final class StatusBarController {
         renderMenu()
     }
 
+    /// Shows the status menu at the mouse location — escape hatch for when the
+    /// menu bar icon is inaccessible (e.g. hidden under the notch).
+    func popUpMenuAtMouse() {
+        renderMenu()
+        menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
+    }
+
     private func renderMenu() {
         menu.removeAllItems()
 


### PR DESCRIPTION
## Problem

A user on macOS 15.7.7 reported he cannot pair because the ClipRelay menu bar icon is invisible — hidden under the MacBook notch. The menu bar icon was the app's *only* entry point, so with it hidden the app is unusable (can't pair, can't reach any menu action). macOS provides no API to force a status item visible.

## What changed

Deliberate user actions now always produce visible UI, independent of icon visibility:

| Trigger | Unpaired | Paired |
|---|---|---|
| Manual launch (Finder/Spotlight/Dock) | Pairing window opens | Status menu pops at cursor |
| Reopen while running | Pairing window opens | Status menu pops at cursor |
| Login-item autostart | Silent (unchanged) | Silent (unchanged) |

- `applicationShouldHandleReopen` added as escape hatch: opening the app again while it runs shows the entry UI.
- Manual first launch shows the entry UI directly (new users no longer need to find the icon at all).
- Login autostart detected via `kAELaunchedAsLogInItem` on the opening AppleEvent and stays silent — no popups at login.
- Paired state reuses the existing status menu via `NSMenu.popUp` at the mouse location: full access to pair-additional-device, forget, toggles, updates with no new window code.

## Notes for review

- All UI paths funnel through one method (`AppDelegate.showEntryUI()`); if we ever want a proper status window, only that method changes.
- `startPairing()` at launch is safe before Bluetooth is powered on: key generation is synchronous, scanning is deferred on the BLE queue and resumes on `.poweredOn`.
- Verified manually: unpaired launch/reopen shows the pairing window; paired launch/reopen pops the menu at the cursor. The login-item silent path is untestable from a terminal (needs a real logout/login) — reviewer with a spare session may want to sanity-check it.
- `swift test`: 160 pass. Mac-only change; Android untouched.

Fixes the "can't see menu bar / can't pair" report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)