### PR TITLE
Android: include feature flags in GitHub issue and email reports

### DIFF
--- a/android/app/src/main/java/org/cliprelay/feedback/LogShareExporter.kt
+++ b/android/app/src/main/java/org/cliprelay/feedback/LogShareExporter.kt
@@ -3,8 +3,6 @@ package org.cliprelay.feedback
 import android.content.Context
 import android.content.Intent
 import android.os.Process
-import org.cliprelay.pairing.PairingStore
-import org.cliprelay.settings.ClipboardSettingsStore
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 
@@ -20,7 +18,7 @@ object LogShareExporter {
 
     fun createShareIntent(context: Context, bleState: String): Intent {
         val text = buildShareText(
-            diagnosticsContext = collectContext(context, bleState),
+            diagnosticsContext = SupportLinks.diagnosticsContext(context, bleState),
             generatedAt = Instant.now(),
             logOutput = captureLogcat(),
         )
@@ -29,22 +27,6 @@ object LogShareExporter {
             putExtra(Intent.EXTRA_SUBJECT, "ClipRelay Android logs")
             putExtra(Intent.EXTRA_TEXT, text)
         }
-    }
-
-    /** App / device / flag context prepended to every shared log. */
-    private fun collectContext(context: Context, bleState: String): List<Pair<String, String>> {
-        val settings = ClipboardSettingsStore(context)
-        val pairing = PairingStore(context)
-        val flags = listOf(
-            "autoCopy" to settings.isAutoCopyEnabled(),
-            "hideSyncedClipboard" to settings.isHideSyncedClipboardEnabled(),
-            "autoClearSyncedClipboard" to settings.isAutoClearSyncedClipboardEnabled(),
-            "imageSync" to pairing.isRichMediaEnabled(),
-        ).joinToString(", ") { "${it.first}=${it.second}" }
-        return SupportLinks.diagnosticsContext(bleState) + listOf(
-            "Paired Macs" to pairing.loadPairedMacs().size.toString(),
-            "Flags" to flags,
-        )
     }
 
     internal fun buildShareText(

--- a/android/app/src/main/java/org/cliprelay/feedback/SupportLinks.kt
+++ b/android/app/src/main/java/org/cliprelay/feedback/SupportLinks.kt
@@ -2,9 +2,12 @@ package org.cliprelay.feedback
 
 // Builds pre-filled support URLs with device context.
 
+import android.content.Context
 import android.net.Uri
 import android.os.Build
 import org.cliprelay.BuildConfig
+import org.cliprelay.pairing.PairingStore
+import org.cliprelay.settings.ClipboardSettingsStore
 
 object SupportLinks {
     private fun deviceContext(): List<Pair<String, String>> = listOf(
@@ -14,11 +17,26 @@ object SupportLinks {
         "Device" to "${Build.MANUFACTURER} ${Build.MODEL}",
     )
 
-    fun diagnosticsContext(bleState: String): List<Pair<String, String>> =
-        deviceContext() + ("BLE State" to bleState)
+    /** App / device / flag context shared by GitHub issues, support emails, and log shares. */
+    fun diagnosticsContext(context: Context, bleState: String): List<Pair<String, String>> {
+        val settings = ClipboardSettingsStore(context)
+        val pairing = PairingStore(context)
+        val flags = listOf(
+            "autoCopy" to settings.isAutoCopyEnabled(),
+            "otpRelay" to settings.isOtpRelayEnabled(),
+            "hideSyncedClipboard" to settings.isHideSyncedClipboardEnabled(),
+            "autoClearSyncedClipboard" to settings.isAutoClearSyncedClipboardEnabled(),
+            "imageSync" to pairing.isRichMediaEnabled(),
+        ).joinToString(", ") { "${it.first}=${it.second}" }
+        return deviceContext() + listOf(
+            "BLE State" to bleState,
+            "Paired Macs" to pairing.loadPairedMacs().size.toString(),
+            "Flags" to flags,
+        )
+    }
 
-    fun gitHubIssueUrl(bleState: String): String {
-        val lines = diagnosticsContext(bleState)
+    fun gitHubIssueUrl(context: Context, bleState: String): String {
+        val lines = diagnosticsContext(context, bleState)
             .joinToString("\n") { "- **${it.first}:** ${it.second}" }
         val body = "\n\n---\n$lines"
         return Uri.parse("https://github.com/geekflyer/cliprelay/issues/new").buildUpon()
@@ -28,8 +46,8 @@ object SupportLinks {
             .toString()
     }
 
-    fun emailUrl(bleState: String): String {
-        val lines = diagnosticsContext(bleState)
+    fun emailUrl(context: Context, bleState: String): String {
+        val lines = diagnosticsContext(context, bleState)
             .joinToString("\n") { "${it.first}: ${it.second}" }
         val body = "\n\n---\n$lines"
         return "mailto:info@cliprelay.org" +

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -1367,15 +1367,16 @@ private fun SupportDialog(
     onLinkClick: (String) -> Unit,
     onShareLogsClick: () -> Unit
 ) {
+    val context = androidx.compose.ui.platform.LocalContext.current
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Feedback & Support") },
         text = {
             Column {
-                TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.gitHubIssueUrl(bleState)) }) {
+                TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.gitHubIssueUrl(context, bleState)) }) {
                     Text("Report Issue on GitHub", modifier = Modifier.fillMaxWidth())
                 }
-                TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.emailUrl(bleState)) }) {
+                TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.emailUrl(context, bleState)) }) {
                     Text("Email Support", modifier = Modifier.fillMaxWidth())
                 }
                 TextButton(onClick = { onLinkClick(org.cliprelay.feedback.SupportLinks.DISCUSSIONS_URL) }) {


### PR DESCRIPTION
## What

Pre-filled GitHub issue and support email bodies from the in-app "Feedback & Support" dialog now include the feature-flag line (`autoCopy`, `otpRelay`, `hideSyncedClipboard`, `autoClearSyncedClipboard`, `imageSync`) and paired-Mac count that were previously only attached to shared logs.

- Moved flag collection from `LogShareExporter` into `SupportLinks.diagnosticsContext(context, bleState)` so all three reporting paths (GitHub issue, email, log share) share one implementation.
- Added the previously missing `otpRelay` flag (it wasn't included in shared logs either).
- `SupportDialog` now passes `LocalContext` through to build the URLs.

## Why

Issue #109 arrived with app version, OS, device, and BLE state — but no settings context. "Closing keyboard and live notifications" can't be narrowed down without knowing whether auto-copy (accessibility service) or OTP relay (notification listener) is enabled. Future from-app reports will carry that context automatically.

## Notes for reviewers

- No behavior change to log sharing beyond the added `otpRelay` flag.
- Verified: full build (`scripts/build-all.sh --debug`), full test suite (`scripts/test-all.sh` — 160 Swift tests + all Android unit tests pass). Hardware smoke tests skipped, no device connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)