### PR TITLE
Android: stop auto-copy from collapsing live notifications — overlay clipboard reader replaces ghost activity (#109)

### DIFF
--- a/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipRelayService.kt
@@ -986,20 +986,34 @@ class ClipRelayService : Service(), L2capServerCallback {
             return
         }
 
-        // Always launch ghost activity — even when the app is "foreground" per
-        // ProcessLifecycleOwner, a Service cannot read the clipboard on Android 10+.
-        // Only an Activity with window focus can call getPrimaryClip() successfully.
-        Log.d(TAG, "Launching ghost activity for clipboard read")
+        // A Service cannot read the clipboard on Android 10+ — only the app
+        // holding window focus can. Prefer the accessibility overlay reader:
+        // unlike a (ghost) activity launch it closes no system dialogs, so the
+        // notification shade, heads-up notifications, Live Update chips, and
+        // the keyboard all stay open (issue #109). Fall back to the ghost
+        // activity only when the overlay is unavailable or never gains focus.
         ghostActivityInFlight = true
-        // Watchdog: if the ghost never launches or dies before reporting back,
-        // clear the flag so auto-copy doesn't stay wedged until a restart.
+        // Watchdog: if the reader/ghost dies before reporting back, clear the
+        // flag so auto-copy doesn't stay wedged until a restart.
         ghostWatchdog?.let(clipboardAutoClearHandler::removeCallbacks)
         ghostWatchdog = Runnable {
             if (ghostActivityInFlight) {
-                Log.w(TAG, "Ghost activity watchdog fired — clearing in-flight flag")
+                Log.w(TAG, "Clipboard read watchdog fired — clearing in-flight flag")
                 clearGhostActivityInFlight()
             }
         }.also { clipboardAutoClearHandler.postDelayed(it, GHOST_WATCHDOG_MS) }
+
+        val overlayStarted = ClipboardAccessibilityService.instance
+            ?.readClipboardViaOverlay(onNeedsGhostFallback = ::launchGhostActivity) == true
+        if (overlayStarted) {
+            Log.d(TAG, "Reading clipboard via accessibility overlay")
+        } else {
+            launchGhostActivity()
+        }
+    }
+
+    private fun launchGhostActivity() {
+        Log.d(TAG, "Launching ghost activity for clipboard read")
         val ghostIntent = Intent(this, ClipboardGhostActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or
                     Intent.FLAG_ACTIVITY_NO_ANIMATION or

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardAccessibilityService.kt
@@ -12,10 +12,16 @@ package org.cliprelay.service
 //      that don't fire TYPE_VIEW_CLICKED for their toolbar buttons.
 //      When a text action toolbar containing "Copy" appears, we set a flag.
 //      When the toolbar closes (next window state change without copy text),
-//      we launch the ghost activity to check if the clipboard was updated.
-//      This avoids stealing focus while the toolbar is still visible.
-//      The ghost activity's clip-freshness check filters out toolbars that
-//      closed without an actual copy.
+//      we trigger a clipboard read to check if the clipboard was updated.
+//      The reader's clip-freshness check filters out toolbars that closed
+//      without an actual copy.
+//
+// Detections are resolved by ClipRelayService via ClipboardOverlayReader
+// (a focusable accessibility overlay — no focus steal, closes no system
+// dialogs), falling back to ClipboardGhostActivity when unavailable. The
+// false-positive gates below still matter: every resolved detection costs a
+// clipboard read, and reading a fresh clip shows the system's "ClipRelay
+// pasted from your clipboard" banner.
 
 import android.accessibilityservice.AccessibilityService
 import android.content.ClipboardManager
@@ -31,6 +37,7 @@ import org.cliprelay.settings.ClipboardSettingsStore
 class ClipboardAccessibilityService : AccessibilityService() {
 
     private lateinit var settingsStore: ClipboardSettingsStore
+    private var overlayReader: ClipboardOverlayReader? = null
 
     // Tracks whether a copy toolbar was recently visible
     @Volatile
@@ -39,6 +46,20 @@ class ClipboardAccessibilityService : AccessibilityService() {
     override fun onServiceConnected() {
         super.onServiceConnected()
         settingsStore = ClipboardSettingsStore(this)
+        overlayReader = ClipboardOverlayReader(this)
+        instance = this
+    }
+
+    /**
+     * Reads the clipboard via a focusable accessibility overlay window —
+     * unlike an activity launch, this closes no system dialogs (notification
+     * shade, heads-up, Live Update chips) and keeps the keyboard open.
+     * Returns false when the overlay could not even be added; the caller
+     * falls back to the ghost activity. [onNeedsGhostFallback] fires later
+     * if the overlay was added but never granted window focus.
+     */
+    fun readClipboardViaOverlay(onNeedsGhostFallback: () -> Unit): Boolean {
+        return overlayReader?.start(onNeedsGhostFallback) ?: false
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
@@ -229,9 +250,8 @@ class ClipboardAccessibilityService : AccessibilityService() {
         logEventIfDebug("window", event)
 
         // Keyboard show/hide fires window events too. They must neither arm
-        // nor disarm toolbar tracking: a disarm here launches the ghost
-        // activity, which steals focus and closes the keyboard the user just
-        // opened (issue #109).
+        // nor disarm toolbar tracking: a disarm here triggers a pointless
+        // clipboard read on every keyboard toggle (issue #109).
         if (isImeWindow(event.windowId)) return
 
         val text = event.text.joinToString(" ")
@@ -251,11 +271,11 @@ class ClipboardAccessibilityService : AccessibilityService() {
             // → toolbar closed (user tapped an option or dismissed it)
             copyToolbarVisible = false
 
-            // Cheap pre-check before paying the ghost-activity cost (focus
-            // steal → keyboard dismissal): where background metadata reads
-            // work (e.g. Samsung), a provably stale clip means no copy
-            // happened. Unreadable/null timestamps (Pixel) fall through to
-            // the ghost, whose own freshness check handles them.
+            // Cheap pre-check before paying the clipboard-read cost: where
+            // background metadata reads work (e.g. Samsung), a provably stale
+            // clip means no copy happened. Unreadable/null timestamps (Pixel)
+            // fall through to the reader, whose own freshness check handles
+            // them.
             val timestampMs = try {
                 (getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager)
                     ?.primaryClipDescription?.timestamp
@@ -376,6 +396,13 @@ class ClipboardAccessibilityService : AccessibilityService() {
         private const val TAG = "ClipboardA11y"
         private const val MAX_WINDOW_SCAN_NODES = 256
         private const val MAX_OVERLAY_SCAN_NODES = 32
+
+        // Same-process handle for ClipRelayService so copy detections can be
+        // resolved with an overlay read instead of the ghost activity. Null
+        // whenever the accessibility service isn't connected.
+        @Volatile
+        var instance: ClipboardAccessibilityService? = null
+            private set
     }
 
     private fun notifyService() {
@@ -391,5 +418,18 @@ class ClipboardAccessibilityService : AccessibilityService() {
 
     override fun onInterrupt() {
         Log.d(TAG, "Accessibility service interrupted")
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        if (instance === this) instance = null
+        overlayReader?.cancel()
+        return super.onUnbind(intent)
+    }
+
+    override fun onDestroy() {
+        if (instance === this) instance = null
+        overlayReader?.cancel()
+        overlayReader = null
+        super.onDestroy()
     }
 }

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardGhostActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardGhostActivity.kt
@@ -1,10 +1,10 @@
 package org.cliprelay.service
 
 // Invisible activity that briefly gains foreground focus to read the clipboard on Android 10+.
-// Launched by ClipRelayService when the clipboard listener fires and the app is backgrounded.
+// FALLBACK ONLY: activity starts collapse the notification shade, heads-up notifications, and
+// Live Update chips (issue #109), so ClipRelayService prefers the accessibility overlay reader
+// (ClipboardOverlayReader) and only launches this when the overlay is unavailable.
 
-import android.content.ClipboardManager
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
@@ -68,56 +68,7 @@ class ClipboardGhostActivity : ComponentActivity() {
      * text (empty clipboard or a clip that predates the detected copy).
      */
     private fun readClipboardAndForward(): Boolean {
-        val clipboardManager = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
-        if (clipboardManager == null) {
-            Log.w(TAG, "ClipboardManager unavailable")
-            return true
-        }
-
-        // Check freshness via metadata BEFORE reading the clip data: a stale
-        // clip means the detection was a false positive (dismissed toolbar,
-        // stray System UI window) or the app hasn't written the new clip yet —
-        // never forward it; a retry may pick up a late write. Metadata reads
-        // don't trigger the system's "app pasted from your clipboard" banner,
-        // so discarded false positives stay invisible to the user.
-        val description = try {
-            clipboardManager.primaryClipDescription
-        } catch (e: SecurityException) {
-            Log.w(TAG, "Clipboard metadata access denied: ${e.message}")
-            null
-        }
-        if (description != null &&
-            !AutoCopyHeuristics.isClipFresh(description.timestamp, System.currentTimeMillis())
-        ) {
-            Log.d(TAG, "Clipboard content is stale — not forwarding")
-            return false
-        }
-
-        val clip = try {
-            clipboardManager.primaryClip
-        } catch (e: SecurityException) {
-            Log.w(TAG, "Clipboard access denied: ${e.message}")
-            return false
-        }
-        if (clip == null || clip.itemCount == 0) {
-            Log.d(TAG, "Clipboard empty")
-            return false
-        }
-
-        val text = clip.getItemAt(0).coerceToText(this)?.toString()
-        if (text.isNullOrBlank()) {
-            Log.d(TAG, "Clipboard text empty")
-            return false
-        }
-
-        // Forward to service via the same path as the share sheet
-        val pushIntent = Intent(this, ClipRelayService::class.java).apply {
-            action = ClipRelayService.ACTION_PUSH_TEXT
-            putExtra(ClipRelayService.EXTRA_TEXT, text)
-        }
-        startService(pushIntent)
-        Log.d(TAG, "Forwarded clipboard text to service (${text.length} chars)")
-        return true
+        return ClipboardReadFlow.readAndForward(this, TAG)
     }
 
     private fun finishGhost() {

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardOverlayReader.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardOverlayReader.kt
@@ -1,0 +1,162 @@
+package org.cliprelay.service
+
+// Reads the clipboard from the background WITHOUT launching an activity.
+//
+// Android 10+ only lets the app holding input focus read the clipboard. The
+// original workaround (ClipboardGhostActivity) gained focus by starting an
+// invisible activity — but every activity start makes the system close
+// "system dialogs": the notification shade, heads-up notifications, and
+// Android 16 Live Update chips all collapse (issue #109). No heuristic can
+// fix that; even a correctly detected copy collapsed whatever the user had
+// open.
+//
+// An accessibility service may instead add a focusable
+// TYPE_ACCESSIBILITY_OVERLAY window: it receives input focus (which satisfies
+// the clipboard-read check) while closing nothing, and FLAG_ALT_FOCUSABLE_IM
+// keeps the IME target on the app beneath so the keyboard stays open. The
+// overlay is 1x1 px, transparent, and untouchable — invisible to the user.
+//
+// If the overlay never gains window focus (OEM quirk), we tear it down and
+// fall back to the ghost activity so auto-copy keeps working at the old cost.
+
+import android.accessibilityservice.AccessibilityService
+import android.content.Context
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.WindowManager
+
+internal class ClipboardOverlayReader(private val service: AccessibilityService) {
+
+    companion object {
+        private const val TAG = "ClipboardOverlay"
+
+        /** Overlay focus normally lands within a frame or two; past this, the
+         *  device isn't granting it — fall back to the ghost activity. */
+        private const val FOCUS_TIMEOUT_MS = 500L
+
+        // Same retry cadence as the ghost activity: some apps write the
+        // clipboard 200-300ms after the copy signal fires.
+        private const val RETRY_DELAY_MS = 500L
+        private const val MAX_READ_ATTEMPTS = 2
+        private const val SAFETY_TIMEOUT_MS = 2500L
+    }
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var overlayView: View? = null
+    private var focusListener: ViewTreeObserver.OnWindowFocusChangeListener? = null
+    private var readAttempts = 0
+    private var gotFocus = false
+
+    val inFlight: Boolean
+        get() = overlayView != null
+
+    /**
+     * Adds the overlay and reads the clipboard once it gains focus.
+     * Returns false if the overlay could not be added at all (caller should
+     * fall back to the ghost activity immediately). [onNeedsGhostFallback]
+     * fires later if the overlay was added but never granted focus.
+     */
+    fun start(onNeedsGhostFallback: () -> Unit): Boolean {
+        if (inFlight) {
+            Log.d(TAG, "Overlay read already in flight")
+            return true
+        }
+        val windowManager =
+            service.getSystemService(Context.WINDOW_SERVICE) as? WindowManager ?: return false
+
+        val view = View(service)
+        val params = WindowManager.LayoutParams(
+            1,
+            1,
+            WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+            WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+                WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM,
+            PixelFormat.TRANSLUCENT
+        ).apply {
+            gravity = Gravity.TOP or Gravity.START
+        }
+
+        val listener = ViewTreeObserver.OnWindowFocusChangeListener { hasFocus ->
+            Log.d(TAG, "Overlay focus changed: hasFocus=$hasFocus")
+            if (hasFocus && !gotFocus) {
+                gotFocus = true
+                // One extra frame after gaining focus so the clipboard
+                // service sees us as the focused uid.
+                view.post { attemptRead() }
+            }
+        }
+        view.viewTreeObserver.addOnWindowFocusChangeListener(listener)
+
+        try {
+            windowManager.addView(view, params)
+        } catch (t: Throwable) {
+            Log.w(TAG, "Could not add clipboard overlay", t)
+            view.viewTreeObserver.removeOnWindowFocusChangeListener(listener)
+            return false
+        }
+
+        overlayView = view
+        focusListener = listener
+        readAttempts = 0
+        gotFocus = false
+
+        handler.postDelayed({
+            if (inFlight && !gotFocus) {
+                Log.w(TAG, "Overlay never gained focus — falling back to ghost activity")
+                tearDown(notifyFinished = false)
+                onNeedsGhostFallback()
+            }
+        }, FOCUS_TIMEOUT_MS)
+        handler.postDelayed({
+            if (inFlight) {
+                Log.w(TAG, "Safety timeout — removing clipboard overlay")
+                tearDown(notifyFinished = true)
+            }
+        }, SAFETY_TIMEOUT_MS)
+        return true
+    }
+
+    private fun attemptRead() {
+        if (!inFlight) return
+        readAttempts += 1
+        Log.d(TAG, "Reading clipboard via overlay (attempt $readAttempts)")
+        if (ClipboardReadFlow.readAndForward(service, TAG) || readAttempts >= MAX_READ_ATTEMPTS) {
+            tearDown(notifyFinished = true)
+        } else {
+            handler.postDelayed({ attemptRead() }, RETRY_DELAY_MS)
+        }
+    }
+
+    private fun tearDown(notifyFinished: Boolean) {
+        val view = overlayView ?: return
+        overlayView = null
+        handler.removeCallbacksAndMessages(null)
+        focusListener?.let { view.viewTreeObserver.removeOnWindowFocusChangeListener(it) }
+        focusListener = null
+        runCatching {
+            (service.getSystemService(Context.WINDOW_SERVICE) as? WindowManager)?.removeView(view)
+        }.onFailure { Log.w(TAG, "Could not remove clipboard overlay", it) }
+
+        if (notifyFinished) {
+            // Same contract as the ghost activity: always clear the service's
+            // in-flight flag, even when nothing was forwarded.
+            val clearIntent = Intent(service, ClipRelayService::class.java).apply {
+                action = ClipRelayService.ACTION_GHOST_FINISHED
+            }
+            runCatching { service.startService(clearIntent) }
+                .onFailure { Log.w(TAG, "Could not notify ClipRelayService", it) }
+        }
+    }
+
+    /** Called when the accessibility service is going away. */
+    fun cancel() {
+        tearDown(notifyFinished = true)
+    }
+}

--- a/android/app/src/main/java/org/cliprelay/service/ClipboardReadFlow.kt
+++ b/android/app/src/main/java/org/cliprelay/service/ClipboardReadFlow.kt
@@ -1,0 +1,74 @@
+package org.cliprelay.service
+
+// Shared clipboard read-and-forward logic for the two focus holders that can
+// read the clipboard on Android 10+: the accessibility overlay window
+// (ClipboardOverlayReader, primary) and the invisible activity
+// (ClipboardGhostActivity, fallback).
+
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+internal object ClipboardReadFlow {
+
+    /**
+     * Reads the clipboard and forwards fresh text to ClipRelayService.
+     * Returns true when done; false when a retry might still find the copied
+     * text (empty clipboard or a clip that predates the detected copy — some
+     * apps write the clipboard a beat after the copy signal fires).
+     */
+    fun readAndForward(context: Context, tag: String): Boolean {
+        val clipboardManager =
+            context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        if (clipboardManager == null) {
+            Log.w(tag, "ClipboardManager unavailable")
+            return true
+        }
+
+        // Check freshness via metadata BEFORE reading the clip data: a stale
+        // clip means the detection was a false positive (dismissed toolbar,
+        // stray System UI window) or the app hasn't written the new clip yet —
+        // never forward it; a retry may pick up a late write. Metadata reads
+        // don't trigger the system's "app pasted from your clipboard" banner,
+        // so discarded false positives stay invisible to the user.
+        val description = try {
+            clipboardManager.primaryClipDescription
+        } catch (e: SecurityException) {
+            Log.w(tag, "Clipboard metadata access denied: ${e.message}")
+            null
+        }
+        if (description != null &&
+            !AutoCopyHeuristics.isClipFresh(description.timestamp, System.currentTimeMillis())
+        ) {
+            Log.d(tag, "Clipboard content is stale — not forwarding")
+            return false
+        }
+
+        val clip = try {
+            clipboardManager.primaryClip
+        } catch (e: SecurityException) {
+            Log.w(tag, "Clipboard access denied: ${e.message}")
+            return false
+        }
+        if (clip == null || clip.itemCount == 0) {
+            Log.d(tag, "Clipboard empty")
+            return false
+        }
+
+        val text = clip.getItemAt(0).coerceToText(context)?.toString()
+        if (text.isNullOrBlank()) {
+            Log.d(tag, "Clipboard text empty")
+            return false
+        }
+
+        // Forward to service via the same path as the share sheet
+        val pushIntent = Intent(context, ClipRelayService::class.java).apply {
+            action = ClipRelayService.ACTION_PUSH_TEXT
+            putExtra(ClipRelayService.EXTRA_TEXT, text)
+        }
+        context.startService(pushIntent)
+        Log.d(tag, "Forwarded clipboard text to service (${text.length} chars)")
+        return true
+    }
+}


### PR DESCRIPTION
Fixes the remaining #109 complaint: expanded Live Update notifications (Android 16 status-bar chips, e.g. YouTube live/media) auto-collapse while auto-copy is enabled ([user's video](https://github.com/user-attachments/assets/189a94cc-16ff-4b95-ae47-5b1de953febf)).

## Root cause

Auto-copy resolved every copy detection by launching the invisible `ClipboardGhostActivity` to gain the window focus Android 10+ requires for clipboard reads. **Every activity start makes the system close "system dialogs"** — notification shade, heads-up notifications, and Live Update chips all collapse. Two consequences:

1. The expanded Live Update chip view is a System UI window that looks identical to the Android 13+ clipboard preview overlay in accessibility events (FrameLayout, single text item, no pane flags, no view IDs on Pixel) — so opening it *triggered* the ghost, which immediately collapsed it.
2. Even a *correctly* detected copy collapsed whatever notification UI the user had open. No detection heuristic can fix that.

## Fix: kill the mechanism, not the trigger

The accessibility service now reads the clipboard by adding a **1×1 transparent focusable `TYPE_ACCESSIBILITY_OVERLAY` window** (`ClipboardOverlayReader`):

- It receives input focus → satisfies the Android 10+ clipboard-read check.
- Adding a window closes **no** system dialogs → shade, heads-up, and Live Update chips stay open.
- `FLAG_ALT_FOCUSABLE_IM` keeps the IME target on the app beneath → keyboard stays open.
- Untouchable + invisible → zero user-visible disruption; false-positive detections are now fully silent (freshness gate discards them via metadata before any clip read).

`ClipboardGhostActivity` remains only as a fallback when the overlay cannot be added or never gains focus within 500 ms (OEM quirk) — worst case equals old behavior. Shared read/forward/freshness logic extracted to `ClipboardReadFlow`.

## Verification

- `scripts/build-all.sh --debug`: both apps build.
- `scripts/test-all.sh`: 160 Swift tests pass; Android unit tests pass.
- Hardware smoke test **skipped — no Android device connected** to this session. On-device verification checklist:
  1. Expand a Live Update chip (YouTube live stream / media) with auto-copy on + Mac connected → must stay open.
  2. Copy text from Chrome selection toolbar → still forwards to Mac.
  3. Copy inside a text field with keyboard open → keyboard stays open.
  4. `adb logcat -s ClipboardOverlay` should show "Reading clipboard via overlay" and never "falling back to ghost activity" on Pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
