### PR TITLE
ci: attach release-signed APK to Android GitHub releases

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -82,7 +82,7 @@ jobs:
           echo "serviceAccountCredentials=play-service-account.json" > android/play.properties
 
       - name: Build release
-        run: ./scripts/build-all.sh --android-only
+        run: ./scripts/build-all.sh --android-only --release
 
       - name: Publish to internal track
         run: ./scripts/publish-android.sh --track internal
@@ -116,6 +116,7 @@ jobs:
           body: ${{ steps.changelog.outputs.body }}
           prerelease: ${{ inputs.beta }}
           files: dist/cliprelay-release.apk
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What

- Build Android release artifacts (`--release` flag) in the release workflow instead of debug-only
- Add `fail_on_unmatched_files: true` to the release-asset step

## Why

The workflow already declared `files: dist/cliprelay-release.apk`, but the build step ran `build-all.sh --android-only` without `--release`, so only the debug APK was ever built. The attach step silently matched no files — every Android GitHub release to date (checked v0.7.5) shipped with zero assets.

## Reviewer notes

- Verified locally: `build-all.sh --android-only --release` produces `dist/cliprelay-release.apk` signed with the release cert (CN=ClipRelay).
- `fail_on_unmatched_files` makes this class of silent regression fail the workflow instead.
- APK is signed with the upload key; users who installed via Play (Play App Signing) can't sideload it over the Play install — fresh installs work fine. Same property as before, just noting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)