### PR TITLE
Android: add pair-from-image fallback for camera-less devices

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -185,6 +185,10 @@ dependencies {
     implementation("com.google.android.material:material:1.12.0")
     // Quickie: CameraX + bundled ML Kit QR scanner, no Google Play services required.
     implementation("io.github.g00fy2.quickie:quickie-bundled:1.12.0")
+    // Same ML Kit artifact quickie already bundles (runtime-only there), declared
+    // explicitly so pair-from-image can call it directly. Keep the version in sync
+    // with quickie's to avoid shipping a second copy.
+    implementation("com.google.mlkit:barcode-scanning:17.3.0")
     // Play In-App Updates: nudges users on old versions to upgrade. Silently
     // no-ops on devices where the app wasn't installed from the Play Store.
     implementation("com.google.android.play:app-update-ktx:2.1.0")

--- a/android/app/src/main/java/org/cliprelay/crypto/E2ECrypto.kt
+++ b/android/app/src/main/java/org/cliprelay/crypto/E2ECrypto.kt
@@ -38,8 +38,21 @@ object E2ECrypto {
         return deviceTag(hexToBytes(tokenHex))
     }
 
+    /**
+     * Resolve an X25519 JCA service, falling back to the generic "XDH" name. Stock
+     * Android registers "X25519" as an alias for Conscrypt's XDH services, but some
+     * OEM builds omit the alias (seen on the AYN Thor, Android 13) and pairing would
+     * crash. Conscrypt's XDH is X25519-only, so both names yield identical keys.
+     */
+    private inline fun <T> x25519Service(getInstance: (String) -> T): T =
+        try {
+            getInstance("X25519")
+        } catch (e: java.security.NoSuchAlgorithmException) {
+            getInstance("XDH")
+        }
+
     fun generateX25519KeyPair(): KeyPair {
-        val kpg = KeyPairGenerator.getInstance("X25519")
+        val kpg = x25519Service { KeyPairGenerator.getInstance(it) }
         return kpg.generateKeyPair()
     }
 
@@ -51,7 +64,7 @@ object E2ECrypto {
             0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6e, 0x03, 0x21, 0x00
         )
         val encoded = x509Header + rawBytes
-        return KeyFactory.getInstance("X25519").generatePublic(X509EncodedKeySpec(encoded))
+        return x25519Service { KeyFactory.getInstance(it) }.generatePublic(X509EncodedKeySpec(encoded))
     }
 
     /** Extract raw 32-byte public key from JCA PublicKey. */
@@ -63,7 +76,7 @@ object E2ECrypto {
     /** Compute ECDH shared secret and derive root secret via HKDF. */
     fun ecdhSharedSecret(privateKey: PrivateKey, remotePublicKeyRaw: ByteArray): ByteArray {
         val remotePub = x25519PublicKeyFromRaw(remotePublicKeyRaw)
-        val ka = JKeyAgreement.getInstance("X25519")
+        val ka = x25519Service { JKeyAgreement.getInstance(it) }
         ka.init(privateKey)
         ka.doPhase(remotePub, true)
         val rawSecret = ka.generateSecret()
@@ -96,7 +109,7 @@ object E2ECrypto {
     /** Compute raw X25519 shared secret (no HKDF wrapping). Production overload using JCA PrivateKey. */
     fun rawX25519(ownPrivateKey: PrivateKey, remotePublicKeyRaw: ByteArray): ByteArray {
         val remotePub = x25519PublicKeyFromRaw(remotePublicKeyRaw)
-        val ka = JKeyAgreement.getInstance("X25519")
+        val ka = x25519Service { JKeyAgreement.getInstance(it) }
         ka.init(ownPrivateKey)
         ka.doPhase(remotePub, true)
         return ka.generateSecret()
@@ -111,9 +124,9 @@ object E2ECrypto {
             0x04, 0x22, 0x04, 0x20
         )
         val encoded = pkcs8Header + ownPrivateKeyRaw
-        val privKey = KeyFactory.getInstance("X25519")
+        val privKey = x25519Service { KeyFactory.getInstance(it) }
             .generatePrivate(java.security.spec.PKCS8EncodedKeySpec(encoded))
-        val ka = JKeyAgreement.getInstance("X25519")
+        val ka = x25519Service { JKeyAgreement.getInstance(it) }
         ka.init(privKey)
         ka.doPhase(remotePub, true)
         return ka.generateSecret()

--- a/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/ClipRelayScreen.kt
@@ -97,9 +97,11 @@ fun ClipRelayScreen(
     imageSyncEnabled: Boolean = false,
     otpRelayEnabled: Boolean = false,
     pairingFailed: Boolean = false,
+    hasCamera: Boolean = true,
     onPairingCancelClick: () -> Unit = {},
     onPairingErrorDismiss: () -> Unit = {},
     onPairClick: () -> Unit,
+    onPairFromImageClick: () -> Unit = {},
     onForgetMacClick: (String) -> Unit = {},
     onBurstShown: () -> Unit,
     onAutoClearSettingChanged: (Boolean) -> Unit,
@@ -206,9 +208,11 @@ fun ClipRelayScreen(
                     imageSyncEnabled = imageSyncEnabled,
                     otpRelayEnabled = otpRelayEnabled,
                     pairingFailed = pairingFailed,
+                    hasCamera = hasCamera,
                     onPairingCancelClick = onPairingCancelClick,
                     onPairingErrorDismiss = onPairingErrorDismiss,
                     onPairClick = onPairClick,
+                    onPairFromImageClick = onPairFromImageClick,
                     onForgetMacClick = onForgetMacClick,
                     onAutoClearSettingChanged = onAutoClearSettingChanged,
                     onHideClipboardSettingChanged = onHideClipboardSettingChanged,
@@ -375,9 +379,11 @@ private fun MainCard(
     imageSyncEnabled: Boolean = false,
     otpRelayEnabled: Boolean = false,
     pairingFailed: Boolean = false,
+    hasCamera: Boolean = true,
     onPairingCancelClick: () -> Unit = {},
     onPairingErrorDismiss: () -> Unit = {},
     onPairClick: () -> Unit,
+    onPairFromImageClick: () -> Unit = {},
     onForgetMacClick: (String) -> Unit = {},
     onAutoClearSettingChanged: (Boolean) -> Unit,
     onHideClipboardSettingChanged: (Boolean) -> Unit = {},
@@ -607,6 +613,17 @@ private fun MainCard(
                         fontWeight = FontWeight.Medium,
                         modifier = Modifier.padding(vertical = 4.dp)
                     )
+                }
+                // Without a camera the primary button already routes to image-based
+                // pairing, so the secondary option only makes sense alongside a scanner.
+                if (hasCamera) {
+                    TextButton(onClick = onPairFromImageClick) {
+                        Text(
+                            text = "Scan from image",
+                            color = Teal.copy(alpha = 0.6f),
+                            fontSize = 13.sp
+                        )
+                    }
                 }
             } else {
                 if (pairingFailed) {

--- a/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/MainActivity.kt
@@ -118,6 +118,10 @@ class MainActivity : AppCompatActivity() {
     // post-grant callback resumes pairing from the link instead of opening the camera scanner.
     private var pendingDeepLinkInfo: org.cliprelay.pairing.PairingInfo? = null
 
+    // Remembers whether the pairing attempt blocked on the BLE permission started from
+    // "Scan from image", so the post-grant callback resumes into the right scanner mode.
+    private var pendingPairFromImage = false
+
     private val pairPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { _ ->
@@ -128,7 +132,7 @@ class MainActivity : AppCompatActivity() {
                 pendingDeepLinkInfo = null
                 startPairingFromInfo(deepLink)
             } else {
-                launchQrScanner()
+                launchQrScanner(fromImage = pendingPairFromImage)
             }
         } else {
             // Denied again — re-show the explanation. If Android will no longer
@@ -260,6 +264,7 @@ class MainActivity : AppCompatActivity() {
                 imageSyncEnabled = imageSyncEnabled,
                 otpRelayEnabled = otpRelayEnabled,
                 pairingFailed = pairingFailed,
+                hasCamera = QrScannerActivity.deviceHasCamera(this),
                 onPairingCancelClick = {
                     viewModel.onPairingCancelled()
                     val cancelIntent = Intent(this, ClipRelayService::class.java)
@@ -269,16 +274,8 @@ class MainActivity : AppCompatActivity() {
                 onPairingErrorDismiss = {
                     viewModel.onPairingFailedDismissed()
                 },
-                onPairClick = {
-                    if (BlePermissions.hasRequiredRuntimePermissions(this)) {
-                        launchQrScanner()
-                    } else {
-                        blePermissionPermanentlyDenied =
-                            BlePermissions.requiredRuntimePermissions()
-                                .none { shouldShowRequestPermissionRationale(it) }
-                        showBlePermissionDialog = true
-                    }
-                },
+                onPairClick = { requestPairing(fromImage = false) },
+                onPairFromImageClick = { requestPairing(fromImage = true) },
                 onForgetMacClick = { macId ->
                     val forgetIntent = Intent(this, ClipRelayService::class.java)
                     forgetIntent.action = ClipRelayService.ACTION_FORGET_DEVICE
@@ -437,8 +434,23 @@ class MainActivity : AppCompatActivity() {
             PairedMacUi(id = mac.id, name = mac.name, connected = mac.id in connectedIds)
         }
 
-    private fun launchQrScanner() {
-        scannerLauncher.launch(Intent(this, QrScannerActivity::class.java))
+    /** Open the scanner if the BLE permission is granted, else explain why it's needed. */
+    private fun requestPairing(fromImage: Boolean) {
+        if (BlePermissions.hasRequiredRuntimePermissions(this)) {
+            launchQrScanner(fromImage)
+        } else {
+            pendingPairFromImage = fromImage
+            blePermissionPermanentlyDenied = BlePermissions.requiredRuntimePermissions()
+                .none { shouldShowRequestPermissionRationale(it) }
+            showBlePermissionDialog = true
+        }
+    }
+
+    private fun launchQrScanner(fromImage: Boolean = false) {
+        scannerLauncher.launch(
+            Intent(this, QrScannerActivity::class.java)
+                .putExtra(QrScannerActivity.EXTRA_SCAN_FROM_IMAGE, fromImage)
+        )
     }
 
     /**

--- a/android/app/src/main/java/org/cliprelay/ui/QrScannerActivity.kt
+++ b/android/app/src/main/java/org/cliprelay/ui/QrScannerActivity.kt
@@ -3,11 +3,57 @@ package org.cliprelay.ui
 // QR-based pairing scanner built on Quickie (CameraX + bundled ML Kit), so pairing works
 // without Google Play services. The old GMS code scanner needed an on-demand "barcode module"
 // download that could stall forever, leaving pairing stuck (issue #56).
+//
+// Also decodes the pairing QR from a saved image (Photo Picker + the same bundled ML Kit),
+// as a fallback for devices without a usable camera (e.g. gaming handhelds).
 
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.hardware.camera2.CameraManager
+import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
 import io.github.g00fy2.quickie.QRResult
 import io.github.g00fy2.quickie.ScanCustomCode
 import io.github.g00fy2.quickie.config.BarcodeFormat
@@ -38,6 +84,16 @@ class QrScannerActivity : AppCompatActivity() {
         }
     }
 
+    private var imageErrorRes by mutableStateOf<Int?>(null)
+    private var decodingImage by mutableStateOf(false)
+
+    private val pickImageLauncher = registerForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        // null = the user backed out of the picker; stay here so they can retry or cancel.
+        if (uri != null) decodeImage(uri)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Pairing needs the BLE foreground service, which cannot start without the
@@ -48,19 +104,76 @@ class QrScannerActivity : AppCompatActivity() {
             finish()
             return
         }
+        // Without a camera the live scanner is a dead end (CameraX retries against a
+        // black screen for ~6s, then fails) — route those devices to the image picker.
+        val scanFromImage =
+            intent.getBooleanExtra(EXTRA_SCAN_FROM_IMAGE, false) || !deviceHasCamera(this)
+        if (scanFromImage) {
+            setContent {
+                ImagePairingScreen(
+                    errorRes = imageErrorRes,
+                    decoding = decodingImage,
+                    onChooseImageClick = ::launchImagePicker,
+                    onCancelClick = { finish() }
+                )
+            }
+        }
         // Launch once; avoid relaunching if the activity is recreated while the scanner is open.
         if (savedInstanceState == null) {
-            scanLauncher.launch(
-                ScannerConfig.build {
-                    setBarcodeFormats(listOf(BarcodeFormat.FORMAT_QR_CODE))
-                    setOverlayStringRes(R.string.qr_scan_prompt)
-                    setShowTorchToggle(true)
-                    setShowCloseButton(true)
-                    setHapticSuccessFeedback(true)
-                    setKeepScreenOn(true)
-                }
-            )
+            if (scanFromImage) {
+                launchImagePicker()
+            } else {
+                scanLauncher.launch(
+                    ScannerConfig.build {
+                        setBarcodeFormats(listOf(BarcodeFormat.FORMAT_QR_CODE))
+                        setOverlayStringRes(R.string.qr_scan_prompt)
+                        setShowTorchToggle(true)
+                        setShowCloseButton(true)
+                        setHapticSuccessFeedback(true)
+                        setKeepScreenOn(true)
+                    }
+                )
+            }
         }
+    }
+
+    private fun launchImagePicker() {
+        pickImageLauncher.launch(
+            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+        )
+    }
+
+    /**
+     * Decode a QR code from [uri] with the same bundled ML Kit the live scanner uses,
+     * then feed the decoded string into [handleScannedValue] — the same handler as a
+     * live scan. Decode failures keep the screen up so the user can pick another image.
+     */
+    private fun decodeImage(uri: Uri) {
+        decodingImage = true
+        imageErrorRes = null
+        val image = runCatching { InputImage.fromFilePath(this, uri) }.getOrElse {
+            decodingImage = false
+            imageErrorRes = R.string.pair_from_image_unreadable
+            return
+        }
+        val scanner = BarcodeScanning.getClient(
+            BarcodeScannerOptions.Builder().setBarcodeFormats(Barcode.FORMAT_QR_CODE).build()
+        )
+        scanner.process(image)
+            .addOnSuccessListener { barcodes: List<Barcode> ->
+                val pairingValue = barcodes.mapNotNull { it.rawValue }
+                    .firstOrNull { PairingUriParser.parse(it) != null }
+                when {
+                    pairingValue != null -> handleScannedValue(pairingValue)
+                    barcodes.isEmpty() -> imageErrorRes = R.string.pair_from_image_no_code
+                    else -> imageErrorRes = R.string.pair_from_image_not_pairing
+                }
+            }
+            .addOnFailureListener { imageErrorRes = R.string.pair_from_image_unreadable }
+            .addOnCompleteListener {
+                decodingImage = false
+                scanner.close()
+            }
     }
 
     private fun handleScannedValue(rawValue: String?) {
@@ -92,5 +205,113 @@ class QrScannerActivity : AppCompatActivity() {
         Toast.makeText(this, "Pairing…", Toast.LENGTH_SHORT).show()
         setResult(RESULT_OK)
         finish()
+    }
+
+    companion object {
+        const val EXTRA_SCAN_FROM_IMAGE = "scan_from_image"
+
+        /**
+         * FEATURE_CAMERA_ANY alone can't be trusted: some devices (e.g. the AYN Thor
+         * handheld) report it while exposing zero actual cameras, so also check that
+         * the camera service knows about at least one device.
+         */
+        fun deviceHasCamera(context: Context): Boolean {
+            if (!context.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)) {
+                return false
+            }
+            val manager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+            return runCatching { manager.cameraIdList.isNotEmpty() }.getOrDefault(true)
+        }
+    }
+}
+
+// ─── Pair-from-image screen ──────────────────────────────────────────────────
+@Composable
+private fun ImagePairingScreen(
+    errorRes: Int?,
+    decoding: Boolean,
+    onChooseImageClick: () -> Unit,
+    onCancelClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFE8F5F3))
+            .systemBarsPadding()
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Column(
+            modifier = Modifier.widthIn(max = 400.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(R.string.pair_from_image_title),
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                color = Teal
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.pair_from_image_instructions),
+                fontSize = 14.sp,
+                color = Color(0x99000000),
+                textAlign = TextAlign.Center,
+                lineHeight = 20.sp
+            )
+            if (errorRes != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(errorRes),
+                    color = Color(0xFFB71C1C),
+                    fontSize = 13.sp,
+                    textAlign = TextAlign.Center,
+                    lineHeight = 18.sp,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(Color(0x14FF5252))
+                        .border(1.dp, Color(0x29FF5252), RoundedCornerShape(18.dp))
+                        .padding(horizontal = 14.dp, vertical = 12.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            Button(
+                onClick = onChooseImageClick,
+                enabled = !decoding,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(28.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Aqua,
+                    contentColor = Teal
+                )
+            ) {
+                if (decoding) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = Teal
+                    )
+                    Spacer(modifier = Modifier.width(10.dp))
+                }
+                Text(
+                    text = stringResource(
+                        if (decoding) R.string.pair_from_image_decoding
+                        else R.string.pair_from_image_choose
+                    ),
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+            }
+            TextButton(onClick = onCancelClick) {
+                Text(
+                    text = stringResource(R.string.pair_from_image_cancel),
+                    color = Teal.copy(alpha = 0.6f),
+                    fontSize = 13.sp
+                )
+            }
+        }
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -19,6 +19,14 @@
     <string name="unpair">Unpair</string>
     <string name="share_help">Tip: Use Android’s Share action in other apps to send selected text to your paired Mac.</string>
     <string name="qr_scan_prompt">On your Mac, open ClipRelay and choose \"Pair New Device…\"</string>
+    <string name="pair_from_image_title">Pair from a saved image</string>
+    <string name="pair_from_image_instructions">On your Mac, open ClipRelay and choose \"Pair New Device…\", then save a screenshot or photo of the QR code to this device and choose it below.</string>
+    <string name="pair_from_image_choose">Choose image</string>
+    <string name="pair_from_image_decoding">Reading image…</string>
+    <string name="pair_from_image_cancel">Cancel</string>
+    <string name="pair_from_image_no_code">No QR code found in that image. Use a sharp, uncropped screenshot of the code on your Mac.</string>
+    <string name="pair_from_image_not_pairing">That QR code isn\'t a ClipRelay pairing code. Choose an image of the code shown in ClipRelay on your Mac.</string>
+    <string name="pair_from_image_unreadable">Couldn\'t read that image. Try a different one.</string>
     <string name="auto_clear_setting_title">Auto-clear synced clipboard</string>
     <string name="auto_clear_setting_subtitle">Clear Mac-synced clipboard text after 60 seconds.</string>
     <string name="hide_clipboard_setting_title">Hide synced clipboard</string>

--- a/scripts/hardware-smoke-test-auto.sh
+++ b/scripts/hardware-smoke-test-auto.sh
@@ -689,7 +689,7 @@ done
 
 ANDROID_MODEL="$("${ADB[@]}" shell getprop ro.product.model | tr -d '\r')"
 MAC_NAME_RAW="$(scutil --get ComputerName 2>/dev/null || hostname)"
-MAC_NAME="$(printf '%s' "$MAC_NAME_RAW" | tr -cs '[:alnum:]_-.' '_')"
+MAC_NAME="$(printf '%s' "$MAC_NAME_RAW" | tr -cs '[:alnum:]_.-' '_')"
 PAIR_TOKEN="$(openssl rand -hex 32)"
 
 echo "- Android device: ${ANDROID_MODEL}"


### PR DESCRIPTION
Fixes #96

## Motivation

Camera-less Android devices (retro gaming handhelds like the Ayn Thor, Retroid Pocket, etc. — see #96) currently can't pair at all: tapping "Pair with Mac" opens the CameraX scanner, which sits on a black screen for ~6 seconds while CameraX retries init and then fails with a "Scan failed" toast. This adds the fallback discussed in the issue: pick a saved screenshot/photo of the pairing QR code instead of scanning it live.

## What changed

**Pair from a saved image** (`QrScannerActivity`, `ClipRelayScreen`, `MainActivity`)
- `QrScannerActivity` gains an image mode: Android Photo Picker (`PickVisualMedia`, so no storage permissions) → decode via `InputImage.fromFilePath` + `BarcodeScanning` → the decoded string goes through the **same `handleScannedValue` handler as the live scanner**, so there's no second pairing path to maintain.
- Distinct, recoverable error states for "no QR code in that image" and "QR code isn't a ClipRelay pairing payload" — the user can pick another image without leaving the screen.
- Devices with a camera keep live scanning as the default and get a secondary "Scan from image" text button on the pairing screen. Camera-less devices route straight to image mode.
- Camera detection doesn't trust `FEATURE_CAMERA_ANY` alone: the Thor reports it while `CameraManager.cameraIdList` is empty, so both are checked.
- The ML Kit barcode artifact is now declared explicitly in `build.gradle.kts`, pinned to the exact version quickie already bundles (it's runtime-only through quickie, so it wasn't compile-visible). No new bytes in the APK.

**X25519 crash fix** (`E2ECrypto`)
- Found while testing on the Thor: its firmware ships Conscrypt without the `"X25519"` JCA alias, so `KeyPairGenerator.getInstance("X25519")` threw `NoSuchAlgorithmException` and pairing crashed the app — even a live scan would have hit this. All X25519 service lookups now fall back to the generic `"XDH"` name, which Conscrypt implements as X25519-only, so derived keys are identical and nothing changes on the wire.

**Smoke test script fix** (`hardware-smoke-test-auto.sh`)
- `tr -cs '[:alnum:]_-.'` parses `_-.` as a reversed range and aborts before the test can start; moved `-` to the end of the set.

## Testing

- Verified on a real Ayn Thor (Android 13, no camera) against a real Mac: pairing from a saved screenshot of the Mac's QR window completes in ~2s ("ECDH pairing complete"), and encrypted clipboard transfer works.
- Both error states exercised on-device (image with no QR, QR encoding a non-ClipRelay URL), each allowing retry in place.
- Confirmed the pre-change behavior on the same device (black preview → "Scan failed" toast) for the record.
- `scripts/build-all.sh --android-only` and the full unit test suites pass (Android 179, macOS 160). No new unit tests: the image path reuses `PairingUriParser`, which `PairingUriParserTest` already covers, and the decode itself is ML Kit.
- Not covered on hardware: the secondary "Scan from image" button on a camera-equipped device (didn't have one handy) — the layout is a standard `TextButton` matching the existing ones.

No changes to the macOS app or the BLE protocol.
